### PR TITLE
Follow-up: import review fixes

### DIFF
--- a/armazenamento/database_optimized.py
+++ b/armazenamento/database_optimized.py
@@ -24,6 +24,7 @@ import time
 import pandas as pd  # type: ignore[import-not-found]
 
 from .database import get_db_connection  # Top-level import (safe - defined early in database.py)
+from .identifier_utils import is_valid_identifier
 from .schema_manager import ensure_columns_exist
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,25 @@ def sqlite_safe_chunksize(num_columns: int, cap: int = SQLITE_DEFAULT_CHUNK_CAP)
     """
     per_row_vars = max(1, num_columns + SQLITE_SAFETY_EXTRA_COLUMNS)
     return min(cap, max(1, SQLITE_MAX_VARIABLES // per_row_vars))
+
+
+def _resolve_physical_table(conn, table_name: str) -> str:
+    """Map legacy view aliases (ssas/ssa_chamados) to the physical table when present."""
+    try:
+        cursor = conn.execute(
+            "SELECT name, type FROM sqlite_master WHERE name=?",
+            (table_name,),
+        )
+        row = cursor.fetchone()
+        if row and row[1] == "view":
+            cursor2 = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='ssa_table'"
+            )
+            if cursor2.fetchone():
+                return "ssa_table"
+    except Exception as exc:  # pragma: no cover
+        logger.debug("Falha ao resolver tabela fisica para %s: %s", table_name, exc)
+    return table_name
 
 
 def insert_dataframe_optimized(
@@ -116,10 +136,14 @@ def insert_dataframe_optimized(
             cache_size = cur.fetchone()[0]
             logger.info(f"OK Configurações aplicadas: journal_mode={journal_mode}, cache_size={cache_size}")
 
+            target_table = _resolve_physical_table(conn, table_name)
+            if not is_valid_identifier(target_table):
+                raise ValueError(f"Invalid SQL identifier for table: {target_table!r}")
+
             # Criar índice temporário se não existir
             try:
                 idx_stmt = (
-                    f"CREATE INDEX IF NOT EXISTS idx_temp_numero_ssa ON {table_name}(numero_ssa)"
+                    f"CREATE INDEX IF NOT EXISTS idx_temp_numero_ssa ON {target_table}(numero_ssa)"
                 )
                 conn.execute(idx_stmt)
             except Exception as e:  # pragma: no cover - não crítico
@@ -137,13 +161,13 @@ def insert_dataframe_optimized(
 
             # ===== GARANTIR QUE TODAS AS COLUNAS EXISTEM =====
             # Adicionar colunas faltantes antes de inserir
-            ensure_columns_exist(conn, table_name, work)
+            ensure_columns_exist(conn, target_table, work)
 
             # ===== INSERIR REGISTROS SEM SSA (APPEND SIMPLES) =====
             if not no_ssa.empty:
                 safe_chunksize = sqlite_safe_chunksize(len(no_ssa.columns))
                 # method='multi' ignora chunksize; usar chunksize seguro
-                no_ssa.to_sql(table_name, conn, if_exists='append', index=False, chunksize=safe_chunksize)
+                no_ssa.to_sql(target_table, conn, if_exists='append', index=False, chunksize=safe_chunksize)
                 total_inserted += len(no_ssa)
                 logger.info(f"[OK] Inseridos {len(no_ssa)} registros sem numero_ssa")
 
@@ -151,8 +175,9 @@ def insert_dataframe_optimized(
             if not has_ssa.empty:
                 # Verificar se tabela existe antes de fazer SELECT
                 table_exists = pd.read_sql_query(
-                    f"SELECT name FROM sqlite_master WHERE type='table' AND name='{table_name}'",
-                    conn
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                    conn,
+                    params=(target_table,),
                 )
 
                 # OTIMIZACAO CHAVE: Uma consulta para TODAS as SSAs existentes
@@ -163,7 +188,7 @@ def insert_dataframe_optimized(
                     # Tabela existe, fazer lookup
                     existing_ssas_df = pd.read_sql_query(
                         (
-                            f"SELECT numero_ssa, data_cadastro FROM {table_name} "
+                            f"SELECT numero_ssa, data_cadastro FROM {target_table} "
                             "WHERE numero_ssa IS NOT NULL"
                         ),
                         conn,
@@ -212,7 +237,7 @@ def insert_dataframe_optimized(
                     # Calcula chunksize dinamico centralizado para evitar limite de variaveis
                     safe_chunksize = sqlite_safe_chunksize(len(insert_df.columns))
                     # method='multi' ignora chunksize; usar chunksize seguro
-                    insert_df.to_sql(table_name, conn, if_exists='append', index=False, chunksize=safe_chunksize)
+                    insert_df.to_sql(target_table, conn, if_exists='append', index=False, chunksize=safe_chunksize)
                     total_inserted += len(insert_df)
                     logger.info(f"[OK] Inseridos {len(insert_df)} novos registros com SSA (chunksize={safe_chunksize})")
 
@@ -229,13 +254,13 @@ def insert_dataframe_optimized(
                         chunk_ssas = ssa_list[i:i + CHUNK_SIZE]
                         ssa_placeholders = ','.join(['?'] * len(chunk_ssas))
                         delete_query = (
-                            f"DELETE FROM {table_name} WHERE numero_ssa IN ({ssa_placeholders})"
+                            f"DELETE FROM {target_table} WHERE numero_ssa IN ({ssa_placeholders})"
                         )
                         conn.execute(delete_query, chunk_ssas)
 
                     # Inserir versões atualizadas com chunk size dinâmico centralizado
                     # method='multi' ignora chunksize; usar chunksize seguro
-                    update_df.to_sql(table_name, conn, if_exists='append', index=False, chunksize=CHUNK_SIZE)
+                    update_df.to_sql(target_table, conn, if_exists='append', index=False, chunksize=CHUNK_SIZE)
                     total_inserted += len(update_df)
                     logger.info(f"[OK] Atualizados {len(update_df)} registros existentes")
 

--- a/armazenamento/database_optimized.py
+++ b/armazenamento/database_optimized.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import logging
 import time
-from contextlib import suppress
 import pandas as pd  # type: ignore[import-not-found]
 
 from .database import get_db_connection  # Top-level import (safe - defined early in database.py)
@@ -278,8 +277,13 @@ def insert_dataframe_optimized(
                         total_inserted += len(update_df)
                         logger.info(f"[OK] Atualizados {len(update_df)} registros existentes")
                     except Exception:
-                        with suppress(Exception):
+                        try:
                             conn.execute("ROLLBACK TO SAVEPOINT ssa_batch_update")
+                        except Exception as exc:
+                            logger.error(
+                                "Falha ao fazer rollback do SAVEPOINT ssa_batch_update: %s",
+                                exc,
+                            )
                         raise
 
             # Commit explícito

--- a/armazenamento/database_optimized.py
+++ b/armazenamento/database_optimized.py
@@ -180,29 +180,37 @@ def insert_dataframe_optimized(
                     params=(target_table,),
                 )
 
-                # OTIMIZACAO CHAVE: Uma consulta para TODAS as SSAs existentes
+                # OTIMIZACAO CHAVE: lookup apenas das SSAs que precisamos, em chunks
                 lookup_start = time.time()
-                existing_ssas_df = pd.DataFrame()  # Vazio por padrao
-
-                if not table_exists.empty:
-                    # Tabela existe, fazer lookup
-                    existing_ssas_df = pd.read_sql_query(
-                        (
-                            f"SELECT numero_ssa, data_cadastro FROM {target_table} "
-                            "WHERE numero_ssa IS NOT NULL"
-                        ),
-                        conn,
-                    )
-                lookup_time = time.time() - lookup_start
-
-                # Criar dicionário para lookup O(1) em vez de O(n) por linha
                 existing_dict = {}
-                if not existing_ssas_df.empty:
-                    existing_dict = dict(zip(existing_ssas_df['numero_ssa'], existing_ssas_df['data_cadastro']))
+                if not table_exists.empty:
+                    unique_ssas = (
+                        has_ssa['numero_ssa']
+                        .dropna()
+                        .astype(str)
+                        .unique()
+                        .tolist()
+                    )
+                    if unique_ssas:
+                        # Respeita limite de variaveis do SQLite (999). Usamos margem.
+                        lookup_chunk = max(1, SQLITE_MAX_VARIABLES - 50)
+                        for i in range(0, len(unique_ssas), lookup_chunk):
+                            chunk_ssas = unique_ssas[i:i + lookup_chunk]
+                            placeholders = ",".join(["?"] * len(chunk_ssas))
+                            query = (
+                                f"SELECT numero_ssa, data_cadastro FROM {target_table} "
+                                f"WHERE numero_ssa IN ({placeholders})"
+                            )
+                            chunk_df = pd.read_sql_query(query, conn, params=chunk_ssas)
+                            if not chunk_df.empty:
+                                existing_dict.update(
+                                    dict(zip(chunk_df['numero_ssa'], chunk_df['data_cadastro']))
+                                )
+                lookup_time = time.time() - lookup_start
 
                 logger.info(
                     "Lookup de SSAs existentes: %s encontrados em %.3fs",
-                    len(existing_ssas_df),
+                    len(existing_dict),
                     lookup_time,
                 )
 

--- a/armazenamento/database_optimized.py
+++ b/armazenamento/database_optimized.py
@@ -55,7 +55,7 @@ def _resolve_physical_table(conn, table_name: str) -> str:
             (table_name,),
         )
         row = cursor.fetchone()
-        if row and row[1] == "view":
+        if row and row[1] == "view" and table_name in {"ssas", "ssa_chamados"}:
             cursor2 = conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='ssa_table'"
             )
@@ -277,7 +277,6 @@ def insert_dataframe_optimized(
                     except Exception:
                         with suppress(Exception):
                             conn.execute("ROLLBACK TO SAVEPOINT ssa_batch_update")
-                            conn.execute("RELEASE SAVEPOINT ssa_batch_update")
                         raise
 
             # Commit explícito

--- a/armazenamento/database_optimized.py
+++ b/armazenamento/database_optimized.py
@@ -73,6 +73,8 @@ def _has_referencing_foreign_keys(conn, target_table: str) -> bool:
         for table in tables:
             if table == target_table:
                 continue
+            if not is_valid_identifier(table):
+                continue
             try:
                 fk_rows = conn.execute(f"PRAGMA foreign_key_list({table})").fetchall()
             except Exception:

--- a/armazenamento/database_optimized.py
+++ b/armazenamento/database_optimized.py
@@ -65,6 +65,30 @@ def _resolve_physical_table(conn, table_name: str) -> str:
     return table_name
 
 
+def _has_referencing_foreign_keys(conn, target_table: str) -> bool:
+    """Check if any table defines foreign keys referencing target_table."""
+    try:
+        cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = [row[0] for row in cursor.fetchall()]
+        for table in tables:
+            if table == target_table:
+                continue
+            try:
+                fk_rows = conn.execute(f"PRAGMA foreign_key_list({table})").fetchall()
+            except Exception:
+                continue
+            for fk in fk_rows:
+                if len(fk) > 2 and fk[2] == target_table:
+                    return True
+    except Exception as exc:  # pragma: no cover
+        logger.debug(
+            "Falha ao inspecionar foreign keys para %s: %s",
+            target_table,
+            exc,
+        )
+    return False
+
+
 def insert_dataframe_optimized(
     df: pd.DataFrame,
     db_path: str,
@@ -259,23 +283,56 @@ def insert_dataframe_optimized(
                     # Processar em chunks seguros para SQLite (centralizado)
                     CHUNK_SIZE = sqlite_safe_chunksize(len(update_df.columns))
                     logger.debug(f"Chunk size calculado: {CHUNK_SIZE} linhas para {len(update_df.columns)} colunas")
-                    ssa_list = list(update_df['numero_ssa'])
                     try:
                         conn.execute("SAVEPOINT ssa_batch_update")
-                        for i in range(0, len(ssa_list), CHUNK_SIZE):
-                            chunk_ssas = ssa_list[i:i + CHUNK_SIZE]
-                            ssa_placeholders = ','.join(['?'] * len(chunk_ssas))
-                            delete_query = (
-                                f"DELETE FROM {target_table} WHERE numero_ssa IN ({ssa_placeholders})"
+                        update_columns = [
+                            col for col in update_df.columns if col not in ("numero_ssa", "id")
+                        ]
+                        if not update_columns:
+                            logger.info("Nenhuma coluna atualizavel encontrada; pulando atualizacao")
+                        elif _has_referencing_foreign_keys(conn, target_table):
+                            set_clause = ", ".join([f"{col}=?" for col in update_columns])
+                            update_sql = (
+                                f"UPDATE {target_table} SET {set_clause} WHERE numero_ssa=?"
                             )
-                            conn.execute(delete_query, chunk_ssas)
+                            for i in range(0, len(update_df), CHUNK_SIZE):
+                                chunk = update_df.iloc[i:i + CHUNK_SIZE]
+                                params = list(
+                                    chunk[update_columns + ["numero_ssa"]]
+                                    .itertuples(index=False, name=None)
+                                )
+                                if params:
+                                    conn.executemany(update_sql, params)
+                            total_inserted += len(update_df)
+                            logger.info(
+                                "[OK] Atualizados %s registros existentes via UPDATE",
+                                len(update_df),
+                            )
+                        else:
+                            ssa_list = list(update_df['numero_ssa'])
+                            for i in range(0, len(ssa_list), CHUNK_SIZE):
+                                chunk_ssas = ssa_list[i:i + CHUNK_SIZE]
+                                ssa_placeholders = ','.join(['?'] * len(chunk_ssas))
+                                delete_query = (
+                                    f"DELETE FROM {target_table} WHERE numero_ssa IN ({ssa_placeholders})"
+                                )
+                                conn.execute(delete_query, chunk_ssas)
 
-                        # Inserir versões atualizadas com chunk size dinâmico centralizado
-                        # method='multi' ignora chunksize; usar chunksize seguro
-                        update_df.to_sql(target_table, conn, if_exists='append', index=False, chunksize=CHUNK_SIZE)
+                            # Inserir versões atualizadas com chunk size dinâmico centralizado
+                            # method='multi' ignora chunksize; usar chunksize seguro
+                            update_df.to_sql(
+                                target_table,
+                                conn,
+                                if_exists='append',
+                                index=False,
+                                chunksize=CHUNK_SIZE,
+                            )
+                            total_inserted += len(update_df)
+                            logger.info(
+                                "[OK] Atualizados %s registros existentes",
+                                len(update_df),
+                            )
                         conn.execute("RELEASE SAVEPOINT ssa_batch_update")
-                        total_inserted += len(update_df)
-                        logger.info(f"[OK] Atualizados {len(update_df)} registros existentes")
                     except Exception:
                         try:
                             conn.execute("ROLLBACK TO SAVEPOINT ssa_batch_update")

--- a/armazenamento/database_optimized.py
+++ b/armazenamento/database_optimized.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 import time
+from contextlib import suppress
 import pandas as pd  # type: ignore[import-not-found]
 
 from .database import get_db_connection  # Top-level import (safe - defined early in database.py)
@@ -257,20 +258,27 @@ def insert_dataframe_optimized(
                     CHUNK_SIZE = sqlite_safe_chunksize(len(update_df.columns))
                     logger.debug(f"Chunk size calculado: {CHUNK_SIZE} linhas para {len(update_df.columns)} colunas")
                     ssa_list = list(update_df['numero_ssa'])
+                    try:
+                        conn.execute("SAVEPOINT ssa_batch_update")
+                        for i in range(0, len(ssa_list), CHUNK_SIZE):
+                            chunk_ssas = ssa_list[i:i + CHUNK_SIZE]
+                            ssa_placeholders = ','.join(['?'] * len(chunk_ssas))
+                            delete_query = (
+                                f"DELETE FROM {target_table} WHERE numero_ssa IN ({ssa_placeholders})"
+                            )
+                            conn.execute(delete_query, chunk_ssas)
 
-                    for i in range(0, len(ssa_list), CHUNK_SIZE):
-                        chunk_ssas = ssa_list[i:i + CHUNK_SIZE]
-                        ssa_placeholders = ','.join(['?'] * len(chunk_ssas))
-                        delete_query = (
-                            f"DELETE FROM {target_table} WHERE numero_ssa IN ({ssa_placeholders})"
-                        )
-                        conn.execute(delete_query, chunk_ssas)
-
-                    # Inserir versões atualizadas com chunk size dinâmico centralizado
-                    # method='multi' ignora chunksize; usar chunksize seguro
-                    update_df.to_sql(target_table, conn, if_exists='append', index=False, chunksize=CHUNK_SIZE)
-                    total_inserted += len(update_df)
-                    logger.info(f"[OK] Atualizados {len(update_df)} registros existentes")
+                        # Inserir versões atualizadas com chunk size dinâmico centralizado
+                        # method='multi' ignora chunksize; usar chunksize seguro
+                        update_df.to_sql(target_table, conn, if_exists='append', index=False, chunksize=CHUNK_SIZE)
+                        conn.execute("RELEASE SAVEPOINT ssa_batch_update")
+                        total_inserted += len(update_df)
+                        logger.info(f"[OK] Atualizados {len(update_df)} registros existentes")
+                    except Exception:
+                        with suppress(Exception):
+                            conn.execute("ROLLBACK TO SAVEPOINT ssa_batch_update")
+                            conn.execute("RELEASE SAVEPOINT ssa_batch_update")
+                        raise
 
             # Commit explícito
             conn.commit()

--- a/armazenamento/database_optimized.py
+++ b/armazenamento/database_optimized.py
@@ -204,6 +204,9 @@ def insert_dataframe_optimized(
                             )
                             chunk_df = pd.read_sql_query(query, conn, params=chunk_ssas)
                             if not chunk_df.empty:
+                                chunk_df["numero_ssa"] = chunk_df["numero_ssa"].astype(str).str.strip()
+                                chunk_df["numero_ssa"] = chunk_df["numero_ssa"].replace(["nan", "None", ""], None)
+                                chunk_df = chunk_df[chunk_df["numero_ssa"].notna()]
                                 existing_dict.update(
                                     dict(zip(chunk_df['numero_ssa'], chunk_df['data_cadastro']))
                                 )

--- a/core/app_logic.py
+++ b/core/app_logic.py
@@ -320,6 +320,7 @@ def run_importer_logic(
     db_name: str = "ssas.db",
     table_name: str = "ssa_table",
     force_import: bool = False,
+    should_cancel: Optional[Callable[[], bool]] = None,
     progress_callback: Optional[Callable[[str, Dict[str, Any]], None]] = None,
 ) -> bool:
     """
@@ -331,6 +332,8 @@ def run_importer_logic(
         db_name (str): Nome do arquivo do banco de dados SQLite.
         table_name (str): Nome da tabela no banco de dados.
         force_import (bool): Se True, forca a reimportacao de todos os arquivos.
+        should_cancel (Optional[Callable[[], bool]]): Callback consultivo que indica
+            se a importacao deve ser interrompida. Deve retornar True para cancelar.
         progress_callback (Optional[Callable]): Callback para reportar progresso da importacao.
 
     Returns:
@@ -448,6 +451,9 @@ def run_importer_logic(
 
         try:
             for index, file_path in enumerate(files_to_process):
+                if should_cancel and should_cancel():
+                    logger.info("Cancelamento solicitado; interrompendo importacao.")
+                    break
                 base_name = os.path.basename(file_path)
 
                 # Notify file start

--- a/core/app_logic.py
+++ b/core/app_logic.py
@@ -174,6 +174,10 @@ def _import_single_file(
     logger.info(f"Iniciando importacao de '{file_path}'...")
     try:
         df = extractor.extract_data_from_excel(file_path)
+        if df is None:
+            raise ExtractionError(
+                f"Extractor returned None for file: {os.path.basename(file_path)}"
+            )
         if df is not None and not df.empty:
             df = df.copy()
             # NOVA: Validar dados antes da insercao
@@ -275,9 +279,9 @@ def _import_single_file(
         else:
             logger.warning(f"Nenhum dado valido extraido de '{file_path}'. Pulando.")
             return True, 0  # Nao e um erro critico, apenas nao ha dados
-    except extractor.ExtractionError:
-        # Re-levanta erros especificos de extracao
-        raise
+    except extractor.ExtractionError as e:
+        # Normalize extractor error type into core.app_logic.ExtractionError
+        raise ExtractionError(str(e)) from e
     except Exception as e:
         logger.error(f"Erro inesperado ao importar '{file_path}': {e}")
         raise ExtractionError(f"Erro ao importar {file_path}") from e

--- a/core/app_logic.py
+++ b/core/app_logic.py
@@ -561,6 +561,9 @@ def run_importer_logic(
                     )
                     continue
                 except ExtractionError as e:
+                    if should_cancel and should_cancel():
+                        logger.info("Cancelamento solicitado; interrompendo importacao.")
+                        break
                     logger.warning(
                         f"Erro de extracao em '{file_path}': {e}. Pulando arquivo..."
                     )

--- a/core/app_logic.py
+++ b/core/app_logic.py
@@ -422,23 +422,30 @@ def run_importer_logic(
         # --- 1. Determinar arquivos a serem processados ---
         files_to_process = _get_files_to_process(docs_dir, cache_file, force_import)
         total_files = len(files_to_process)
-        if progress_callback:
+        progress_cb = progress_callback
+
+        def _emit_progress(event_type: str, data: Dict[str, Any]) -> None:
+            nonlocal progress_cb
+            if not progress_cb:
+                return
             try:
-                progress_callback("start", {"total": total_files})
-            except Exception as e:
-                logger.debug(f"Progress callback failed: {e}")
+                progress_cb(event_type, data)
+            except Exception as exc:
+                logger.warning(
+                    "Progress callback failed for event '%s': %s. Disabling progress callback.",
+                    event_type,
+                    exc,
+                    exc_info=True,
+                )
+                progress_cb = None
+
+        _emit_progress("start", {"total": total_files})
 
         if not files_to_process:
             logger.info(
                 "Nenhum arquivo novo ou modificado encontrado para processamento."
             )
-            if progress_callback:
-                try:
-                    progress_callback(
-                        "finish", {"total": 0, "processed": 0, "errors": []}
-                    )
-                except Exception as e:
-                    logger.debug(f"Progress callback failed: {e}")
+            _emit_progress("finish", {"total": 0, "processed": 0, "errors": []})
             return False
 
         logger.info(
@@ -457,18 +464,14 @@ def run_importer_logic(
                 base_name = os.path.basename(file_path)
 
                 # Notify file start
-                if progress_callback:
-                    try:
-                        progress_callback(
-                            "file_start",
-                            {
-                                "current": index + 1,
-                                "total": total_files,
-                                "filename": base_name,
-                            },
-                        )
-                    except Exception as e:
-                        logger.debug(f"Progress callback failed during file_start: {e}")
+                _emit_progress(
+                    "file_start",
+                    {
+                        "current": index + 1,
+                        "total": total_files,
+                        "filename": base_name,
+                    },
+                )
 
                 if base_name.startswith("~$"):
                     logger.info("Ignorando arquivo temporario '%s'", base_name)
@@ -480,16 +483,10 @@ def run_importer_logic(
                     if success:
                         successfully_processed_files.append(file_path)
                         # Notify file success
-                        if progress_callback:
-                            try:
-                                progress_callback(
-                                    "file_success",
-                                    {"filename": base_name, "records": record_count},
-                                )
-                            except Exception as e:
-                                logger.debug(
-                                    f"Progress callback failed during file_success: {e}"
-                                )
+                        _emit_progress(
+                            "file_success",
+                            {"filename": base_name, "records": record_count},
+                        )
                 except DatabaseConnectionError as e:
                     logger.error(
                         f"Erro de conexao com banco ao processar '{file_path}': {e}"
@@ -498,24 +495,16 @@ def run_importer_logic(
                         "Interrompendo processamento devido a falha de conexao"
                     )
                     critical_errors.append(("connection", file_path, str(e)))
-                    if progress_callback:
-                        try:
-                            progress_callback(
-                                "file_error", {"filename": base_name, "error": str(e)}
-                            )
-                        except Exception:
-                            pass
+                    _emit_progress(
+                        "file_error", {"filename": base_name, "error": str(e)}
+                    )
                     break
                 except DatabaseCorruptionError as e:
                     logger.error(f"Corrupcao detectada ao processar '{file_path}': {e}")
                     logger.info("Tentando reparo automatico do banco...")
-                    if progress_callback:
-                        try:
-                            progress_callback(
-                                "file_error", {"filename": base_name, "error": str(e)}
-                            )
-                        except Exception:
-                            pass
+                    _emit_progress(
+                        "file_error", {"filename": base_name, "error": str(e)}
+                    )
                     if database.repair_database_if_needed(
                         db_path, table_name=table_name
                     ):
@@ -533,24 +522,16 @@ def run_importer_logic(
                         f"Espaco em disco insuficiente ao processar '{file_path}': {e}"
                     )
                     critical_errors.append(("space", file_path, str(e)))
-                    if progress_callback:
-                        try:
-                            progress_callback(
-                                "file_error", {"filename": base_name, "error": str(e)}
-                            )
-                        except Exception:
-                            pass
+                    _emit_progress(
+                        "file_error", {"filename": base_name, "error": str(e)}
+                    )
                     break
                 except DatabaseSchemaError as e:
                     logger.error(f"Erro de schema ao processar '{file_path}': {e}")
                     logger.info("Tentando recriacao do schema...")
-                    if progress_callback:
-                        try:
-                            progress_callback(
-                                "file_error", {"filename": base_name, "error": str(e)}
-                            )
-                        except Exception:
-                            pass
+                    _emit_progress(
+                        "file_error", {"filename": base_name, "error": str(e)}
+                    )
                     if database.initialize_database(db_path):
                         logger.info("Schema recriado, continuando processamento...")
                         critical_errors.append(("schema_repaired", file_path, str(e)))
@@ -564,66 +545,46 @@ def run_importer_logic(
                         f"Dados invalidos em '{file_path}': {e}. Pulando arquivo..."
                     )
                     critical_errors.append(("validation", file_path, str(e)))
-                    if progress_callback:
-                        try:
-                            progress_callback(
-                                "file_error", {"filename": base_name, "error": str(e)}
-                            )
-                        except Exception:
-                            pass
+                    _emit_progress(
+                        "file_error", {"filename": base_name, "error": str(e)}
+                    )
                     continue
                 except ExtractionError as e:
                     logger.warning(
                         f"Erro de extracao em '{file_path}': {e}. Pulando arquivo..."
                     )
                     critical_errors.append(("extraction", file_path, str(e)))
-                    if progress_callback:
-                        try:
-                            progress_callback(
-                                "file_error", {"filename": base_name, "error": str(e)}
-                            )
-                        except Exception:
-                            pass
+                    _emit_progress(
+                        "file_error", {"filename": base_name, "error": str(e)}
+                    )
                     continue
                 except DatabaseError as e:
                     logger.error(
                         f"Erro de banco ao processar '{file_path}': {e}. Continuando..."
                     )
                     critical_errors.append(("database_generic", file_path, str(e)))
-                    if progress_callback:
-                        try:
-                            progress_callback(
-                                "file_error", {"filename": base_name, "error": str(e)}
-                            )
-                        except Exception:
-                            pass
+                    _emit_progress(
+                        "file_error", {"filename": base_name, "error": str(e)}
+                    )
                     continue
                 except Exception as e:
                     logger.error(
                         f"Erro inesperado ao processar '{file_path}': {e}. Continuando..."
                     )
                     critical_errors.append(("unexpected", file_path, str(e)))
-                    if progress_callback:
-                        try:
-                            progress_callback(
-                                "file_error", {"filename": base_name, "error": str(e)}
-                            )
-                        except Exception:
-                            pass
+                    _emit_progress(
+                        "file_error", {"filename": base_name, "error": str(e)}
+                    )
                     continue
         finally:
-            if progress_callback:
-                try:
-                    progress_callback(
-                        "finish",
-                        {
-                            "total": total_files,
-                            "processed": len(successfully_processed_files),
-                            "errors": critical_errors,
-                        },
-                    )
-                except Exception as e:
-                    logger.debug(f"Progress callback failed at finish: {e}")
+            _emit_progress(
+                "finish",
+                {
+                    "total": total_files,
+                    "processed": len(successfully_processed_files),
+                    "errors": critical_errors,
+                },
+            )
 
         # Log de resumo de erros
         if critical_errors:

--- a/core/app_logic.py
+++ b/core/app_logic.py
@@ -154,7 +154,10 @@ def _get_files_to_process(
 
 
 def _import_single_file(
-    file_path: str, db_path: str, table_name: str
+    file_path: str,
+    db_path: str,
+    table_name: str,
+    should_cancel: Optional[Callable[[], bool]] = None,
 ) -> tuple[bool, int]:
     """
     Importa um unico arquivo Excel para o banco de dados.
@@ -163,6 +166,7 @@ def _import_single_file(
         file_path (str): Caminho completo para o arquivo Excel.
         db_path (str): Caminho para o banco de dados SQLite.
         table_name (str): Nome da tabela no banco de dados.
+        should_cancel (Optional[Callable[[], bool]]): Callback consultivo para cancelar a operacao.
 
     Returns:
         tuple[bool, int]: (sucesso, numero_de_registros_processados)
@@ -173,7 +177,7 @@ def _import_single_file(
     """
     logger.info(f"Iniciando importacao de '{file_path}'...")
     try:
-        df = extractor.extract_data_from_excel(file_path)
+        df = extractor.extract_data_from_excel(file_path, should_cancel=should_cancel)
         if df is None:
             raise ExtractionError(
                 f"Extractor returned None for file: {os.path.basename(file_path)}"
@@ -478,7 +482,10 @@ def run_importer_logic(
                     continue
                 try:
                     success, record_count = _import_single_file(
-                        file_path, db_path, table_name
+                        file_path,
+                        db_path,
+                        table_name,
+                        should_cancel=should_cancel,
                     )
                     if success:
                         successfully_processed_files.append(file_path)

--- a/core/app_logic.py
+++ b/core/app_logic.py
@@ -561,7 +561,8 @@ def run_importer_logic(
                     )
                     continue
                 except ExtractionError as e:
-                    if should_cancel and should_cancel():
+                    msg = str(e).lower()
+                    if "operation cancelled" in msg and should_cancel:
                         logger.info("Cancelamento solicitado; interrompendo importacao.")
                         break
                     logger.warning(

--- a/core/app_logic.py
+++ b/core/app_logic.py
@@ -290,6 +290,8 @@ def _import_single_file(
     except extractor.ExtractionError as e:
         # Normalize extractor error type into core.app_logic.ExtractionError
         raise ExtractionError(str(e)) from e
+    except ExtractionError:
+        raise
     except Exception as e:
         logger.error(f"Erro inesperado ao importar '{file_path}': {e}")
         raise ExtractionError(f"Erro ao importar {file_path}") from e

--- a/core/app_logic.py
+++ b/core/app_logic.py
@@ -184,6 +184,8 @@ def _import_single_file(
             )
         if df is not None and not df.empty:
             df = df.copy()
+            if should_cancel and should_cancel():
+                raise extractor.ExtractionError("operation cancelled")
             # NOVA: Validar dados antes da insercao
             logger.info(f"Validando dados extraidos de '{file_path}'...")
             validation_report = database.validate_dataframe_before_insert(
@@ -267,6 +269,8 @@ def _import_single_file(
             record_count = len(df)
 
             # CORRECAO CRITICA: Usar smart_upsert para evitar duplicatas
+            if should_cancel and should_cancel():
+                raise extractor.ExtractionError("operation cancelled")
             success = database.insert_dataframe_with_smart_upsert(
                 df, db_path, table_name
             )

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -440,7 +440,8 @@ def load_display_mappings_integrity() -> Dict[str, str]:
         logger.warning(f"display_mappings.json foi recriado em '{path}' com valores padrão.")
     except Exception as e:
         logger.error(f"Falha ao restaurar display_mappings.json: {e}")
-        raise RuntimeError(f"Falha ao restaurar display_mappings.json em '{path}'") from e
+        logger.error("Usando defaults em memoria; arquivo nao foi atualizado.")
+        return DEFAULT_DISPLAY_MAPPINGS.copy()
     return DEFAULT_DISPLAY_MAPPINGS.copy()
 
 def load_column_mappings_integrity() -> Dict[str, list]:
@@ -471,7 +472,8 @@ def load_column_mappings_integrity() -> Dict[str, list]:
         logger.warning(f"column_mappings.json foi recriado em '{path}' com valores padrão.")
     except Exception as e:
         logger.error(f"Falha ao restaurar column_mappings.json: {e}")
-        raise RuntimeError(f"Falha ao restaurar column_mappings.json em '{path}'") from e
+        logger.error("Usando defaults em memoria; arquivo nao foi atualizado.")
+        return DEFAULT_COLUMN_MAPPINGS.copy()
     return DEFAULT_COLUMN_MAPPINGS.copy()
 
 def load_settings() -> Dict[str, Any]:

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -9,9 +9,57 @@ import json
 import os
 import shutil
 import logging
+import tempfile
+from contextlib import suppress
 from typing import Dict, Any
 
 logger = logging.getLogger(__name__)
+
+def _atomic_write_json_file(path: str, data: Any, *, indent: int, ensure_ascii: bool) -> None:
+    """Write JSON atomically to prevent truncated/corrupted config files on crash."""
+    target_dir = os.path.dirname(path) or "."
+    base_name = os.path.basename(path) or "config.json"
+    os.makedirs(target_dir, exist_ok=True)
+
+    fd = None
+    tmp_path = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(prefix=f".{base_name}.tmp.", dir=target_dir)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=indent, ensure_ascii=ensure_ascii)
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError as exc:
+                logger.debug("fsync failed for config temp file (%s): %s", tmp_path, exc)
+        os.replace(tmp_path, path)
+        tmp_path = None
+    finally:
+        if tmp_path:
+            with suppress(Exception):
+                os.remove(tmp_path)
+
+def _atomic_copy_file(src: str, dst: str) -> None:
+    """Copy a file atomically to avoid partial writes when creating defaults."""
+    target_dir = os.path.dirname(dst) or "."
+    base_name = os.path.basename(dst) or "file"
+    os.makedirs(target_dir, exist_ok=True)
+
+    fd = None
+    tmp_path = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(prefix=f".{base_name}.tmp.", dir=target_dir)
+        try:
+            os.close(fd)
+        except Exception:
+            pass
+        shutil.copyfile(src, tmp_path)
+        os.replace(tmp_path, dst)
+        tmp_path = None
+    finally:
+        if tmp_path:
+            with suppress(Exception):
+                os.remove(tmp_path)
 
 # Caminhos padrão
 CONFIG_DIR = 'config'
@@ -374,8 +422,7 @@ def load_display_mappings_integrity() -> Dict[str, str]:
     # Restore
     try:
         os.makedirs(cfg_dir, exist_ok=True)
-        with open(path, 'w', encoding='utf-8') as f:
-            json.dump(DEFAULT_DISPLAY_MAPPINGS, f, indent=2, ensure_ascii=False)
+        _atomic_write_json_file(path, DEFAULT_DISPLAY_MAPPINGS, indent=2, ensure_ascii=False)
         logger.warning(f"display_mappings.json foi recriado em '{path}' com valores padrão.")
     except Exception as e:
         logger.error(f"Falha ao restaurar display_mappings.json: {e}")
@@ -405,8 +452,7 @@ def load_column_mappings_integrity() -> Dict[str, list]:
     # Restore
     try:
         os.makedirs(cfg_dir, exist_ok=True)
-        with open(path, 'w', encoding='utf-8') as f:
-            json.dump(DEFAULT_COLUMN_MAPPINGS, f, indent=2, ensure_ascii=False)
+        _atomic_write_json_file(path, DEFAULT_COLUMN_MAPPINGS, indent=2, ensure_ascii=False)
         logger.warning(f"column_mappings.json foi recriado em '{path}' com valores padrão.")
     except Exception as e:
         logger.error(f"Falha ao restaurar column_mappings.json: {e}")
@@ -447,8 +493,7 @@ def save_settings(settings: Dict[str, Any]):
     """
     try:
         os.makedirs(os.path.dirname(USER_SETTINGS_FILE), exist_ok=True)
-        with open(USER_SETTINGS_FILE, 'w', encoding='utf-8') as f:
-            json.dump(settings, f, indent=4, ensure_ascii=False)
+        _atomic_write_json_file(USER_SETTINGS_FILE, settings, indent=4, ensure_ascii=False)
         logger.info(f"Configurações salvas em '{USER_SETTINGS_FILE}'.")
     except IOError as e:
         logger.error(f"Erro ao salvar configurações em '{USER_SETTINGS_FILE}': {e}")
@@ -471,7 +516,7 @@ def ensure_default_settings():
             example_path = os.path.join(CONFIG_DIR, example_file)
             if os.path.exists(example_path):
                 try:
-                    shutil.copyfile(example_path, target_file)
+                    _atomic_copy_file(example_path, target_file)
                     logger.info(f"Arquivo de configuração padrão criado: {target_file}")
                 except IOError as e:
                     logger.error(f"Falha ao copiar '{example_path}' para '{target_file}': {e}")
@@ -498,16 +543,13 @@ def ensure_default_settings():
                             },
                             "default_filters": []
                         }
-                        with open(target_file, 'w', encoding='utf-8') as f:
-                            json.dump(default_content, f, indent=2, ensure_ascii=False)
+                        _atomic_write_json_file(target_file, default_content, indent=2, ensure_ascii=False)
                         logger.info(f"Arquivo padrão gerado: {target_file}")
                     elif target_file.endswith('display_mappings.json'):
-                        with open(target_file, 'w', encoding='utf-8') as f:
-                            json.dump(DEFAULT_DISPLAY_MAPPINGS, f, indent=2, ensure_ascii=False)
+                        _atomic_write_json_file(target_file, DEFAULT_DISPLAY_MAPPINGS, indent=2, ensure_ascii=False)
                         logger.info(f"Arquivo padrão gerado: {target_file}")
                     elif target_file.endswith('column_mappings.json'):
-                        with open(target_file, 'w', encoding='utf-8') as f:
-                            json.dump(DEFAULT_COLUMN_MAPPINGS, f, indent=2, ensure_ascii=False)
+                        _atomic_write_json_file(target_file, DEFAULT_COLUMN_MAPPINGS, indent=2, ensure_ascii=False)
                         logger.info(f"Arquivo padrão gerado: {target_file}")
                     else:
                         logger.warning(f"Arquivo de exemplo '{example_path}' não encontrado para '{target_file}'.")

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -39,6 +39,16 @@ def _atomic_write_json_file(path: str, data: Any, *, indent: int, ensure_ascii: 
             with suppress(Exception):
                 os.remove(tmp_path)
 
+def atomic_write_json_file(
+    path: str,
+    data: Any,
+    *,
+    indent: int = 2,
+    ensure_ascii: bool = False,
+) -> None:
+    """Public helper to write JSON atomically."""
+    _atomic_write_json_file(path, data, indent=indent, ensure_ascii=ensure_ascii)
+
 def _atomic_copy_file(src: str, dst: str) -> None:
     """Copy a file atomically to avoid partial writes when creating defaults."""
     target_dir = os.path.dirname(dst) or "."

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -440,6 +440,7 @@ def load_display_mappings_integrity() -> Dict[str, str]:
         logger.warning(f"display_mappings.json foi recriado em '{path}' com valores padrão.")
     except Exception as e:
         logger.error(f"Falha ao restaurar display_mappings.json: {e}")
+        raise RuntimeError(f"Falha ao restaurar display_mappings.json em '{path}'") from e
     return DEFAULT_DISPLAY_MAPPINGS.copy()
 
 def load_column_mappings_integrity() -> Dict[str, list]:
@@ -470,6 +471,7 @@ def load_column_mappings_integrity() -> Dict[str, list]:
         logger.warning(f"column_mappings.json foi recriado em '{path}' com valores padrão.")
     except Exception as e:
         logger.error(f"Falha ao restaurar column_mappings.json: {e}")
+        raise RuntimeError(f"Falha ao restaurar column_mappings.json em '{path}'") from e
     return DEFAULT_COLUMN_MAPPINGS.copy()
 
 def load_settings() -> Dict[str, Any]:

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -26,6 +26,7 @@ def _atomic_write_json_file(path: str, data: Any, *, indent: int, ensure_ascii: 
     try:
         fd, tmp_path = tempfile.mkstemp(prefix=f".{base_name}.tmp.", dir=target_dir)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
+            fd = None  # ownership transferred to file object
             json.dump(data, f, indent=indent, ensure_ascii=ensure_ascii)
             f.flush()
             try:
@@ -35,6 +36,9 @@ def _atomic_write_json_file(path: str, data: Any, *, indent: int, ensure_ascii: 
         os.replace(tmp_path, path)
         tmp_path = None
     finally:
+        if fd is not None:
+            with suppress(Exception):
+                os.close(fd)
         if tmp_path:
             with suppress(Exception):
                 os.remove(tmp_path)

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -68,6 +68,11 @@ def _atomic_copy_file(src: str, dst: str) -> None:
         except Exception:
             pass
         shutil.copyfile(src, tmp_path)
+        try:
+            with open(tmp_path, "rb") as f:
+                os.fsync(f.fileno())
+        except OSError as exc:
+            logger.debug("fsync failed for config temp file (%s): %s", tmp_path, exc)
         os.replace(tmp_path, dst)
         tmp_path = None
     finally:

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -65,6 +65,7 @@ def _atomic_copy_file(src: str, dst: str) -> None:
         fd, tmp_path = tempfile.mkstemp(prefix=f".{base_name}.tmp.", dir=target_dir)
         try:
             os.close(fd)
+            fd = None
         except Exception:
             pass
         shutil.copyfile(src, tmp_path)
@@ -76,6 +77,9 @@ def _atomic_copy_file(src: str, dst: str) -> None:
         os.replace(tmp_path, dst)
         tmp_path = None
     finally:
+        if fd is not None:
+            with suppress(Exception):
+                os.close(fd)
         if tmp_path:
             with suppress(Exception):
                 os.remove(tmp_path)

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -10,6 +10,10 @@ Scope is split by priority to keep delivery safe and incremental.
 
 ## P1 hardening targets
 
+- SSAMainWindow God Class (gui/gui_ssa.py ~6k lines):
+  - Split UI layout, filtering/controller logic, and theming into separate modules.
+  - Plan refactor in a dedicated sprint; avoid cross-cutting changes in this PR.
+  - Define seams for unit tests before extraction to reduce regression risk.
 - Derivadas c2 follow-up (db and related tools only):
   - Keep derivadas sync/maintenance decoupled from import flow; trigger via `scripts/derivadas_cli.py` or scheduler only.
   - Add controlled runbook for `scripts/derivadas_cli.py sync --full-rebuild` with rollback notes.

--- a/extracao/extractor.py
+++ b/extracao/extractor.py
@@ -7,7 +7,6 @@ Lê arquivos .xlsx, identifica cabeçalhos, normaliza nomes de colunas usando
 """
 
 import pandas as pd
-import os
 import re
 from typing import Optional, Dict, Any
 import logging
@@ -219,6 +218,7 @@ def extract_data_from_excel(file_path: str) -> Optional[pd.DataFrame]:
                                 ou None em caso de erro.
     """
     logger.info(f"Iniciando extração de dados de '{file_path}'...")
+    saw_header = False
     try:
         all_sheets_data = []
         xl_file = pd.ExcelFile(file_path, engine='openpyxl')
@@ -227,6 +227,9 @@ def extract_data_from_excel(file_path: str) -> Optional[pd.DataFrame]:
             logger.debug(f"Processando planilha '{sheet_name}'...")
             # Le a planilha inteira
             sheet_df = xl_file.parse(sheet_name, header=None)
+            if sheet_df.empty or sheet_df.shape[1] == 0:
+                logger.debug("Planilha '%s' vazia; ignorando.", sheet_name)
+                continue
 
             # Encontra a linha do cabecalho (primeira celula nao vazia na coluna 0)
             header_row_idx = None
@@ -236,6 +239,7 @@ def extract_data_from_excel(file_path: str) -> Optional[pd.DataFrame]:
                     break
 
             if header_row_idx is not None:
+                saw_header = True
                 # Define os cabecalhos
                 sheet_df.columns = sheet_df.iloc[header_row_idx]
                 # Remove linhas anteriores ao cabecalho e o proprio cabecalho
@@ -251,11 +255,22 @@ def extract_data_from_excel(file_path: str) -> Optional[pd.DataFrame]:
                 else:
                     logger.debug(f"Planilha '{sheet_name}' está vazia após processamento.")
             else:
-                 logger.warning(f"Planilha '{sheet_name}' em '{file_path}' não possui cabeçalho identificável.")
+                logger.warning(
+                    "Planilha '%s' em '%s' nao possui cabecalho identificavel.",
+                    sheet_name,
+                    file_path,
+                )
 
         if not all_sheets_data:
-             logger.warning(f"Nenhum dado válido encontrado em '{file_path}'.")
-             return None
+            if saw_header:
+                logger.info(
+                    "Arquivo '%s' sem linhas de dados apos cabecalho; retornando vazio.",
+                    file_path,
+                )
+                return pd.DataFrame()
+            raise ExtractionError(
+                f"No header found in any sheet for file: {file_path}"
+            )
 
         # Combina dados de todas as planilhas
         combined_df = pd.concat(all_sheets_data, ignore_index=True, sort=False)
@@ -268,8 +283,11 @@ def extract_data_from_excel(file_path: str) -> Optional[pd.DataFrame]:
             logger.debug(f"Removidas {initial_len - final_len} linhas completamente vazias.")
 
         if combined_df.empty:
-            logger.warning(f"Nenhum dado válido encontrado em '{file_path}' após combinação.")
-            return None
+            logger.warning(
+                "Nenhum dado valido encontrado em '%s' apos combinacao; retornando vazio.",
+                file_path,
+            )
+            return pd.DataFrame()
 
         # Carrega o mapeamento de colunas
         column_mappings = _load_column_mappings()
@@ -360,15 +378,21 @@ def extract_data_from_excel(file_path: str) -> Optional[pd.DataFrame]:
         logger.info(f"Extração concluída com sucesso. {len(combined_df)} linhas válidas extraídas.")
         return combined_df
 
-    except FileNotFoundError:
-        logger.error(f"Arquivo '{file_path}' não encontrado.")
-        return None
+    except ExtractionError:
+        raise
+    except FileNotFoundError as e:
+        logger.error("Arquivo '%s' nao encontrado.", file_path)
+        raise ExtractionError(f"File not found: {file_path}") from e
     except pd.errors.ParserError as e:
-        logger.error(f"Erro ao ler '{file_path}': Problema ao analisar o arquivo Excel. Detalhes: {e}")
-        return None
+        logger.error(
+            "Erro ao ler '%s': problema ao analisar arquivo Excel: %s",
+            file_path,
+            e,
+        )
+        raise ExtractionError(f"Parser error reading Excel file: {file_path}") from e
     except Exception as e:
-        logger.error(f"Erro inesperado ao processar '{file_path}': {e}", exc_info=True)
-        return None
+        logger.error("Erro inesperado ao processar '%s': %s", file_path, e, exc_info=True)
+        raise ExtractionError(f"Unexpected error processing Excel file: {file_path}") from e
 
 def read_report(file_path: str) -> tuple[Optional[pd.DataFrame], Dict[str, Any]]:
     """

--- a/extracao/extractor.py
+++ b/extracao/extractor.py
@@ -304,10 +304,23 @@ def extract_data_from_excel(
 
         # Carrega o mapeamento de colunas
         column_mappings = _load_column_mappings()
+        if not column_mappings:
+            logger.warning(
+                "Mapeamento de colunas vazio; mantendo nomes originais para '%s'.",
+                file_path,
+            )
 
         # Normaliza os nomes das colunas e resolve duplicadas
-        combined_df.rename(columns=column_mappings, inplace=True)
+        if column_mappings:
+            combined_df.rename(columns=column_mappings, inplace=True)
         combined_df = _deduplicate_columns(combined_df)
+
+        required_columns = {"numero_ssa", "descricao_ssa", "data_cadastro"}
+        missing_required = required_columns.difference(set(combined_df.columns))
+        if missing_required:
+            raise ExtractionError(
+                f"Missing required columns after normalization: {sorted(missing_required)}"
+            )
 
         if 'prazo_limite' in combined_df.columns:
             status_col = 'status_execucao_prazo'

--- a/extracao/extractor.py
+++ b/extracao/extractor.py
@@ -6,6 +6,7 @@ Lê arquivos .xlsx, identifica cabeçalhos, normaliza nomes de colunas usando
 `config/column_mappings.json` e converte tipos de dados fundamentais.
 """
 
+import os
 import pandas as pd
 import re
 from typing import Optional, Dict, Any, Callable
@@ -222,6 +223,7 @@ def extract_data_from_excel(
                                 ou None em caso de erro.
     """
     logger.info(f"Iniciando extração de dados de '{file_path}'...")
+    base_name = os.path.basename(file_path) if file_path else "arquivo"
     saw_header = False
     try:
         def _check_cancel() -> None:
@@ -281,7 +283,7 @@ def extract_data_from_excel(
                 )
                 return pd.DataFrame()
             raise ExtractionError(
-                f"No header found in any sheet for file: {file_path}"
+                f"No header found in any sheet for file: {base_name}"
             )
 
         # Combina dados de todas as planilhas
@@ -396,17 +398,17 @@ def extract_data_from_excel(
         raise
     except FileNotFoundError as e:
         logger.error("Arquivo '%s' nao encontrado.", file_path)
-        raise ExtractionError(f"File not found: {file_path}") from e
+        raise ExtractionError(f"File not found: {base_name}") from e
     except pd.errors.ParserError as e:
         logger.error(
             "Erro ao ler '%s': problema ao analisar arquivo Excel: %s",
             file_path,
             e,
         )
-        raise ExtractionError(f"Parser error reading Excel file: {file_path}") from e
+        raise ExtractionError(f"Parser error reading Excel file: {base_name}") from e
     except Exception as e:
         logger.error("Erro inesperado ao processar '%s': %s", file_path, e, exc_info=True)
-        raise ExtractionError(f"Unexpected error processing Excel file: {file_path}") from e
+        raise ExtractionError(f"Unexpected error processing Excel file: {base_name}") from e
 
 def read_report(file_path: str) -> tuple[Optional[pd.DataFrame], Dict[str, Any]]:
     """

--- a/extracao/extractor.py
+++ b/extracao/extractor.py
@@ -211,7 +211,7 @@ def extract_data_from_excel(
     file_path: str,
     *,
     should_cancel: Optional[Callable[[], bool]] = None,
-) -> Optional[pd.DataFrame]:
+) -> pd.DataFrame:
     """
     Extrai dados de um único arquivo Excel (.xlsx).
 
@@ -219,8 +219,8 @@ def extract_data_from_excel(
         file_path (str): Caminho completo para o arquivo Excel.
 
     Returns:
-        Optional[pd.DataFrame]: Um DataFrame com os dados extraídos e normalizados,
-                                ou None em caso de erro.
+        pd.DataFrame: Um DataFrame com os dados extraídos e normalizados.
+            Pode ser vazio quando o arquivo tem cabecalho sem linhas de dados.
     """
     logger.info(f"Iniciando extração de dados de '{file_path}'...")
     base_name = os.path.basename(file_path) if file_path else "arquivo"
@@ -232,48 +232,47 @@ def extract_data_from_excel(
 
         _check_cancel()
         all_sheets_data = []
-        xl_file = pd.ExcelFile(file_path, engine='openpyxl')
+        with pd.ExcelFile(file_path, engine='openpyxl') as xl_file:
+            for sheet_name in xl_file.sheet_names:
+                _check_cancel()
+                logger.debug(f"Processando planilha '{sheet_name}'...")
+                # Le a planilha inteira
+                sheet_df = xl_file.parse(sheet_name, header=None)
+                if sheet_df.empty or sheet_df.shape[1] == 0:
+                    logger.debug("Planilha '%s' vazia; ignorando.", sheet_name)
+                    continue
 
-        for sheet_name in xl_file.sheet_names:
-            _check_cancel()
-            logger.debug(f"Processando planilha '{sheet_name}'...")
-            # Le a planilha inteira
-            sheet_df = xl_file.parse(sheet_name, header=None)
-            if sheet_df.empty or sheet_df.shape[1] == 0:
-                logger.debug("Planilha '%s' vazia; ignorando.", sheet_name)
-                continue
+                # Encontra a linha do cabecalho (primeira celula nao vazia na coluna 0)
+                header_row_idx = None
+                for idx, value in enumerate(sheet_df.iloc[:, 0]):
+                    if idx % 250 == 0:
+                        _check_cancel()
+                    if pd.notna(value) and str(value).strip() != '':
+                        header_row_idx = idx
+                        break
 
-            # Encontra a linha do cabecalho (primeira celula nao vazia na coluna 0)
-            header_row_idx = None
-            for idx, value in enumerate(sheet_df.iloc[:, 0]):
-                if idx % 250 == 0:
-                    _check_cancel()
-                if pd.notna(value) and str(value).strip() != '':
-                    header_row_idx = idx
-                    break
+                if header_row_idx is not None:
+                    saw_header = True
+                    # Define os cabecalhos
+                    sheet_df.columns = sheet_df.iloc[header_row_idx]
+                    # Remove linhas anteriores ao cabecalho e o proprio cabecalho
+                    sheet_df = sheet_df.drop(sheet_df.index[:header_row_idx + 1])
+                    # Reseta o indice
+                    sheet_df = sheet_df.reset_index(drop=True)
 
-            if header_row_idx is not None:
-                saw_header = True
-                # Define os cabecalhos
-                sheet_df.columns = sheet_df.iloc[header_row_idx]
-                # Remove linhas anteriores ao cabecalho e o proprio cabecalho
-                sheet_df = sheet_df.drop(sheet_df.index[:header_row_idx + 1])
-                # Reseta o indice
-                sheet_df = sheet_df.reset_index(drop=True)
+                    # Remove colunas completamente vazias
+                    sheet_df = sheet_df.dropna(axis=1, how='all')
 
-                # Remove colunas completamente vazias
-                sheet_df = sheet_df.dropna(axis=1, how='all')
-
-                if not sheet_df.empty:
-                    all_sheets_data.append(sheet_df)
+                    if not sheet_df.empty:
+                        all_sheets_data.append(sheet_df)
+                    else:
+                        logger.debug(f"Planilha '{sheet_name}' está vazia após processamento.")
                 else:
-                    logger.debug(f"Planilha '{sheet_name}' está vazia após processamento.")
-            else:
-                logger.warning(
-                    "Planilha '%s' em '%s' nao possui cabecalho identificavel.",
-                    sheet_name,
-                    file_path,
-                )
+                    logger.warning(
+                        "Planilha '%s' em '%s' nao possui cabecalho identificavel.",
+                        sheet_name,
+                        file_path,
+                    )
 
         if not all_sheets_data:
             if saw_header:

--- a/extracao/extractor.py
+++ b/extracao/extractor.py
@@ -8,7 +8,7 @@ Lê arquivos .xlsx, identifica cabeçalhos, normaliza nomes de colunas usando
 
 import pandas as pd
 import re
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Callable
 import logging
 from shared.column_mappings import load_column_mappings_integrity
 
@@ -206,7 +206,11 @@ def _normalize_datatypes(df: pd.DataFrame) -> pd.DataFrame:
     logger.debug("Normalização de tipos concluída.")
     return df_normalized
 
-def extract_data_from_excel(file_path: str) -> Optional[pd.DataFrame]:
+def extract_data_from_excel(
+    file_path: str,
+    *,
+    should_cancel: Optional[Callable[[], bool]] = None,
+) -> Optional[pd.DataFrame]:
     """
     Extrai dados de um único arquivo Excel (.xlsx).
 
@@ -220,10 +224,16 @@ def extract_data_from_excel(file_path: str) -> Optional[pd.DataFrame]:
     logger.info(f"Iniciando extração de dados de '{file_path}'...")
     saw_header = False
     try:
+        def _check_cancel() -> None:
+            if should_cancel is not None and should_cancel():
+                raise ExtractionError("operation cancelled")
+
+        _check_cancel()
         all_sheets_data = []
         xl_file = pd.ExcelFile(file_path, engine='openpyxl')
 
         for sheet_name in xl_file.sheet_names:
+            _check_cancel()
             logger.debug(f"Processando planilha '{sheet_name}'...")
             # Le a planilha inteira
             sheet_df = xl_file.parse(sheet_name, header=None)
@@ -234,6 +244,8 @@ def extract_data_from_excel(file_path: str) -> Optional[pd.DataFrame]:
             # Encontra a linha do cabecalho (primeira celula nao vazia na coluna 0)
             header_row_idx = None
             for idx, value in enumerate(sheet_df.iloc[:, 0]):
+                if idx % 250 == 0:
+                    _check_cancel()
                 if pd.notna(value) and str(value).strip() != '':
                     header_row_idx = idx
                     break
@@ -318,11 +330,13 @@ def extract_data_from_excel(file_path: str) -> Optional[pd.DataFrame]:
         logger.debug(f"Colunas renomeadas. Novas colunas: {list(combined_df.columns)}")
 
         # Normaliza os tipos de dados
+        _check_cancel()
         combined_df = _normalize_datatypes(combined_df)
 
         # --- Sanitizacao Basica e Robusta de Strings ---
         logger.debug("Iniciando sanitização de strings...")
         for col in combined_df.columns:
+            _check_cancel()
             # Verifica se a coluna é de tipo 'object' (pandas usa para strings e mixed types)
             if pd.api.types.is_object_dtype(combined_df[col]):
                 # 1. Converte para string, tratando valores NA

--- a/gui/cache/filter_cache.py
+++ b/gui/cache/filter_cache.py
@@ -30,9 +30,10 @@ class FilterCache:
         combined = f"{df_hash}|{chunks_str}|{default_mode}"
         return hashlib.md5(combined.encode('utf-8')).hexdigest()
 
-    def get(self, df_hash: str, search_chunks: list, default_mode: str):
+    def get(self, df_hash: str, search_chunks: list, default_mode: str) -> pd.DataFrame | None:
         """Recupera resultado do cache se disponivel."""
         key = self._generate_key(df_hash, search_chunks, default_mode)
+        result = None
 
         with self._lock:
             if key in self._cache:
@@ -47,7 +48,10 @@ class FilterCache:
                 return None
 
         # Return copy outside the lock to keep critical section small.
-        return result.copy()  # Retorna copia para evitar modificacoes
+        if isinstance(result, pd.DataFrame):
+            return result.copy()  # Retorna copia para evitar modificacoes
+        logger.debug("Cache hit sem DataFrame valido para key: %s", key[:8])
+        return None
 
     def put(self, df_hash: str, search_chunks: list, default_mode: str, result: pd.DataFrame):
         """Armazena resultado no cache."""

--- a/gui/cache/filter_cache.py
+++ b/gui/cache/filter_cache.py
@@ -5,6 +5,7 @@ import hashlib
 import logging
 import pandas as pd
 from collections import OrderedDict
+import threading
 
 logger = logging.getLogger(__name__)
 
@@ -12,10 +13,13 @@ logger = logging.getLogger(__name__)
 class FilterCache:
     """Cache inteligente LRU para resultados de filtros da GUI."""
 
-    def __init__(self, max_size: int = 50):
+    def __init__(self, max_size: int = 50, lock=None):
         self.max_size = max_size
         self._cache = OrderedDict()  # LRU cache
         self._stats = {'hits': 0, 'misses': 0, 'evictions': 0}
+        # This cache is shared across FilterWorker instances and accessed from QThreads.
+        # Protect internal state to prevent races (e.g., key in cache then pop KeyError).
+        self._lock = lock or threading.Lock()
 
     def _generate_key(self, df_hash: str, search_chunks: list, default_mode: str) -> str:
         """Gera chave unica para cache baseada nos parametros de filtro."""
@@ -26,58 +30,68 @@ class FilterCache:
         combined = f"{df_hash}|{chunks_str}|{default_mode}"
         return hashlib.md5(combined.encode('utf-8')).hexdigest()
 
-    def get(self, df_hash: str, search_chunks: list, default_mode: str) -> pd.DataFrame:
+    def get(self, df_hash: str, search_chunks: list, default_mode: str):
         """Recupera resultado do cache se disponivel."""
         key = self._generate_key(df_hash, search_chunks, default_mode)
 
-        if key in self._cache:
-            # Move para o final (marca como recentemente usado)
-            result = self._cache.pop(key)
-            self._cache[key] = result
-            self._stats['hits'] += 1
-            logger.debug(f"Cache hit for filter key: {key[:8]}...")
-            return result.copy()  # Retorna copia para evitar modificacoes
+        with self._lock:
+            if key in self._cache:
+                # Move para o final (marca como recentemente usado)
+                result = self._cache.pop(key)
+                self._cache[key] = result
+                self._stats['hits'] += 1
+                logger.debug(f"Cache hit for filter key: {key[:8]}...")
+            else:
+                self._stats['misses'] += 1
+                logger.debug(f"Cache miss for filter key: {key[:8]}...")
+                return None
 
-        self._stats['misses'] += 1
-        logger.debug(f"Cache miss for filter key: {key[:8]}...")
-        return None
+        # Return copy outside the lock to keep critical section small.
+        return result.copy()  # Retorna copia para evitar modificacoes
 
     def put(self, df_hash: str, search_chunks: list, default_mode: str, result: pd.DataFrame):
         """Armazena resultado no cache."""
         key = self._generate_key(df_hash, search_chunks, default_mode)
+        result_copy = result.copy()
 
-        # Remove entrada existente se houver
-        if key in self._cache:
-            del self._cache[key]
+        with self._lock:
+            # Remove entrada existente se houver
+            if key in self._cache:
+                del self._cache[key]
 
-        # Adiciona nova entrada
-        self._cache[key] = result.copy()
+            # Adiciona nova entrada
+            self._cache[key] = result_copy
 
-        # Implementa politica LRU
-        while len(self._cache) > self.max_size:
-            # Remove item mais antigo (primeiro na OrderedDict)
-            oldest_key = next(iter(self._cache))
-            del self._cache[oldest_key]
-            self._stats['evictions'] += 1
+            # Implementa politica LRU
+            while len(self._cache) > self.max_size:
+                # Remove item mais antigo (primeiro na OrderedDict)
+                oldest_key = next(iter(self._cache))
+                del self._cache[oldest_key]
+                self._stats['evictions'] += 1
 
-        logger.debug(f"Cache put for filter key: {key[:8]}... (size: {len(self._cache)})")
+            logger.debug(f"Cache put for filter key: {key[:8]}... (size: {len(self._cache)})")
 
     def clear(self):
         """Limpa todo o cache."""
-        self._cache.clear()
-        self._stats = {'hits': 0, 'misses': 0, 'evictions': 0}
-        logger.debug("Filter cache cleared")
+        with self._lock:
+            self._cache.clear()
+            self._stats = {'hits': 0, 'misses': 0, 'evictions': 0}
+            logger.debug("Filter cache cleared")
 
     def get_stats(self) -> dict:
         """Retorna estatisticas do cache."""
-        total = self._stats['hits'] + self._stats['misses']
-        hit_rate = (self._stats['hits'] / total * 100) if total > 0 else 0
+        with self._lock:
+            size = len(self._cache)
+            stats = dict(self._stats)
+
+        total = stats['hits'] + stats['misses']
+        hit_rate = (stats['hits'] / total * 100) if total > 0 else 0
 
         return {
-            'size': len(self._cache),
+            'size': size,
             'max_size': self.max_size,
-            'hits': self._stats['hits'],
-            'misses': self._stats['misses'],
-            'evictions': self._stats['evictions'],
+            'hits': stats['hits'],
+            'misses': stats['misses'],
+            'evictions': stats['evictions'],
             'hit_rate': hit_rate
         }

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -4425,7 +4425,8 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         if request_id is not None and active_id is not None and request_id != active_id:
             logger.debug("Ignorando resultado de carga obsoleto (request_id=%s, active=%s)", request_id, active_id)
             return
-        self.df_completo = df.copy()
+        df_copy = df.copy()
+        self.df_completo = df_copy
         try:
             self.clear_filter_cache()
         except Exception as exc:
@@ -4441,7 +4442,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         except Exception as exc:
             logger.debug("Falha ao parar debounce de setor apos carga de dados: %s", exc)
         # Inicialmente, exibimos todos os dados
-        base = df.copy()
+        base = df_copy
         # Ordenacao padrao: nao-STE primeiro; depois numero SSA desc
         try:
             if 'situacao' in base.columns:
@@ -4460,7 +4461,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         except Exception as e:
             logger.warning("Falha na ordenacao inicial dos dados: %s", e)
         self.df_exibido = base
-        self._df_last_search_filtered = df.copy()
+        self._df_last_search_filtered = df_copy
         self._widths_computed_for_df_hash = None
         try:
             self.clear_filter_button.setEnabled(self._has_any_active_filters())

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -4273,7 +4273,6 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         GLOBAL_RETIRED_DATA_LOADER_META[worker] = perf_counter()
         if worker not in GLOBAL_RETIRED_DATA_LOADER_WORKERS:
             GLOBAL_RETIRED_DATA_LOADER_WORKERS.append(worker)
-        GLOBAL_RETIRED_DATA_LOADER_META[worker] = perf_counter()
 
         def _release_worker_ref(w=worker):
             try:

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -64,6 +64,11 @@ logger = logging.getLogger(__name__)
 # Retencao global defensiva para workers de carga que sobrevivem ao ciclo da janela.
 GLOBAL_RETIRED_DATA_LOADER_WORKERS = []
 MAX_GLOBAL_RETIRED_DATA_LOADER_WORKERS = 64
+
+# Retencao global defensiva para workers de reescaneamento (importacao) que podem
+# continuar por alguns instantes apos o fechamento do dialogo modal.
+GLOBAL_RETIRED_RESCAN_WORKERS = []
+MAX_GLOBAL_RETIRED_RESCAN_WORKERS = 8
 logger.addHandler(logging.NullHandler())
 
 from utils.formatting import format_dataframe_for_display, format_cell  # noqa: E402
@@ -6225,6 +6230,15 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         from gui.workers import RescanWorker
         from gui.widgets import RescanProgressDialog
 
+        active_worker = getattr(self, "_active_rescan_worker", None)
+        if active_worker is not None:
+            try:
+                if hasattr(active_worker, "isRunning") and active_worker.isRunning():
+                    self.status_label.setText("Status: Reescaneamento ja em andamento.")
+                    return
+            except Exception as exc:
+                logger.debug("Falha ao checar worker ativo de reescaneamento: %s", exc)
+
         # Check if main.py exists
         main_py_path = os.path.join(project_root, 'main.py')
         if not os.path.exists(main_py_path):
@@ -6236,26 +6250,59 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
 
         # Create and configure worker
         worker = RescanWorker(main_py_path, project_root)
+        self._active_rescan_worker = worker
 
         # Connect signals
         worker.output_line.connect(progress_dialog.append_output)
         worker.error_line.connect(progress_dialog.append_error)
         worker.progress.connect(progress_dialog.update_progress)
 
+        cancelled = False
+
+        def _release_worker_ref(*_args) -> None:
+            try:
+                if getattr(self, "_active_rescan_worker", None) is worker:
+                    self._active_rescan_worker = None
+            except Exception as exc:
+                logger.debug("Falha ao liberar referencia do RescanWorker: %s", exc)
+            try:
+                if worker in GLOBAL_RETIRED_RESCAN_WORKERS:
+                    GLOBAL_RETIRED_RESCAN_WORKERS.remove(worker)
+            except Exception as exc:
+                logger.debug("Falha ao remover RescanWorker da lista global: %s", exc)
+
         def on_success():
+            _release_worker_ref()
             progress_dialog.set_finished(True)
             self.status_label.setText("Status: Reescaneamento concluido. Clique em 'Carregar Dados' para atualizar.")
 
         def on_error(error_msg):
+            nonlocal cancelled
+            if cancelled or str(error_msg).strip().lower().startswith("processo cancelado"):
+                cancelled = True
+                progress_dialog.set_finished(False, "Processo cancelado pelo usuario")
+                self.status_label.setText("Status: Reescaneamento cancelado.")
+                _release_worker_ref()
+                return
             progress_dialog.set_finished(False, error_msg)
             self.status_label.setText("Status: Erro no reescaneamento.")
+            _release_worker_ref()
 
         worker.finished_success.connect(on_success)
         worker.finished_error.connect(on_error)
+        try:
+            worker.finished.connect(_release_worker_ref)
+        except Exception as exc:
+            logger.debug("Falha ao conectar signal finished do RescanWorker: %s", exc)
+        try:
+            worker.finished.connect(worker.deleteLater)
+        except Exception as exc:
+            logger.debug("Falha ao conectar deleteLater no RescanWorker: %s", exc)
 
-        # Cancelamento cooperativo: nao fecha o dialogo imediatamente.
-        # Solicita cancelamento e aguarda o worker finalizar com seguranca.
+        # Cancelamento cooperativo: solicita cancelamento e permite fechar o dialogo.
         def on_cancel_requested():
+            nonlocal cancelled
+            cancelled = True
             if worker.isRunning():
                 worker.stop()
                 self.status_label.setText("Status: Cancelamento solicitado no reescaneamento.")
@@ -6268,9 +6315,11 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
 
         # Cleanup (best-effort, sem bloquear a UI)
         if worker.isRunning():
-            logger.warning(
-                "RescanWorker ainda esta em execucao apos fechamento do dialogo; mantendo em background."
-            )
+            if worker not in GLOBAL_RETIRED_RESCAN_WORKERS:
+                GLOBAL_RETIRED_RESCAN_WORKERS.append(worker)
+                if len(GLOBAL_RETIRED_RESCAN_WORKERS) > MAX_GLOBAL_RETIRED_RESCAN_WORKERS:
+                    GLOBAL_RETIRED_RESCAN_WORKERS[:] = GLOBAL_RETIRED_RESCAN_WORKERS[-MAX_GLOBAL_RETIRED_RESCAN_WORKERS:]
+            logger.warning("RescanWorker ainda esta em execucao apos fechamento do dialogo; mantendo em background.")
 
     def open_docs_folder(self):
         """Abre a pasta docs_entrada no explorador de arquivos (nao bloqueante)."""
@@ -6447,6 +6496,40 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
             self._prune_retired_data_loader_workers()
         except Exception as exc:
             logger.debug("Falha ao podar workers aposentados no closeEvent: %s", exc)
+
+        # Best-effort: parar reescaneamento/importacao em andamento ao encerrar a janela.
+        rescan_worker = getattr(self, "_active_rescan_worker", None)
+        if rescan_worker is not None:
+            try:
+                if hasattr(rescan_worker, "isRunning") and rescan_worker.isRunning():
+                    try:
+                        if hasattr(rescan_worker, "stop"):
+                            rescan_worker.stop()
+                    except Exception as exc:
+                        logger.debug("Falha ao solicitar stop do RescanWorker no closeEvent: %s", exc)
+                    try:
+                        rescan_worker.wait(1500)
+                    except Exception as exc:
+                        logger.debug("Falha ao aguardar RescanWorker no closeEvent: %s", exc)
+                    try:
+                        if hasattr(rescan_worker, "isRunning") and rescan_worker.isRunning():
+                            if rescan_worker not in GLOBAL_RETIRED_RESCAN_WORKERS:
+                                GLOBAL_RETIRED_RESCAN_WORKERS.append(rescan_worker)
+                                if len(GLOBAL_RETIRED_RESCAN_WORKERS) > MAX_GLOBAL_RETIRED_RESCAN_WORKERS:
+                                    GLOBAL_RETIRED_RESCAN_WORKERS[:] = GLOBAL_RETIRED_RESCAN_WORKERS[-MAX_GLOBAL_RETIRED_RESCAN_WORKERS:]
+                            logger.debug(
+                                "RescanWorker ainda ativo durante closeEvent; mantendo referencia global."
+                            )
+                    except Exception as exc:
+                        logger.debug("Falha ao checar/reter RescanWorker no closeEvent: %s", exc)
+            except Exception as exc:
+                logger.debug("Falha ao encerrar RescanWorker durante closeEvent: %s", exc)
+            finally:
+                try:
+                    if not (hasattr(rescan_worker, "isRunning") and rescan_worker.isRunning()):
+                        self._active_rescan_worker = None
+                except Exception:
+                    self._active_rescan_worker = None
 
         # Aceita o evento de fechamento
         event.accept()

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -87,8 +87,8 @@ try:
         QSpacerItem, QSizePolicy, QFrame, QListWidget, QListWidgetItem, QCheckBox, QTabWidget,
         QScrollArea, QToolButton, QWidgetAction
     )
-    from PyQt6.QtCore import Qt, QThread, pyqtSignal, QTimer, QEvent, QPoint, QSignalBlocker
-    from PyQt6.QtGui import QAction, QFont
+    from PyQt6.QtCore import Qt, QThread, pyqtSignal, QTimer, QEvent, QPoint, QSignalBlocker, QUrl
+    from PyQt6.QtGui import QAction, QFont, QDesktopServices
 
     # Import workers, cache, widgets, and helpers from separate modules
     from gui.workers import DataLoaderWorker, FilterWorker  # noqa: E402
@@ -6218,16 +6218,39 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
             )
 
     def open_docs_folder(self):
-        """Abre a pasta docs_entrada no Windows Explorer."""
+        """Abre a pasta docs_entrada no explorador de arquivos (nao bloqueante)."""
         docs_path = os.path.join(project_root, 'docs_entrada')
 
         if os.path.exists(docs_path):
             try:
-                # Abre no Windows Explorer
-                subprocess.run(['explorer', docs_path], check=True)
+                # Prefer Qt abstraction to avoid blocking UI (subprocess.run) and to keep cross-platform.
+                if QT_AVAILABLE:
+                    url = QUrl.fromLocalFile(docs_path)
+                    ok = QDesktopServices.openUrl(url)
+                    if ok:
+                        return
+                    raise RuntimeError("QDesktopServices.openUrl returned False")
+                raise RuntimeError("Qt nao disponivel para abrir pastas")
             except Exception as e:
-                QMessageBox.warning(self, "Erro", f"Erro ao abrir pasta: {e}")
+                logger.warning("Falha ao abrir pasta docs_entrada via Qt: %s", e)
+                try:
+                    # Best-effort fallback, non-blocking.
+                    if sys.platform.startswith("win"):
+                        subprocess.Popen(["explorer", docs_path])
+                    elif sys.platform == "darwin":
+                        subprocess.Popen(["open", docs_path])
+                    else:
+                        subprocess.Popen(["xdg-open", docs_path])
+                    return
+                except Exception as fallback_exc:
+                    logger.warning("Fallback para abrir pasta falhou: %s", fallback_exc)
+                    # Avoid modal dialogs during automated tests (can deadlock pytest runner).
+                    if os.environ.get("PYTEST_CURRENT_TEST"):
+                        return
+                    QMessageBox.warning(self, "Erro", f"Erro ao abrir pasta: {fallback_exc}")
         else:
+            if os.environ.get("PYTEST_CURRENT_TEST"):
+                return
             QMessageBox.warning(self, "Erro", f"Pasta nao encontrada: {docs_path}")
 
     def load_other_database(self):

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -548,6 +548,23 @@ DETAILS_DIALOG_MIN_HEIGHT = 500  # px
 HIGHLIGHT_BACKGROUND_COLOR = 'yellow'
 HIGHLIGHT_FONT_WEIGHT = 'bold'
 
+# Prefer explicit monospace families across Windows/macOS/Linux to avoid Qt
+# trying (and failing) to resolve a generic "Monospace" alias.
+MONO_FONT_FAMILY = (
+    # macOS first
+    "'SF Mono', Menlo, Monaco, 'Andale Mono', "
+    # Windows 11 common monospace families
+    "Consolas, 'Cascadia Mono', 'Cascadia Code', 'Segoe UI Mono', 'Lucida Console', "
+    # Debian / Linux common monospace families
+    "'DejaVu Sans Mono', 'Liberation Mono', 'Noto Sans Mono', 'Ubuntu Mono', "
+    "'Droid Sans Mono', 'FreeMono', 'Nimbus Mono L', 'Courier 10 Pitch', "
+    # Popular developer fonts (often installed)
+    "'Fira Code', 'Fira Mono', 'JetBrains Mono', 'Roboto Mono', "
+    "Inconsolata, Hack, 'Source Code Pro', "
+    # Last-resort fallbacks
+    "'Courier New', Courier"
+)
+
 DIVISAO_SETORES = {
     "SMME": ["MEL1", "MEL2", "MEL3", "MEL4"],
     "SMIN": ["IEE1", "IEE2", "IEE3", "IEE4"],
@@ -2627,7 +2644,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
             text_edit.setPlainText(text)
             text_edit.setReadOnly(True)
             try:
-                text_edit.setStyleSheet("font-family: Consolas, monospace; font-size: 11px;")
+                text_edit.setStyleSheet(f"font-family: {MONO_FONT_FAMILY}; font-size: 11px;")
             except Exception as exc:
                 logger.debug("Failed to style derivadas popup text editor: %s", exc)
             layout.addWidget(text_edit)
@@ -3643,10 +3660,18 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         except Exception as exc:
             logger.warning("Falha ao sincronizar filtro avancado de ano de execucao: %s", exc)
         try:
-            self.adv_week_emissao_start.setText("" if data.get("semana_emissao_inicio") is None else str(data.get("semana_emissao_inicio")))
-            self.adv_week_emissao_end.setText("" if data.get("semana_emissao_fim") is None else str(data.get("semana_emissao_fim")))
-            self.adv_week_execucao_start.setText("" if data.get("semana_execucao_inicio") is None else str(data.get("semana_execucao_inicio")))
-            self.adv_week_execucao_end.setText("" if data.get("semana_execucao_fim") is None else str(data.get("semana_execucao_fim")))
+            week_fields = (
+                ("adv_week_emissao_start", "semana_emissao_inicio"),
+                ("adv_week_emissao_end", "semana_emissao_fim"),
+                ("adv_week_execucao_start", "semana_execucao_inicio"),
+                ("adv_week_execucao_end", "semana_execucao_fim"),
+            )
+            for attr, key in week_fields:
+                widget = getattr(self, attr, None)
+                if widget is None:
+                    continue
+                value = data.get(key)
+                widget.setText("" if value is None else str(value))
         except Exception as exc:
             logger.warning("Falha ao sincronizar intervalo de semanas dos filtros avancados: %s", exc)
         try:
@@ -4955,9 +4980,20 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         try:
             tab_contexts = getattr(self, "_tab_contexts", None)
             if isinstance(tab_contexts, list):
+                # Only mark the active tab context as themed.
+                # Other tabs must be re-themed on demand when they get bound, otherwise
+                # they can keep stale styles after theme switches.
+                active_kind = getattr(self, "_current_tab_kind", None)
+                active_search = getattr(self, "search_input", None)
                 for ctx in tab_contexts:
-                    if isinstance(ctx, dict):
+                    if not isinstance(ctx, dict):
+                        continue
+                    if active_kind and ctx.get("tab_kind") == active_kind:
                         ctx["_theme_name"] = normalized
+                        break
+                    if active_search is not None and ctx.get("search_input") is active_search:
+                        ctx["_theme_name"] = normalized
+                        break
         except Exception as exc:
             logger.debug("Falha ao registrar tema atual nos contextos de aba: %s", exc)
         try:
@@ -5768,7 +5804,9 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
             text_color = "#000000"
             link_color = text_color
 
-        html_lines = [f'<html><body style="font-family: monospace; font-size: {font_size_pt}pt; color: {text_color};">']
+        html_lines = [
+            f'<html><body style="font-family: {MONO_FONT_FAMILY}; font-size: {font_size_pt}pt; color: {text_color};">'
+        ]
         html_lines.append('<table style="width: 100%; border-collapse: collapse;">')
 
         # Ordenar campos: prioridade primeiro, depois alfabetico

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -42,7 +42,7 @@ if project_root not in sys.path:
 # Importações dos managers unificados
 from gui.simple_width_manager import SimpleWidthManager, SimpleCacheManager  # noqa: E402
 from utils.themes import get_palette, get_theme_roles, normalize_theme  # noqa: E402
-from core.config_manager import DEFAULT_DISPLAY_MAPPINGS  # noqa: E402
+from core.config_manager import DEFAULT_DISPLAY_MAPPINGS, atomic_write_json_file  # noqa: E402
 from gui.gui_config import (  # noqa: E402
     GUI_MAIN_PREFERENCES,
     REQUIRED_DISPLAY_COLUMNS,
@@ -735,8 +735,12 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
 
     def _persist_gui_preferences(self):
         try:
-            with open(os.path.join(project_root, 'config', 'gui_main_preferences.json'), 'w', encoding='utf-8') as f:
-                json.dump(GUI_MAIN_PREFERENCES, f, ensure_ascii=False, indent=2)
+            atomic_write_json_file(
+                os.path.join(project_root, "config", "gui_main_preferences.json"),
+                GUI_MAIN_PREFERENCES,
+                indent=2,
+                ensure_ascii=False,
+            )
         except Exception as e:
             logger.warning("Falha ao persistir preferencias GUI: %s", e)
 
@@ -5158,8 +5162,12 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
             gui_settings = GUI_MAIN_PREFERENCES.setdefault('gui_settings', {})
             if gui_settings.get('theme') != normalized:
                 gui_settings['theme'] = normalized
-                with open(os.path.join(project_root, 'config', 'gui_main_preferences.json'), 'w', encoding='utf-8') as f:
-                    json.dump(GUI_MAIN_PREFERENCES, f, ensure_ascii=False, indent=2)
+                atomic_write_json_file(
+                    os.path.join(project_root, "config", "gui_main_preferences.json"),
+                    GUI_MAIN_PREFERENCES,
+                    indent=2,
+                    ensure_ascii=False,
+                )
         except Exception as exc:
             logger.warning("Falha ao persistir tema em gui_main_preferences.json: %s", exc)
         self._apply_macos_contrast(normalized)

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -4070,16 +4070,21 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
             reprog_vals = filters.get("num_reprogramacoes_values") or []
             mode = filters.get("num_reprogramacoes_mode")
             if reprog_vals and mode and "num_reprogramacoes" in df.columns:
-                series = pd.to_numeric(df["num_reprogramacoes"], errors="coerce").dropna()
-                vals = [int(v) for v in reprog_vals if pd.notna(v)]
-                if mode == "eq":
-                    mask &= series.isin(vals)
-                elif mode == "lte":
-                    threshold = max(vals)
-                    mask &= series <= threshold
-                elif mode == "gte":
-                    threshold = min(vals)
-                    mask &= series >= threshold
+                nums = pd.to_numeric(df["num_reprogramacoes"], errors="coerce")
+                vals = []
+                for raw in reprog_vals:
+                    text = str(raw).strip()
+                    if text.isdigit():
+                        vals.append(int(text))
+                if vals:
+                    if mode == "eq":
+                        mask &= nums.isin(vals)
+                    elif mode == "lte":
+                        threshold = max(vals)
+                        mask &= nums <= threshold
+                    elif mode == "gte":
+                        threshold = min(vals)
+                        mask &= nums >= threshold
         except Exception as exc:
             logger.debug("Failed to apply reprogramacoes advanced filter: %s", exc)
 

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -6310,6 +6310,12 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
                 logger.debug("Falha ao remover RescanWorker da lista global: %s", exc)
 
         def on_success():
+            nonlocal cancelled
+            if cancelled:
+                progress_dialog.set_finished(False, "Processo cancelado pelo usuario")
+                self.status_label.setText("Status: Reescaneamento cancelado.")
+                _release_worker_ref()
+                return
             _release_worker_ref()
             progress_dialog.set_finished(True)
             self.status_label.setText("Status: Reescaneamento concluido. Clique em 'Carregar Dados' para atualizar.")

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -2680,7 +2680,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
                 return
 
             # Verificar se ha valores normalizados validos (ignora '', None, NaN)
-            normalized = df[derivada_col].apply(self._normalize_ssa_value)
+            normalized = self._normalize_ssa_series(df[derivada_col])
             has_derivadas = normalized.ne("").any()
             btn.setEnabled(bool(has_derivadas))
         except Exception as exc:
@@ -3181,7 +3181,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
             # Extrai numeros unicos de SSAs derivadas se nao estiver em cache
             try:
                 if "derivada_de" in df.columns:
-                    derivadas_series = df["derivada_de"].apply(self._normalize_ssa_value)
+                    derivadas_series = self._normalize_ssa_series(df["derivada_de"])
                     derivadas_numbers = sorted(
                         {v for v in derivadas_series.unique() if v and str(v).strip()},
                         key=lambda x: str(x).casefold()
@@ -4162,7 +4162,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         derivada_is = bool(filters.get("derivada_is"))
 
         if "derivada_de" in df.columns:
-            series_derivada = df["derivada_de"].apply(self._normalize_ssa_value)
+            series_derivada = self._normalize_ssa_series(df["derivada_de"])
             has_derivada = series_derivada.ne("")
             if derivada_is:
                 mask &= has_derivada
@@ -4186,7 +4186,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
                 if origins:
                     try:
                         origin_norm = {str(o) for o in origins if str(o).strip()}
-                        numero_norm = df["numero_ssa"].apply(self._normalize_ssa_value)
+                        numero_norm = self._normalize_ssa_series(df["numero_ssa"])
                         mask &= numero_norm.isin(origin_norm)
                     except Exception as exc:
                         logger.debug("Failed to apply derivada origin filter to numero_ssa: %s", exc)
@@ -4436,17 +4436,9 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
             else:
                 is_ste = pd.Series([False]*len(base), index=base.index)
             if 'numero_ssa' in base.columns:
-                def _ssa_sort_key(raw_value):
-                    text_value = str(raw_value or "")
-                    digits = "".join(ch for ch in text_value if ch.isdigit())
-                    if not digits:
-                        return -1
-                    try:
-                        return int(digits)
-                    except Exception:
-                        return -1
-
-                ssa_int = base["numero_ssa"].apply(_ssa_sort_key)
+                ssa_text = base["numero_ssa"].astype(str)
+                ssa_digits = ssa_text.str.replace(r"\D+", "", regex=True)
+                ssa_int = pd.to_numeric(ssa_digits, errors="coerce").fillna(-1).astype("int64")
             else:
                 ssa_int = pd.Series([-1]*len(base), index=base.index)
             base = base.assign(__is_ste=is_ste, __ssa=ssa_int).sort_values(
@@ -5896,6 +5888,26 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
             return digits
         return lowered
 
+    def _normalize_ssa_series(self, series: pd.Series) -> pd.Series:
+        """Normaliza valores de SSA em modo vetorizado (mais rapido que apply).
+
+        Regra: se houver digitos, retorna apenas os digitos; senao retorna o texto casefold.
+        Valores vazios/NaN/None/NaT/<NA> viram string vazia.
+        """
+        try:
+            s = series.astype(str).str.strip()
+            lowered = s.str.casefold()
+            empty_mask = s.eq("") | lowered.isin(("nan", "none", "nat", "<na>"))
+            digits = s.str.replace(r"\D+", "", regex=True)
+            out = digits.where(digits.ne(""), lowered)
+            return out.where(~empty_mask, "")
+        except Exception as exc:
+            logger.debug("Falha ao normalizar SSA series; fallback apply: %s", exc)
+            try:
+                return series.apply(self._normalize_ssa_value)
+            except Exception:
+                return pd.Series([""] * len(series), index=getattr(series, "index", None))
+
     def update_details_from_selection(self):
         """Atualiza o painel de detalhes com base na linha selecionada."""
         if self.table_widget.rowCount() == 0:
@@ -5968,7 +5980,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         if not num_norm:
             return []
         try:
-            series_norm = self.df_completo["derivada_de"].apply(self._normalize_ssa_value)
+            series_norm = self._normalize_ssa_series(self.df_completo["derivada_de"])
             mask = series_norm.eq(num_norm)
             derived_raw = self.df_completo.loc[mask, "numero_ssa"].tolist()
             derived = []
@@ -5989,7 +6001,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
             df_reset = self.df_exibido.reset_index(drop=True)
             if "numero_ssa" not in df_reset.columns:
                 return
-            series_norm = df_reset["numero_ssa"].apply(self._normalize_ssa_value)
+            series_norm = self._normalize_ssa_series(df_reset["numero_ssa"])
             mask = series_norm.eq(num_norm)
             if not mask.any():
                 self.search_input.setText(f"={num_norm}")

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -4088,6 +4088,13 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         except Exception as exc:
             logger.debug("Failed to apply reprogramacoes advanced filter: %s", exc)
 
+        # Early bailouts: avoid expensive parsing work when mask is already empty.
+        try:
+            if not bool(mask.any()):
+                return df.iloc[0:0]
+        except Exception as exc:
+            logger.debug("Failed to evaluate advanced filter mask.any(): %s", exc)
+
         def _to_int_set(values):
             result = set()
             for raw in values or []:
@@ -4169,6 +4176,12 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
 
         _apply_week_range("semana_cadastro", "semana_emissao_inicio", "semana_emissao_fim", "semana_emissao_exclude")
         _apply_week_range("semana_executada", "semana_execucao_inicio", "semana_execucao_fim", "semana_execucao_exclude")
+
+        try:
+            if not bool(mask.any()):
+                return df.iloc[0:0]
+        except Exception as exc:
+            logger.debug("Failed to evaluate advanced filter mask.any() after week ranges: %s", exc)
 
         derivada_has = bool(filters.get("derivada_has"))
         derivada_all_ste = bool(filters.get("derivada_all_ste"))

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -4381,11 +4381,15 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
 
         if DataLoaderWorker is None:
             logger.error("DataLoaderWorker indisponivel para load_data")
-            QMessageBox.critical(
-                self,
-                "Erro de Carregamento",
-                "Data loader indisponivel neste ambiente. Consulte os logs.",
-            )
+            # Evita deadlock por dialogo modal durante testes automatizados.
+            if os.environ.get("PYTEST_CURRENT_TEST"):
+                logger.debug("PYTEST_CURRENT_TEST set; skipping modal DataLoaderWorker error dialog.")
+            else:
+                QMessageBox.critical(
+                    self,
+                    "Erro de Carregamento",
+                    "Data loader indisponivel neste ambiente. Consulte os logs.",
+                )
             self.status_label.setText("Status: Erro ao carregar dados.")
             self.progress_bar.setVisible(False)
             self.load_button.setEnabled(True)

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -64,11 +64,16 @@ logger = logging.getLogger(__name__)
 # Retencao global defensiva para workers de carga que sobrevivem ao ciclo da janela.
 GLOBAL_RETIRED_DATA_LOADER_WORKERS = []
 MAX_GLOBAL_RETIRED_DATA_LOADER_WORKERS = 64
+GLOBAL_RETIRED_DATA_LOADER_META = {}
 
 # Retencao global defensiva para workers de reescaneamento (importacao) que podem
 # continuar por alguns instantes apos o fechamento do dialogo modal.
 GLOBAL_RETIRED_RESCAN_WORKERS = []
 MAX_GLOBAL_RETIRED_RESCAN_WORKERS = 8
+GLOBAL_RETIRED_RESCAN_META = {}
+
+RETIRED_WORKER_TTL_SEC = 300.0
+RETIRED_WORKER_FORCE_WAIT_MS = 500
 logger.addHandler(logging.NullHandler())
 
 from utils.formatting import format_dataframe_for_display, format_cell  # noqa: E402
@@ -4264,8 +4269,10 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         if worker in retired:
             return
         retired.append(worker)
+        GLOBAL_RETIRED_DATA_LOADER_META[worker] = perf_counter()
         if worker not in GLOBAL_RETIRED_DATA_LOADER_WORKERS:
             GLOBAL_RETIRED_DATA_LOADER_WORKERS.append(worker)
+        GLOBAL_RETIRED_DATA_LOADER_META[worker] = perf_counter()
 
         def _release_worker_ref(w=worker):
             try:
@@ -4278,6 +4285,10 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
                     GLOBAL_RETIRED_DATA_LOADER_WORKERS.remove(w)
             except Exception as exc:
                 logger.debug("Falha ao remover worker de carga da lista global aposentada: %s", exc)
+            try:
+                GLOBAL_RETIRED_DATA_LOADER_META.pop(w, None)
+            except Exception as exc:
+                logger.debug("Falha ao remover meta do worker de carga: %s", exc)
 
         try:
             worker.finished.connect(_release_worker_ref)
@@ -4319,16 +4330,105 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
 
     def _prune_retired_data_loader_workers(self) -> None:
         """Remove referencias globais/locais para workers ja finalizados."""
+        now = perf_counter()
         retired_local = list(getattr(self, "_retired_data_loader_workers", []) or [])
-        if retired_local:
-            self._retired_data_loader_workers = [w for w in retired_local if self._is_data_loader_worker_running(w)]
-        else:
-            self._retired_data_loader_workers = []
+        pruned_local = []
+        for w in retired_local:
+            if not self._is_data_loader_worker_running(w):
+                GLOBAL_RETIRED_DATA_LOADER_META.pop(w, None)
+                continue
+            started_at = GLOBAL_RETIRED_DATA_LOADER_META.get(w, now)
+            age = now - started_at
+            if age > RETIRED_WORKER_TTL_SEC:
+                logger.warning("Data loader worker excedeu TTL; solicitando stop.")
+                try:
+                    stopped = self._cleanup_data_loader_worker(
+                        w,
+                        wait_ms=RETIRED_WORKER_FORCE_WAIT_MS,
+                    )
+                except Exception as exc:
+                    logger.debug("Falha ao encerrar data loader worker expirado: %s", exc)
+                    stopped = False
+                if stopped:
+                    GLOBAL_RETIRED_DATA_LOADER_META.pop(w, None)
+                    continue
+                GLOBAL_RETIRED_DATA_LOADER_META[w] = now
+            pruned_local.append(w)
+        self._retired_data_loader_workers = pruned_local
 
-        running_global = [w for w in GLOBAL_RETIRED_DATA_LOADER_WORKERS if self._is_data_loader_worker_running(w)]
+        running_global = []
+        for w in GLOBAL_RETIRED_DATA_LOADER_WORKERS:
+            if not self._is_data_loader_worker_running(w):
+                GLOBAL_RETIRED_DATA_LOADER_META.pop(w, None)
+                continue
+            started_at = GLOBAL_RETIRED_DATA_LOADER_META.get(w, now)
+            age = now - started_at
+            if age > RETIRED_WORKER_TTL_SEC:
+                logger.warning("Data loader worker excedeu TTL; solicitando stop.")
+                try:
+                    stopped = self._cleanup_data_loader_worker(
+                        w,
+                        wait_ms=RETIRED_WORKER_FORCE_WAIT_MS,
+                    )
+                except Exception as exc:
+                    logger.debug("Falha ao encerrar data loader worker expirado: %s", exc)
+                    stopped = False
+                if stopped:
+                    GLOBAL_RETIRED_DATA_LOADER_META.pop(w, None)
+                    continue
+                GLOBAL_RETIRED_DATA_LOADER_META[w] = now
+            running_global.append(w)
         if len(running_global) > MAX_GLOBAL_RETIRED_DATA_LOADER_WORKERS:
             running_global = running_global[-MAX_GLOBAL_RETIRED_DATA_LOADER_WORKERS:]
         GLOBAL_RETIRED_DATA_LOADER_WORKERS[:] = running_global
+        for w in list(GLOBAL_RETIRED_DATA_LOADER_META.keys()):
+            if w not in GLOBAL_RETIRED_DATA_LOADER_WORKERS and w not in self._retired_data_loader_workers:
+                GLOBAL_RETIRED_DATA_LOADER_META.pop(w, None)
+
+    def _is_rescan_worker_running(self, worker) -> bool:
+        if not self._is_data_loader_worker_alive(worker):
+            return False
+        try:
+            if hasattr(worker, "isRunning"):
+                return bool(worker.isRunning())
+        except Exception:
+            return False
+        return False
+
+    def _prune_retired_rescan_workers(self) -> None:
+        now = perf_counter()
+        running_global = []
+        for w in GLOBAL_RETIRED_RESCAN_WORKERS:
+            if not self._is_rescan_worker_running(w):
+                GLOBAL_RETIRED_RESCAN_META.pop(w, None)
+                continue
+            started_at = GLOBAL_RETIRED_RESCAN_META.get(w, now)
+            age = now - started_at
+            if age > RETIRED_WORKER_TTL_SEC:
+                logger.warning("Rescan worker excedeu TTL; solicitando stop.")
+                try:
+                    if hasattr(w, "stop"):
+                        w.stop()
+                    if hasattr(w, "quit"):
+                        w.quit()
+                    if hasattr(w, "wait"):
+                        w.wait(int(RETIRED_WORKER_FORCE_WAIT_MS))
+                    if hasattr(w, "isRunning") and w.isRunning() and hasattr(w, "terminate"):
+                        w.terminate()
+                        w.wait(int(RETIRED_WORKER_FORCE_WAIT_MS))
+                except Exception as exc:
+                    logger.debug("Falha ao encerrar rescan worker expirado: %s", exc)
+                if not self._is_rescan_worker_running(w):
+                    GLOBAL_RETIRED_RESCAN_META.pop(w, None)
+                    continue
+                GLOBAL_RETIRED_RESCAN_META[w] = now
+            running_global.append(w)
+        if len(running_global) > MAX_GLOBAL_RETIRED_RESCAN_WORKERS:
+            running_global = running_global[-MAX_GLOBAL_RETIRED_RESCAN_WORKERS:]
+        GLOBAL_RETIRED_RESCAN_WORKERS[:] = running_global
+        for w in list(GLOBAL_RETIRED_RESCAN_META.keys()):
+            if w not in GLOBAL_RETIRED_RESCAN_WORKERS:
+                GLOBAL_RETIRED_RESCAN_META.pop(w, None)
 
     def _cleanup_data_loader_worker(self, worker, wait_ms: int = 1500) -> bool:
         """Finaliza worker de carga com modo bloqueante opcional.
@@ -6308,6 +6408,10 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
                     GLOBAL_RETIRED_RESCAN_WORKERS.remove(worker)
             except Exception as exc:
                 logger.debug("Falha ao remover RescanWorker da lista global: %s", exc)
+            try:
+                GLOBAL_RETIRED_RESCAN_META.pop(worker, None)
+            except Exception as exc:
+                logger.debug("Falha ao remover meta do RescanWorker: %s", exc)
 
         def on_success():
             nonlocal cancelled
@@ -6361,8 +6465,10 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         if worker.isRunning():
             if worker not in GLOBAL_RETIRED_RESCAN_WORKERS:
                 GLOBAL_RETIRED_RESCAN_WORKERS.append(worker)
+                GLOBAL_RETIRED_RESCAN_META[worker] = perf_counter()
                 if len(GLOBAL_RETIRED_RESCAN_WORKERS) > MAX_GLOBAL_RETIRED_RESCAN_WORKERS:
                     GLOBAL_RETIRED_RESCAN_WORKERS[:] = GLOBAL_RETIRED_RESCAN_WORKERS[-MAX_GLOBAL_RETIRED_RESCAN_WORKERS:]
+            self._prune_retired_rescan_workers()
             logger.warning("RescanWorker ainda esta em execucao apos fechamento do dialogo; mantendo em background.")
 
     def open_docs_folder(self):
@@ -6559,8 +6665,10 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
                         if hasattr(rescan_worker, "isRunning") and rescan_worker.isRunning():
                             if rescan_worker not in GLOBAL_RETIRED_RESCAN_WORKERS:
                                 GLOBAL_RETIRED_RESCAN_WORKERS.append(rescan_worker)
+                                GLOBAL_RETIRED_RESCAN_META[rescan_worker] = perf_counter()
                                 if len(GLOBAL_RETIRED_RESCAN_WORKERS) > MAX_GLOBAL_RETIRED_RESCAN_WORKERS:
                                     GLOBAL_RETIRED_RESCAN_WORKERS[:] = GLOBAL_RETIRED_RESCAN_WORKERS[-MAX_GLOBAL_RETIRED_RESCAN_WORKERS:]
+                            self._prune_retired_rescan_workers()
                             logger.debug(
                                 "RescanWorker ainda ativo durante closeEvent; mantendo referencia global."
                             )

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -2664,6 +2664,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
 
     def _build_derivadas_tree(self, df: pd.DataFrame, numero_col: str, derivada_col: str):
         """Constroi arvore de derivadas com normalizacao robusta de SSA."""
+        mae_filhas_set: dict[str, set[str]] = {}
         mae_filhas: dict[str, list[str]] = {}
         filha_mae: dict[str, str] = {}
         if df is None or df.empty:
@@ -2682,9 +2683,9 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
             if not numero or not derivada_de:
                 continue
             filha_mae[numero] = derivada_de
-            mae_filhas.setdefault(derivada_de, set()).add(numero)
+            mae_filhas_set.setdefault(derivada_de, set()).add(numero)
 
-        for mae, filhas in list(mae_filhas.items()):
+        for mae, filhas in list(mae_filhas_set.items()):
             mae_filhas[mae] = sorted(filhas, key=lambda value: str(value).casefold())
 
         return mae_filhas, filha_mae

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -6198,23 +6198,24 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         worker.finished_success.connect(on_success)
         worker.finished_error.connect(on_error)
 
-        # Handle dialog rejection (cancel button)
-        def on_dialog_rejected():
+        # Cancelamento cooperativo: nao fecha o dialogo imediatamente.
+        # Solicita cancelamento e aguarda o worker finalizar com seguranca.
+        def on_cancel_requested():
             if worker.isRunning():
                 worker.stop()
-                worker.wait(2000)  # Wait up to 2 seconds
-                if worker.isRunning():
-                    worker.terminate()
+                self.status_label.setText("Status: Cancelamento solicitado no reescaneamento.")
 
-        progress_dialog.rejected.connect(on_dialog_rejected)
+        progress_dialog.cancel_requested.connect(on_cancel_requested)
 
         # Start worker and show dialog
         worker.start()
         progress_dialog.exec()
 
-        # Cleanup
+        # Cleanup (best-effort, sem bloquear a UI)
         if worker.isRunning():
-            worker.wait()
+            logger.warning(
+                "RescanWorker ainda esta em execucao apos fechamento do dialogo; mantendo em background."
+            )
 
     def open_docs_folder(self):
         """Abre a pasta docs_entrada no Windows Explorer."""

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -1873,7 +1873,15 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         filter_name = ""
         try:
             parent = button.parent()
-            while parent is not None:
+            seen = set()
+            for _ in range(50):
+                if parent is None:
+                    break
+                pid = id(parent)
+                if pid in seen:
+                    logger.debug("Ciclo detectado ao subir parent() no menu multiselect; abortando.")
+                    break
+                seen.add(pid)
                 if isinstance(parent, QGroupBox):
                     candidate = parent.title()
                     # Ignorar titulos genericos como "Valores"
@@ -2641,9 +2649,9 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
         except Exception:
             return mae_filhas, filha_mae
 
-        for _, row in df_work.iterrows():
-            numero = self._normalize_ssa_value(row.get(numero_col))
-            derivada_de = self._normalize_ssa_value(row.get(derivada_col))
+        for numero_raw, derivada_raw in df_work.itertuples(index=False, name=None):
+            numero = self._normalize_ssa_value(numero_raw)
+            derivada_de = self._normalize_ssa_value(derivada_raw)
             if not numero or not derivada_de:
                 continue
             filha_mae[numero] = derivada_de
@@ -5874,11 +5882,15 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin):
             return None
 
     def _normalize_ssa_value(self, value):
-        text = str(value or "").strip()
+        try:
+            raw = value or ""
+        except Exception:
+            raw = ""
+        text = str(raw).strip()
         if not text:
             return ""
         lowered = text.casefold()
-        if lowered in ("nan", "none", "nat"):
+        if lowered in ("nan", "none", "nat", "<na>"):
             return ""
         try:
             digits = re.sub(r"\D", "", text)

--- a/gui/mixins/filter_gui_ssa_mixin.py
+++ b/gui/mixins/filter_gui_ssa_mixin.py
@@ -338,7 +338,11 @@ class FilterGUISSAMixin:
         if request_id is not None and active_id is not None and request_id != active_id:
             logger.debug("Ignorando erro de filtro obsoleto (request_id=%s, active=%s)", request_id, active_id)
             return
-        QMessageBox.critical(self, "Erro de Filtro", error_msg)
+        # Avoid modal dialogs during automated tests (can deadlock the pytest runner).
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            logger.debug("PYTEST_CURRENT_TEST set; skipping modal filter error dialog.")
+        else:
+            QMessageBox.critical(self, "Erro de Filtro", error_msg)
         self.status_label.setText("Status: Erro ao aplicar filtro.")
 
 

--- a/gui/widgets/rescan_progress_dialog.py
+++ b/gui/widgets/rescan_progress_dialog.py
@@ -122,13 +122,18 @@ class RescanProgressDialog(QDialog):
                 self.append_error(f"\nERRO FINAL: {message}")
 
     def reject(self) -> None:
-        """While running, request cancel instead of closing the dialog."""
+        """Request cancel and close the dialog while running.
+
+        The rescan can take time to stop. Keeping the dialog open and modal can
+        trap the user and make "exit/close" feel broken. Here we request cancel
+        once and allow the dialog to close immediately.
+        """
         if self._finished:
             super().reject()
             return
-        if self._cancel_requested:
-            return
-        self._cancel_requested = True
-        self.cancel_button.setEnabled(False)
-        self.status_label.setText("Cancelamento solicitado. Aguarde...")
-        self.cancel_requested.emit()
+        if not self._cancel_requested:
+            self._cancel_requested = True
+            self.cancel_button.setEnabled(False)
+            self.status_label.setText("Cancelamento solicitado. Aguarde...")
+            self.cancel_requested.emit()
+        super().reject()

--- a/gui/widgets/rescan_progress_dialog.py
+++ b/gui/widgets/rescan_progress_dialog.py
@@ -88,6 +88,10 @@ class RescanProgressDialog(QDialog):
 
     def append_output(self, line: str):
         """Append line to output display."""
+        # When the dialog is cancelled and closed, the worker may still emit a few
+        # lines while stopping. Avoid spending UI time updating a hidden dialog.
+        if self._cancel_requested and not self.isVisible():
+            return
         self.output_text.append(line)
         # Auto-scroll to bottom
         scrollbar = self.output_text.verticalScrollBar()
@@ -95,6 +99,8 @@ class RescanProgressDialog(QDialog):
 
     def append_error(self, line: str):
         """Append line to error display."""
+        if self._cancel_requested and not self.isVisible():
+            return
         self.error_text.append(line)
         # Auto-scroll to bottom
         scrollbar = self.error_text.verticalScrollBar()
@@ -102,6 +108,8 @@ class RescanProgressDialog(QDialog):
 
     def update_progress(self, percentage: int, message: str):
         """Update progress bar and status."""
+        if self._cancel_requested and not self.isVisible():
+            return
         self.progress_bar.setValue(percentage)
         self.status_label.setText(message)
 
@@ -136,4 +144,4 @@ class RescanProgressDialog(QDialog):
             self.cancel_button.setEnabled(False)
             self.status_label.setText("Cancelamento solicitado. Aguarde...")
             self.cancel_requested.emit()
-        super().reject()
+        # Mantem dialogo aberto enquanto o worker finaliza, evitando fechar cedo.

--- a/gui/widgets/rescan_progress_dialog.py
+++ b/gui/widgets/rescan_progress_dialog.py
@@ -5,7 +5,7 @@ from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QTextEdit,
     QPushButton, QProgressBar, QLabel
 )
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtGui import QFont
 
 
@@ -20,11 +20,15 @@ class RescanProgressDialog(QDialog):
     - Cancel button
     """
 
+    cancel_requested = pyqtSignal()
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Reescaneamento em Andamento")
         self.setModal(True)
         self.resize(800, 600)
+        self._cancel_requested = False
+        self._finished = False
         self.setup_ui()
 
     def setup_ui(self):
@@ -103,6 +107,7 @@ class RescanProgressDialog(QDialog):
 
     def set_finished(self, success: bool, message: str = ""):
         """Mark process as finished."""
+        self._finished = True
         self.cancel_button.setEnabled(False)
         self.close_button.setEnabled(True)
 
@@ -115,3 +120,15 @@ class RescanProgressDialog(QDialog):
             self.status_label.setStyleSheet("font-weight: bold; font-size: 12pt; color: red;")
             if message:
                 self.append_error(f"\nERRO FINAL: {message}")
+
+    def reject(self) -> None:
+        """While running, request cancel instead of closing the dialog."""
+        if self._finished:
+            super().reject()
+            return
+        if self._cancel_requested:
+            return
+        self._cancel_requested = True
+        self.cancel_button.setEnabled(False)
+        self.status_label.setText("Cancelamento solicitado. Aguarde...")
+        self.cancel_requested.emit()

--- a/gui/widgets/rescan_progress_dialog.py
+++ b/gui/widgets/rescan_progress_dialog.py
@@ -130,12 +130,7 @@ class RescanProgressDialog(QDialog):
                 self.append_error(f"\nERRO FINAL: {message}")
 
     def reject(self) -> None:
-        """Request cancel and close the dialog while running.
-
-        The rescan can take time to stop. Keeping the dialog open and modal can
-        trap the user and make "exit/close" feel broken. Here we request cancel
-        once and allow the dialog to close immediately.
-        """
+        """Request cancel while running, allow close on a second attempt."""
         if self._finished:
             super().reject()
             return
@@ -144,4 +139,5 @@ class RescanProgressDialog(QDialog):
             self.cancel_button.setEnabled(False)
             self.status_label.setText("Cancelamento solicitado. Aguarde...")
             self.cancel_requested.emit()
-        # Mantem dialogo aberto enquanto o worker finaliza, evitando fechar cedo.
+            return
+        super().reject()

--- a/gui/workers/rescan_worker.py
+++ b/gui/workers/rescan_worker.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import logging
+from contextlib import suppress
 from PyQt6.QtCore import QThread, pyqtSignal
 
 # Add project root to path for imports
@@ -85,6 +86,7 @@ class RescanWorker(QThread):
 
     def run(self):
         """Execute rescan in background thread using modular import."""
+        handler_added = False
         try:
             self.output_line.emit("=== Iniciando Reescaneamento (Modular) ===")
             self.output_line.emit("")
@@ -92,6 +94,7 @@ class RescanWorker(QThread):
 
             # Add log handler to capture import messages
             self.logger.addHandler(self.log_handler)
+            handler_added = True
             self.logger.setLevel(logging.INFO)
 
             # Call modular import function directly
@@ -104,10 +107,6 @@ class RescanWorker(QThread):
                 should_cancel=lambda: self._should_stop,
                 progress_callback=self._progress_callback,
             )
-
-            # Remove log handler
-            self.logger.removeHandler(self.log_handler)
-            self.logger.setLevel(self.original_level)
 
             if self._should_stop:
                 self.finished_error.emit("Processo cancelado pelo usuario")
@@ -122,10 +121,15 @@ class RescanWorker(QThread):
                 self.finished_error.emit("Importacao concluida mas nenhum dado foi atualizado")
 
         except Exception as e:
-            self.logger.removeHandler(self.log_handler)
-            self.logger.setLevel(self.original_level)
             self.error_line.emit(f"Erro ao executar reescaneamento: {e}")
             self.finished_error.emit(f"Erro ao executar reescaneamento: {e}")
+        finally:
+            # Ensure we never deadlock the GUI due to cleanup failures here.
+            if handler_added:
+                with suppress(Exception):
+                    self.logger.removeHandler(self.log_handler)
+            with suppress(Exception):
+                self.logger.setLevel(self.original_level)
 
     def stop(self):
         """Request thread to stop."""

--- a/gui/workers/rescan_worker.py
+++ b/gui/workers/rescan_worker.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import logging
+import threading
 from contextlib import suppress
 from PyQt6.QtCore import QThread, pyqtSignal
 
@@ -13,6 +14,12 @@ if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
 from core.app_logic import run_importer_logic  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+_LOGGER_LOCK = threading.Lock()
+_LOGGER_REFCOUNT = 0
+_LOGGER_PREV_LEVEL = None
 
 
 class RescanWorker(QThread):
@@ -44,7 +51,32 @@ class RescanWorker(QThread):
         # Set up logging to capture import messages
         self.log_handler = _LogHandler(self.output_line, self.error_line)
         self.logger = logging.getLogger('ssa')
-        self.original_level = self.logger.level
+
+        self._logger_attached = False
+
+    def _attach_logger(self) -> None:
+        global _LOGGER_REFCOUNT, _LOGGER_PREV_LEVEL
+        with _LOGGER_LOCK:
+            if _LOGGER_REFCOUNT == 0:
+                _LOGGER_PREV_LEVEL = self.logger.level
+                if _LOGGER_PREV_LEVEL > logging.INFO:
+                    self.logger.setLevel(logging.INFO)
+            if self.log_handler not in self.logger.handlers:
+                self.logger.addHandler(self.log_handler)
+            _LOGGER_REFCOUNT += 1
+            self._logger_attached = True
+
+    def _detach_logger(self) -> None:
+        global _LOGGER_REFCOUNT, _LOGGER_PREV_LEVEL
+        with _LOGGER_LOCK:
+            if self.log_handler in self.logger.handlers:
+                self.logger.removeHandler(self.log_handler)
+            if _LOGGER_REFCOUNT > 0:
+                _LOGGER_REFCOUNT -= 1
+            if _LOGGER_REFCOUNT == 0 and _LOGGER_PREV_LEVEL is not None:
+                self.logger.setLevel(_LOGGER_PREV_LEVEL)
+                _LOGGER_PREV_LEVEL = None
+            self._logger_attached = False
 
     def _progress_callback(self, event_type, data):
         """Handle progress callbacks from run_importer_logic."""
@@ -86,16 +118,13 @@ class RescanWorker(QThread):
 
     def run(self):
         """Execute rescan in background thread using modular import."""
-        handler_added = False
         try:
             self.output_line.emit("=== Iniciando Reescaneamento (Modular) ===")
             self.output_line.emit("")
             self.progress.emit(5, "Configurando...")
 
             # Add log handler to capture import messages
-            self.logger.addHandler(self.log_handler)
-            handler_added = True
-            self.logger.setLevel(logging.INFO)
+            self._attach_logger()
 
             # Call modular import function directly
             success = run_importer_logic(
@@ -120,16 +149,15 @@ class RescanWorker(QThread):
             else:
                 self.finished_error.emit("Importacao concluida mas nenhum dado foi atualizado")
 
-        except Exception as e:
-            self.error_line.emit(f"Erro ao executar reescaneamento: {e}")
-            self.finished_error.emit(f"Erro ao executar reescaneamento: {e}")
+        except Exception:
+            logger.exception("Erro inesperado no reescaneamento")
+            self.error_line.emit("Erro ao executar reescaneamento.")
+            self.finished_error.emit("Erro ao executar reescaneamento.")
         finally:
             # Ensure we never deadlock the GUI due to cleanup failures here.
-            if handler_added:
+            if self._logger_attached:
                 with suppress(Exception):
-                    self.logger.removeHandler(self.log_handler)
-            with suppress(Exception):
-                self.logger.setLevel(self.original_level)
+                    self._detach_logger()
 
     def stop(self):
         """Request thread to stop."""

--- a/gui/workers/rescan_worker.py
+++ b/gui/workers/rescan_worker.py
@@ -69,6 +69,8 @@ class RescanWorker(QThread):
     def _detach_logger(self) -> None:
         global _LOGGER_REFCOUNT, _LOGGER_PREV_LEVEL
         with _LOGGER_LOCK:
+            if not self._logger_attached:
+                return
             if self.log_handler in self.logger.handlers:
                 self.logger.removeHandler(self.log_handler)
             if _LOGGER_REFCOUNT > 0:

--- a/gui/workers/rescan_worker.py
+++ b/gui/workers/rescan_worker.py
@@ -11,7 +11,7 @@ project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from core.app_logic import run_importer_logic
+from core.app_logic import run_importer_logic  # noqa: E402
 
 
 class RescanWorker(QThread):
@@ -101,7 +101,8 @@ class RescanWorker(QThread):
                 db_name='ssas.db',
                 table_name='ssa_table',
                 force_import=True,  # Rescan = force reimport
-                progress_callback=self._progress_callback
+                should_cancel=lambda: self._should_stop,
+                progress_callback=self._progress_callback,
             )
 
             # Remove log handler

--- a/interface/cli_enhancement_manager.py
+++ b/interface/cli_enhancement_manager.py
@@ -115,7 +115,17 @@ class CLIEnhancementManager:
                 fcntl.flock(f.fileno(), flags)
             elif msvcrt is not None:  # pragma: no cover - Windows
                 mode = getattr(msvcrt, "LK_NBLCK", msvcrt.LK_LOCK)
-                msvcrt.locking(f.fileno(), mode, 4096)
+                try:
+                    current_pos = f.tell()
+                except Exception:
+                    current_pos = 0
+                try:
+                    file_size = os.fstat(f.fileno()).st_size
+                except Exception:
+                    file_size = 0
+                remaining = file_size - current_pos
+                lock_len = max(remaining, 1)
+                msvcrt.locking(f.fileno(), mode, lock_len)
         except Exception as exc:
             logger.debug("Nao foi possivel aplicar lock no settings: %s", exc)
 

--- a/interface/cli_enhancement_manager.py
+++ b/interface/cli_enhancement_manager.py
@@ -62,7 +62,12 @@ class CLIEnhancementManager:
             tmp_path = None
             try:
                 fd, tmp_path = tempfile.mkstemp(prefix=f".{base_name}.tmp.", dir=target_dir)
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                try:
+                    fobj = os.fdopen(fd, "w", encoding="utf-8")
+                except BaseException:
+                    os.close(fd)
+                    raise
+                with fobj as f:
                     self._lock_file_if_possible(f)
                     json.dump(self.settings, f, indent=2, ensure_ascii=False)
                     f.flush()

--- a/interface/cli_enhancement_manager.py
+++ b/interface/cli_enhancement_manager.py
@@ -115,7 +115,7 @@ class CLIEnhancementManager:
                 fcntl.flock(f.fileno(), flags)
             elif msvcrt is not None:  # pragma: no cover - Windows
                 mode = getattr(msvcrt, "LK_NBLCK", msvcrt.LK_LOCK)
-                msvcrt.locking(f.fileno(), mode, 1)
+                msvcrt.locking(f.fileno(), mode, 4096)
         except Exception as exc:
             logger.debug("Nao foi possivel aplicar lock no settings: %s", exc)
 

--- a/interface/cli_enhancement_manager.py
+++ b/interface/cli_enhancement_manager.py
@@ -58,6 +58,23 @@ class CLIEnhancementManager:
             target_dir = os.path.dirname(self.settings_file) or "."
             base_name = os.path.basename(self.settings_file) or "cli_enhancements.json"
 
+            lock_file = None
+            try:
+                lock_path = f"{self.settings_file}.lock"
+                lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+                try:
+                    lock_file = os.fdopen(lock_fd, "w")
+                except BaseException:
+                    os.close(lock_fd)
+                    raise
+                self._lock_file_if_possible(lock_file)
+            except Exception as exc:
+                logger.debug("Nao foi possivel preparar lock para settings: %s", exc)
+                if lock_file is not None:
+                    with suppress(Exception):
+                        lock_file.close()
+                lock_file = None
+
             fd = None
             tmp_path = None
             try:
@@ -81,6 +98,9 @@ class CLIEnhancementManager:
                 if tmp_path:
                     with suppress(Exception):
                         os.remove(tmp_path)
+            if lock_file is not None:
+                with suppress(Exception):
+                    lock_file.close()
         except Exception as e:
             logger.error(f"Erro ao salvar configurações CLI: {e}")
 
@@ -88,9 +108,13 @@ class CLIEnhancementManager:
         """Best-effort file lock to avoid races on settings writes."""
         try:
             if fcntl is not None:
-                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+                flags = fcntl.LOCK_EX
+                if hasattr(fcntl, "LOCK_NB"):
+                    flags |= fcntl.LOCK_NB
+                fcntl.flock(f.fileno(), flags)
             elif msvcrt is not None:  # pragma: no cover - Windows
-                msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+                mode = getattr(msvcrt, "LK_NBLCK", msvcrt.LK_LOCK)
+                msvcrt.locking(f.fileno(), mode, 1)
         except Exception as exc:
             logger.debug("Nao foi possivel aplicar lock no settings: %s", exc)
 

--- a/interface/cli_enhancement_manager.py
+++ b/interface/cli_enhancement_manager.py
@@ -8,8 +8,18 @@ import json
 import logging
 import tempfile
 from contextlib import suppress
+from typing import Any
 
 logger = logging.getLogger(__name__)
+
+try:
+    import fcntl  # type: ignore
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore
+try:
+    import msvcrt  # type: ignore
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None  # type: ignore
 
 class CLIEnhancementManager:
     """
@@ -53,6 +63,7 @@ class CLIEnhancementManager:
             try:
                 fd, tmp_path = tempfile.mkstemp(prefix=f".{base_name}.tmp.", dir=target_dir)
                 with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    self._lock_file_if_possible(f)
                     json.dump(self.settings, f, indent=2, ensure_ascii=False)
                     f.flush()
                     try:
@@ -67,6 +78,16 @@ class CLIEnhancementManager:
                         os.remove(tmp_path)
         except Exception as e:
             logger.error(f"Erro ao salvar configurações CLI: {e}")
+
+    def _lock_file_if_possible(self, f: Any) -> None:
+        """Best-effort file lock to avoid races on settings writes."""
+        try:
+            if fcntl is not None:
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            elif msvcrt is not None:  # pragma: no cover - Windows
+                msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+        except Exception as exc:
+            logger.debug("Nao foi possivel aplicar lock no settings: %s", exc)
 
     def is_enhanced_printer_enabled(self) -> bool:
         """Verifica se enhanced table printer está habilitado."""

--- a/interface/cli_enhancement_manager.py
+++ b/interface/cli_enhancement_manager.py
@@ -53,12 +53,12 @@ class CLIEnhancementManager:
 
     def _save_settings(self):
         """Salva configurações das melhorias."""
+        lock_file = None
         try:
             os.makedirs(os.path.dirname(self.settings_file), exist_ok=True)
             target_dir = os.path.dirname(self.settings_file) or "."
             base_name = os.path.basename(self.settings_file) or "cli_enhancements.json"
 
-            lock_file = None
             try:
                 lock_path = f"{self.settings_file}.lock"
                 lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
@@ -98,11 +98,12 @@ class CLIEnhancementManager:
                 if tmp_path:
                     with suppress(Exception):
                         os.remove(tmp_path)
+        except Exception as e:
+            logger.error(f"Erro ao salvar configurações CLI: {e}")
+        finally:
             if lock_file is not None:
                 with suppress(Exception):
                     lock_file.close()
-        except Exception as e:
-            logger.error(f"Erro ao salvar configurações CLI: {e}")
 
     def _lock_file_if_possible(self, f: Any) -> None:
         """Best-effort file lock to avoid races on settings writes."""

--- a/interface/cli_enhancement_manager.py
+++ b/interface/cli_enhancement_manager.py
@@ -6,6 +6,8 @@ Permite ativar/desativar enhanced table printer facilmente.
 import os
 import json
 import logging
+import tempfile
+from contextlib import suppress
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +45,26 @@ class CLIEnhancementManager:
         """Salva configurações das melhorias."""
         try:
             os.makedirs(os.path.dirname(self.settings_file), exist_ok=True)
-            with open(self.settings_file, 'w', encoding='utf-8') as f:
-                json.dump(self.settings, f, indent=2, ensure_ascii=False)
+            target_dir = os.path.dirname(self.settings_file) or "."
+            base_name = os.path.basename(self.settings_file) or "cli_enhancements.json"
+
+            fd = None
+            tmp_path = None
+            try:
+                fd, tmp_path = tempfile.mkstemp(prefix=f".{base_name}.tmp.", dir=target_dir)
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(self.settings, f, indent=2, ensure_ascii=False)
+                    f.flush()
+                    try:
+                        os.fsync(f.fileno())
+                    except OSError as exc:
+                        logger.debug("fsync failed for temp settings file (%s): %s", tmp_path, exc)
+                os.replace(tmp_path, self.settings_file)
+                tmp_path = None
+            finally:
+                if tmp_path:
+                    with suppress(Exception):
+                        os.remove(tmp_path)
         except Exception as e:
             logger.error(f"Erro ao salvar configurações CLI: {e}")
 
@@ -101,7 +121,7 @@ class CLIEnhancementManager:
         status.append("• Seleção otimizada de colunas")
 
         version = self.settings.get("version", "1.0")
-        status.append(f"")
+        status.append("")
         status.append(f"Versão das melhorias: {version}")
 
         return "\n".join(status)

--- a/interface/command_handlers.py
+++ b/interface/command_handlers.py
@@ -23,7 +23,7 @@ def _save_settings_handler(settings: dict):
     try:
         # Delegate to core.config_manager for atomic writes and consistent formatting.
         save_settings(settings)
-        print("Configuracoes salvas em 'config/settings.json'.")
+        print("Configuracoes salvas com sucesso.")
     except Exception as e:  # noqa: BLE001
         print(f"ERRO: Nao foi possivel salvar as configuracoes. Erro: {e}")
 

--- a/interface/command_handlers.py
+++ b/interface/command_handlers.py
@@ -5,7 +5,7 @@ import json
 # Importacoes relativas necessarias para as funcoes
 # Supondo que 'config' esta no root do projeto para os settings
 # Isso sera ajustado via sys.path em cli.py/main.py se necessario
-from core.config_manager import load_settings, load_display_mappings_integrity
+from core.config_manager import load_settings, load_display_mappings_integrity, save_settings
 
 def _load_mappings_handler(file_name: str) -> dict:
     """Carrega mapeamentos de configuracao de arquivos JSON."""
@@ -20,12 +20,11 @@ def _load_mappings_handler(file_name: str) -> dict:
 
 def _save_settings_handler(settings: dict):
     """Salva as configuracoes atualizadas de volta ao settings.json."""
-    settings_path = os.path.join('config', 'settings.json')
     try:
-        with open(settings_path, 'w', encoding='utf-8') as f:
-            json.dump(settings, f, indent=4)
-        print(f"Configuracoes salvas em '{settings_path}'.")
-    except IOError as e:
+        # Delegate to core.config_manager for atomic writes and consistent formatting.
+        save_settings(settings)
+        print("Configuracoes salvas em 'config/settings.json'.")
+    except Exception as e:  # noqa: BLE001
         print(f"ERRO: Nao foi possivel salvar as configuracoes. Erro: {e}")
 
 def print_help():

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ e inicia a interface CLI ou GUI conforme as opcoes fornecidas.
 """
 
 import argparse
+import itertools
 import logging
 import os
 import shutil
@@ -131,6 +132,26 @@ def _configure_logging(
     _logging_configured = True
 
 
+def _debug_listdir_preview(path: str, label: str, limit: int = 50) -> None:
+    """Loga uma previsualizacao de conteudo de diretorio sem varrer tudo."""
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+    if not os.path.exists(path):
+        return
+    try:
+        entries = []
+        with os.scandir(path) as it:
+            for entry in itertools.islice(it, limit + 1):
+                entries.append(entry.name)
+        truncated = len(entries) > limit
+        if truncated:
+            entries = entries[:limit]
+        suffix = " (preview truncado)" if truncated else ""
+        logger.debug("Arquivos em %s: %s%s", label, entries, suffix)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Falha ao listar %s: %s", label, exc)
+
+
 # Adiciona o diretorio raiz do projeto ao sys.path
 def _get_project_root():
     """Retorna o diretorio raiz do projeto de forma robusta para diferentes builds."""
@@ -205,9 +226,6 @@ def main(cli_args=None):
     """
     logger.debug("Iniciando funcao main()")
 
-    import sys
-    import os
-
     logger.debug("Verificando escopo da variavel sys...")
     logger.debug("sys disponivel no escopo global: %s", 'sys' in globals())
     logger.debug("sys disponivel no escopo local: %s", 'sys' in locals())
@@ -225,16 +243,8 @@ def main(cli_args=None):
     logger.debug("Diretorio extracao (raiz) existe: %s", os.path.exists(extracao_root))
     logger.debug("Diretorio extracao (core) existe: %s", os.path.exists(extracao_core))
 
-    if os.path.exists(extracao_root) and logger.isEnabledFor(logging.DEBUG):
-        try:
-            logger.debug("Conteudo de extracao (raiz): %s", os.listdir(extracao_root))
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Falha ao listar conteudo de extracao (raiz): %s", exc)
-    if os.path.exists(extracao_core) and logger.isEnabledFor(logging.DEBUG):
-        try:
-            logger.debug("Conteudo de extracao (core): %s", os.listdir(extracao_core))
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Falha ao listar conteudo de extracao (core): %s", exc)
+    _debug_listdir_preview(extracao_root, "extracao (raiz)")
+    _debug_listdir_preview(extracao_core, "extracao (core)")
 
     extractor_root = os.path.join(extracao_root, 'extractor.py')
     extractor_core = os.path.join(extracao_core, 'extractor.py')
@@ -570,36 +580,12 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
 
         # Listar arquivos nos diretorios importantes
         if logger.isEnabledFor(logging.DEBUG):
-            if os.path.exists(data_dir):
-                try:
-                    logger.debug("Arquivos em data/: %s", os.listdir(data_dir))
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug("Falha ao listar data/: %s", exc)
-            if os.path.exists(docs_dir):
-                try:
-                    logger.debug("Arquivos em docs_entrada/: %s", os.listdir(docs_dir))
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug("Falha ao listar docs_entrada/: %s", exc)
-            if os.path.exists(config_dir):
-                try:
-                    logger.debug("Arquivos em config/: %s", os.listdir(config_dir))
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug("Falha ao listar config/: %s", exc)
-            if os.path.exists(core_dir):
-                try:
-                    logger.debug("Arquivos em core/: %s", os.listdir(core_dir))
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug("Falha ao listar core/: %s", exc)
-            if os.path.exists(armazenamento_dir):
-                try:
-                    logger.debug("Arquivos em core/armazenamento/: %s", os.listdir(armazenamento_dir))
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug("Falha ao listar core/armazenamento/: %s", exc)
-            if os.path.exists(extracao_dir):
-                try:
-                    logger.debug("Arquivos em core/extracao/: %s", os.listdir(extracao_dir))
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug("Falha ao listar core/extracao/: %s", exc)
+            _debug_listdir_preview(data_dir, "data/")
+            _debug_listdir_preview(docs_dir, "docs_entrada/")
+            _debug_listdir_preview(config_dir, "config/")
+            _debug_listdir_preview(core_dir, "core/")
+            _debug_listdir_preview(armazenamento_dir, "core/armazenamento/")
+            _debug_listdir_preview(extracao_dir, "core/extracao/")
 
         # Verificar arquivos especificos que causam problemas
         database_py = os.path.join(armazenamento_dir, 'database.py')
@@ -677,8 +663,6 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
                 logger.debug("Tentando importar enable_optimized_import de armazenamento.database_optimized")
 
                 # Testar caminho absoluto
-                import sys
-                import os
                 current_project_root = project_root
                 optimized_path = os.path.join(current_project_root, 'armazenamento', 'database_optimized.py')
                 logger.debug("Caminho absoluto do modulo otimizado: %s", optimized_path)
@@ -687,7 +671,6 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
                 logger.debug("Verificando disponibilidade do modo otimizado...")
 
                 # Verificar se o arquivo existe
-                import os
                 optimized_file_path = os.path.join(current_project_root, 'armazenamento', 'database_optimized.py')
                 logger.debug("Caminho do arquivo otimizado: %s", optimized_file_path)
                 logger.debug("Arquivo otimizado existe: %s", os.path.exists(optimized_file_path))
@@ -701,10 +684,7 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
                     logger.debug("Diretorio armazenamento no sys.path: %s", armazenamento_path in sys.path)
 
                     if os.path.exists(armazenamento_path) and logger.isEnabledFor(logging.DEBUG):
-                        try:
-                            logger.debug("Arquivos em armazenamento/: %s", os.listdir(armazenamento_path))
-                        except Exception as exc:  # noqa: BLE001
-                            logger.debug("Falha ao listar armazenamento/: %s", exc)
+                        _debug_listdir_preview(armazenamento_path, "armazenamento/")
 
                 try:
                     # Tentar importar o modulo completo primeiro

--- a/main.py
+++ b/main.py
@@ -57,55 +57,6 @@ class _ASCIIOnlyFilter(logging.Filter):
         return True
 
 
-# ==============================================================================
-# DEAD CODE - DELETE CANDIDATE
-# ==============================================================================
-# Status: Always returns None (extracao.extractor exists but has no run_importer_logic)
-# Created: Unknown (likely intended for future extensibility)
-# Last modified: 2025-10-29T12:30:00 (marked as dead code)
-# Recommendation: DELETE - function always returns None, serves no purpose
-# Lines affected: 43-76
-#
-# This function tries to load run_importer_logic from extracao.extractor, but:
-# - extracao/extractor.py exists but has no run_importer_logic function
-# - Function always returns None
-# - Caller (line 677) checks result but it's always None
-# - Can safely remove function and lines 677-679
-def _load_external_run_importer(project_root: str):
-    """
-    Try to load run_importer_logic from extracao.extractor, if available.
-
-    Returns:
-        callable | None: External implementation (if provided), otherwise None.
-    """
-    try:
-        import importlib.util
-
-        spec = importlib.util.find_spec("extracao.extractor")
-        if not spec or not spec.loader:
-            logger.debug("Optional extractor override not found.")
-            return None
-
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        candidate = getattr(module, "run_importer_logic", None)
-        if callable(candidate):
-            logger.debug("Using run_importer_logic provided by extracao.extractor.")
-            return candidate
-
-        logger.debug(
-            "extracao.extractor module present but without run_importer_logic; using core.app_logic."
-        )
-        return None
-    except Exception as exc:  # noqa: BLE001
-        logger.debug(
-            "Failed to load extracao.extractor override (%s); falling back to core.app_logic.",
-            exc,
-            exc_info=True,
-        )
-        return None
-
-
 class SafeRawTextHelpFormatter(argparse.RawTextHelpFormatter):
     """RawTextHelpFormatter que tolera % literais nos textos."""
 
@@ -742,12 +693,6 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
             logger.debug("Usando modo LEGADO/DEBUG (--standard ativo)")
 
         logger.info(f"Iniciando processo de importacao (force_rescan={force_import}, optimized={use_optimized})...")
-        # DEAD CODE: Lines 690-693 - external_run always None, condition never true
-        # Can safely delete lines 690-693 when deleting _load_external_run_importer
-        logger.debug("Verificando implementacao externa de run_importer_logic")
-        external_run = _load_external_run_importer(project_root)
-        if external_run is not None:
-            run_importer_logic = external_run  # noqa: PLW0603
 
         try:
             logger.debug("Executando run_importer_logic...")

--- a/main.py
+++ b/main.py
@@ -225,10 +225,16 @@ def main(cli_args=None):
     logger.debug("Diretorio extracao (raiz) existe: %s", os.path.exists(extracao_root))
     logger.debug("Diretorio extracao (core) existe: %s", os.path.exists(extracao_core))
 
-    if os.path.exists(extracao_root):
-        logger.debug("Conteudo de extracao (raiz): %s", os.listdir(extracao_root))
-    if os.path.exists(extracao_core):
-        logger.debug("Conteudo de extracao (core): %s", os.listdir(extracao_core))
+    if os.path.exists(extracao_root) and logger.isEnabledFor(logging.DEBUG):
+        try:
+            logger.debug("Conteudo de extracao (raiz): %s", os.listdir(extracao_root))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Falha ao listar conteudo de extracao (raiz): %s", exc)
+    if os.path.exists(extracao_core) and logger.isEnabledFor(logging.DEBUG):
+        try:
+            logger.debug("Conteudo de extracao (core): %s", os.listdir(extracao_core))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Falha ao listar conteudo de extracao (core): %s", exc)
 
     extractor_root = os.path.join(extracao_root, 'extractor.py')
     extractor_core = os.path.join(extracao_core, 'extractor.py')
@@ -547,18 +553,37 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
         logger.debug("extracao_dir existe: %s", os.path.exists(extracao_dir))
 
         # Listar arquivos nos diretorios importantes
-        if os.path.exists(data_dir):
-            logger.debug("Arquivos em data/: %s", os.listdir(data_dir))
-        if os.path.exists(docs_dir):
-            logger.debug("Arquivos em docs_entrada/: %s", os.listdir(docs_dir))
-        if os.path.exists(config_dir):
-            logger.debug("Arquivos em config/: %s", os.listdir(config_dir))
-        if os.path.exists(core_dir):
-            logger.debug("Arquivos em core/: %s", os.listdir(core_dir))
-        if os.path.exists(armazenamento_dir):
-            logger.debug("Arquivos em core/armazenamento/: %s", os.listdir(armazenamento_dir))
-        if os.path.exists(extracao_dir):
-            logger.debug("Arquivos em core/extracao/: %s", os.listdir(extracao_dir))
+        if logger.isEnabledFor(logging.DEBUG):
+            if os.path.exists(data_dir):
+                try:
+                    logger.debug("Arquivos em data/: %s", os.listdir(data_dir))
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("Falha ao listar data/: %s", exc)
+            if os.path.exists(docs_dir):
+                try:
+                    logger.debug("Arquivos em docs_entrada/: %s", os.listdir(docs_dir))
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("Falha ao listar docs_entrada/: %s", exc)
+            if os.path.exists(config_dir):
+                try:
+                    logger.debug("Arquivos em config/: %s", os.listdir(config_dir))
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("Falha ao listar config/: %s", exc)
+            if os.path.exists(core_dir):
+                try:
+                    logger.debug("Arquivos em core/: %s", os.listdir(core_dir))
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("Falha ao listar core/: %s", exc)
+            if os.path.exists(armazenamento_dir):
+                try:
+                    logger.debug("Arquivos em core/armazenamento/: %s", os.listdir(armazenamento_dir))
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("Falha ao listar core/armazenamento/: %s", exc)
+            if os.path.exists(extracao_dir):
+                try:
+                    logger.debug("Arquivos em core/extracao/: %s", os.listdir(extracao_dir))
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("Falha ao listar core/extracao/: %s", exc)
 
         # Verificar arquivos especificos que causam problemas
         database_py = os.path.join(armazenamento_dir, 'database.py')
@@ -654,8 +679,11 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
                 armazenamento_path = os.path.join(current_project_root, 'armazenamento')
                 logger.debug("Diretorio armazenamento no sys.path: %s", armazenamento_path in sys.path)
 
-                if os.path.exists(armazenamento_path):
-                    logger.debug("Arquivos em armazenamento/: %s", os.listdir(armazenamento_path))
+                if os.path.exists(armazenamento_path) and logger.isEnabledFor(logging.DEBUG):
+                    try:
+                        logger.debug("Arquivos em armazenamento/: %s", os.listdir(armazenamento_path))
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("Falha ao listar armazenamento/: %s", exc)
 
             try:
                 # Tentar importar o modulo completo primeiro

--- a/main.py
+++ b/main.py
@@ -298,6 +298,18 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
     )
 
     parser.add_argument(
+        '--skip-import',
+        action='store_true',
+        help='''Pula a importacao/verificacao inicial e inicia a GUI/CLI usando o banco existente.
+
+        Use quando voce precisa abrir o app rapidamente e aceita trabalhar com dados possivelmente desatualizados.
+        Para importar depois:
+          - GUI: use o botao "Reescanear" (quando disponivel)
+          - CLI: execute sem --skip-import (ou com --force-rescan, se necessario)
+        '''
+    )
+
+    parser.add_argument(
         '--optimized',
         action='store_true',
         help='''DEPRECATED: Modo otimizado agora e PADRAO. Use --standard para modo legado.
@@ -453,6 +465,9 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
         except Exception:
             print('0.0.0')
         return
+
+    if getattr(args, "skip_import", False) and getattr(args, "force_rescan", False):
+        parser.error("--skip-import nao pode ser combinado com --force-rescan/--rescan")
 
     # Configura logging
     _configure_logging(project_root)
@@ -640,118 +655,122 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
             return
 
         # --- 3. Importacao de Dados (fluxo normal) ---
-        # Determina se a reimportacao e forcada e se deve usar versao otimizada
-        force_import = args.force_rescan
+        if getattr(args, "skip_import", False):
+            logger.info("Pulando importacao/verificacao inicial (--skip-import).")
+            db_updated = False
+        else:
+            # Determina se a reimportacao e forcada e se deve usar versao otimizada
+            force_import = args.force_rescan
 
-        # MUDANCA: Modo otimizado agora e PADRAO (exceto se --standard for usado)
-        use_optimized = not args.standard
+            # MUDANCA: Modo otimizado agora e PADRAO (exceto se --standard for usado)
+            use_optimized = not args.standard
 
-        # Aviso de depreciacao se --optimized for usado
-        if args.optimized:
-            logger.warning("  Flag --optimized e deprecated: modo otimizado ja e padrao. Use --standard para modo legado.")
+            # Aviso de depreciacao se --optimized for usado
+            if args.optimized:
+                logger.warning("  Flag --optimized e deprecated: modo otimizado ja e padrao. Use --standard para modo legado.")
 
-        # Ativar importacao otimizada (agora padrao)
-        if use_optimized:
-            logger.info("Modo de importacao OTIMIZADA ativo (padrao)")
-            logger.debug("Tentando importar enable_optimized_import de armazenamento.database_optimized")
+            # Ativar importacao otimizada (agora padrao)
+            if use_optimized:
+                logger.info("Modo de importacao OTIMIZADA ativo (padrao)")
+                logger.debug("Tentando importar enable_optimized_import de armazenamento.database_optimized")
 
-            # Testar caminho absoluto
-            import sys
-            import os
-            current_project_root = project_root
-            optimized_path = os.path.join(current_project_root, 'armazenamento', 'database_optimized.py')
-            logger.debug("Caminho absoluto do modulo otimizado: %s", optimized_path)
-            logger.debug("Arquivo otimizado presente: %s", os.path.exists(optimized_path))
+                # Testar caminho absoluto
+                import sys
+                import os
+                current_project_root = project_root
+                optimized_path = os.path.join(current_project_root, 'armazenamento', 'database_optimized.py')
+                logger.debug("Caminho absoluto do modulo otimizado: %s", optimized_path)
+                logger.debug("Arquivo otimizado presente: %s", os.path.exists(optimized_path))
 
-            logger.debug("Verificando disponibilidade do modo otimizado...")
+                logger.debug("Verificando disponibilidade do modo otimizado...")
 
-            # Verificar se o arquivo existe
-            import os
-            optimized_file_path = os.path.join(current_project_root, 'armazenamento', 'database_optimized.py')
-            logger.debug("Caminho do arquivo otimizado: %s", optimized_file_path)
-            logger.debug("Arquivo otimizado existe: %s", os.path.exists(optimized_file_path))
+                # Verificar se o arquivo existe
+                import os
+                optimized_file_path = os.path.join(current_project_root, 'armazenamento', 'database_optimized.py')
+                logger.debug("Caminho do arquivo otimizado: %s", optimized_file_path)
+                logger.debug("Arquivo otimizado existe: %s", os.path.exists(optimized_file_path))
 
-            if os.path.exists(optimized_file_path):
-                file_stat = os.stat(optimized_file_path)
-                logger.debug("Permissoes do arquivo otimizado: %s", oct(file_stat.st_mode))
-                logger.debug("Tamanho do arquivo otimizado: %d bytes", file_stat.st_size)
+                if os.path.exists(optimized_file_path):
+                    file_stat = os.stat(optimized_file_path)
+                    logger.debug("Permissoes do arquivo otimizado: %s", oct(file_stat.st_mode))
+                    logger.debug("Tamanho do arquivo otimizado: %d bytes", file_stat.st_size)
 
-                armazenamento_path = os.path.join(current_project_root, 'armazenamento')
-                logger.debug("Diretorio armazenamento no sys.path: %s", armazenamento_path in sys.path)
+                    armazenamento_path = os.path.join(current_project_root, 'armazenamento')
+                    logger.debug("Diretorio armazenamento no sys.path: %s", armazenamento_path in sys.path)
 
-                if os.path.exists(armazenamento_path) and logger.isEnabledFor(logging.DEBUG):
-                    try:
-                        logger.debug("Arquivos em armazenamento/: %s", os.listdir(armazenamento_path))
-                    except Exception as exc:  # noqa: BLE001
-                        logger.debug("Falha ao listar armazenamento/: %s", exc)
+                    if os.path.exists(armazenamento_path) and logger.isEnabledFor(logging.DEBUG):
+                        try:
+                            logger.debug("Arquivos em armazenamento/: %s", os.listdir(armazenamento_path))
+                        except Exception as exc:  # noqa: BLE001
+                            logger.debug("Falha ao listar armazenamento/: %s", exc)
 
-            try:
-                # Tentar importar o modulo completo primeiro
-                logger.debug("Tentando importar armazenamento.database_optimized...")
-                import armazenamento.database_optimized
-                logger.debug("Importacao do modulo completo bem-sucedida")
+                try:
+                    # Tentar importar o modulo completo primeiro
+                    logger.debug("Tentando importar armazenamento.database_optimized...")
+                    import armazenamento.database_optimized
+                    logger.debug("Importacao do modulo completo bem-sucedida")
 
-                # Verificar se a funcao existe no modulo
-                logger.debug("Verificando se enable_optimized_import existe no modulo...")
-                if hasattr(armazenamento.database_optimized, 'enable_optimized_import'):
-                    logger.debug("Funcao enable_optimized_import encontrada")
+                    # Verificar se a funcao existe no modulo
+                    logger.debug("Verificando se enable_optimized_import existe no modulo...")
+                    if hasattr(armazenamento.database_optimized, 'enable_optimized_import'):
+                        logger.debug("Funcao enable_optimized_import encontrada")
 
-                    from armazenamento.database_optimized import enable_optimized_import
-                    logger.debug("Importacao de enable_optimized_import bem-sucedida")
+                        from armazenamento.database_optimized import enable_optimized_import
+                        logger.debug("Importacao de enable_optimized_import bem-sucedida")
 
-                    enable_optimized_import()
-                    logger.debug("enable_optimized_import() executado com sucesso")
-                else:
-                    logger.error("Funcao enable_optimized_import NAO encontrada no modulo")
+                        enable_optimized_import()
+                        logger.debug("enable_optimized_import() executado com sucesso")
+                    else:
+                        logger.error("Funcao enable_optimized_import NAO encontrada no modulo")
+                        logger.warning("Modo otimizado nao disponivel, recorrendo ao modo legado")
+                        use_optimized = False
+
+                except ImportError as e:
+                    logger.error("Falha ao importar enable_optimized_import: %s", e)
+                    logger.debug("Tipo do erro: %s", type(e).__name__)
+                    logger.debug("Modulo associado: %s", getattr(e, 'name', 'desconhecido'))
                     logger.warning("Modo otimizado nao disponivel, recorrendo ao modo legado")
                     use_optimized = False
+                except Exception as e:
+                    logger.error("Erro ao executar enable_optimized_import: %s", e)
+                    logger.debug("Tipo do erro: %s", type(e).__name__)
+                    logger.warning("Modo otimizado falhou, recorrendo ao modo legado")
+                    use_optimized = False
+            else:
+                logger.debug("Usando modo LEGADO/DEBUG (--standard ativo)")
 
-            except ImportError as e:
-                logger.error("Falha ao importar enable_optimized_import: %s", e)
-                logger.debug("Tipo do erro: %s", type(e).__name__)
-                logger.debug("Modulo associado: %s", getattr(e, 'name', 'desconhecido'))
-                logger.warning("Modo otimizado nao disponivel, recorrendo ao modo legado")
-                use_optimized = False
-            except Exception as e:
-                logger.error("Erro ao executar enable_optimized_import: %s", e)
-                logger.debug("Tipo do erro: %s", type(e).__name__)
-                logger.warning("Modo otimizado falhou, recorrendo ao modo legado")
-                use_optimized = False
-        else:
-            logger.debug("Usando modo LEGADO/DEBUG (--standard ativo)")
+            logger.info(f"Iniciando processo de importacao (force_rescan={force_import}, optimized={use_optimized})...")
 
-        logger.info(f"Iniciando processo de importacao (force_rescan={force_import}, optimized={use_optimized})...")
-
-        try:
-            logger.debug("Executando run_importer_logic...")
-            db_updated = run_importer_logic(force_import=force_import)
-            logger.debug("Importacao de dados concluida. Resultado: db_updated=%s", db_updated)
-        except Exception as e:
-            logger.error("Falha critica na importacao de dados: %s", e)
-            logger.error("Este e o ponto mais critico do processo. Verifique:")
-            logger.error("  1. Existencia e permissoes da pasta 'data'")
-            logger.error("  2. Conexao com o banco de dados")
-            logger.error("  3. Arquivos Excel na pasta de entrada")
-            logger.error("  4. Memoria disponivel do sistema")
-            raise
-
-        # Desativar importacao otimizada apos uso
-        if use_optimized:
             try:
-                from armazenamento.database_optimized import disable_optimized_import
-                disable_optimized_import()
-            except ImportError:
-                pass
+                logger.debug("Executando run_importer_logic...")
+                db_updated = run_importer_logic(force_import=force_import)
+                logger.debug("Importacao de dados concluida. Resultado: db_updated=%s", db_updated)
             except Exception as e:
-                logger.warning(f"Falha ao desativar modo otimizado: {e}")
+                logger.error("Falha critica na importacao de dados: %s", e)
+                logger.error("Este e o ponto mais critico do processo. Verifique:")
+                logger.error("  1. Existencia e permissoes da pasta 'data'")
+                logger.error("  2. Conexao com o banco de dados")
+                logger.error("  3. Arquivos Excel na pasta de entrada")
+                logger.error("  4. Memoria disponivel do sistema")
+                raise
 
-        if db_updated:
-            logger.info("Banco de dados atualizado com sucesso.")
-            logger.debug("Banco de dados foi atualizado. Verifique se os dados estao acessiveis.")
-        else:
-            logger.info("Nenhum novo ou modificado relatorio encontrado.")
-            logger.debug("Nenhum novo relatorio encontrado. Isso pode ser normal ou indicar problemas.")
-            logger.debug("Verifique se ha arquivos Excel na pasta de entrada e se eles contem dados validos.")
+            # Desativar importacao otimizada apos uso
+            if use_optimized:
+                try:
+                    from armazenamento.database_optimized import disable_optimized_import
+                    disable_optimized_import()
+                except ImportError:
+                    pass
+                except Exception as e:
+                    logger.warning(f"Falha ao desativar modo otimizado: {e}")
+
+            if db_updated:
+                logger.info("Banco de dados atualizado com sucesso.")
+                logger.debug("Banco de dados foi atualizado. Verifique se os dados estao acessiveis.")
+            else:
+                logger.info("Nenhum novo ou modificado relatorio encontrado.")
+                logger.debug("Nenhum novo relatorio encontrado. Isso pode ser normal ou indicar problemas.")
+                logger.debug("Verifique se ha arquivos Excel na pasta de entrada e se eles contem dados validos.")
 
         # --- 4. Inicio da Interface ---
         # Respeita variaveis de ambiente para facilitar testes e integracao

--- a/main.py
+++ b/main.py
@@ -756,16 +756,16 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
                 logger.error("  3. Arquivos Excel na pasta de entrada")
                 logger.error("  4. Memoria disponivel do sistema")
                 raise
-
-            # Desativar importacao otimizada apos uso
-            if optimized_enabled:
-                try:
-                    from armazenamento.database_optimized import disable_optimized_import
-                    disable_optimized_import()
-                except ImportError:
-                    pass
-                except Exception as e:
-                    logger.warning(f"Falha ao desativar modo otimizado: {e}")
+            finally:
+                # Desativar importacao otimizada apos uso
+                if optimized_enabled:
+                    try:
+                        from armazenamento.database_optimized import disable_optimized_import
+                        disable_optimized_import()
+                    except ImportError:
+                        pass
+                    except Exception as e:
+                        logger.warning(f"Falha ao desativar modo otimizado: {e}")
 
             if db_updated:
                 logger.info("Banco de dados atualizado com sucesso.")

--- a/main.py
+++ b/main.py
@@ -474,6 +474,7 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
     try:
         logger.setLevel(getattr(logging, args.log_level))
     except AttributeError:
+        print(f"Nível de log inválido: {args.log_level}. Usando INFO.")
         logger.setLevel(logging.INFO)
 
     # Banner inicial
@@ -670,6 +671,7 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
                 logger.warning("  Flag --optimized e deprecated: modo otimizado ja e padrao. Use --standard para modo legado.")
 
             # Ativar importacao otimizada (agora padrao)
+            optimized_enabled = False
             if use_optimized:
                 logger.info("Modo de importacao OTIMIZADA ativo (padrao)")
                 logger.debug("Tentando importar enable_optimized_import de armazenamento.database_optimized")
@@ -719,6 +721,7 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
                         logger.debug("Importacao de enable_optimized_import bem-sucedida")
 
                         enable_optimized_import()
+                        optimized_enabled = True
                         logger.debug("enable_optimized_import() executado com sucesso")
                     else:
                         logger.error("Funcao enable_optimized_import NAO encontrada no modulo")
@@ -755,7 +758,7 @@ Mais detalhes: README.md e GUIA_MODO_OPTIMIZED.md
                 raise
 
             # Desativar importacao otimizada apos uso
-            if use_optimized:
+            if optimized_enabled:
                 try:
                     from armazenamento.database_optimized import disable_optimized_import
                     disable_optimized_import()

--- a/scripts/run_pytest_stream_and_log.py
+++ b/scripts/run_pytest_stream_and_log.py
@@ -98,6 +98,7 @@ def main():
 
     line_queue: "queue.Queue[str | None]" = queue.Queue(maxsize=_queue_maxsize())
     dropped_lines = 0
+    dropped_lock = threading.Lock()
 
     def _safe_queue_put(value: str | None) -> None:
         nonlocal dropped_lines
@@ -112,7 +113,8 @@ def main():
                 except queue.Full:
                     try:
                         line_queue.get_nowait()
-                        dropped_lines += 1
+                        with dropped_lock:
+                            dropped_lines += 1
                     except queue.Empty:
                         time.sleep(0.005)
 
@@ -129,22 +131,28 @@ def main():
                 pass
 
             if evicted:
-                dropped_lines += 1
+                with dropped_lock:
+                    dropped_lines += 1
 
             try:
                 line_queue.put_nowait(value)
-                if evicted and dropped_lines % 200 == 1:
-                    warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
-                    try:
-                        line_queue.put_nowait(warn)
-                    except queue.Full:
-                        pass
+                if evicted:
+                    with dropped_lock:
+                        warn_count = dropped_lines
+                    if warn_count % 200 == 1:
+                        warn = f"[WARN] output queue full; dropped {warn_count} line(s)\n"
+                        try:
+                            line_queue.put_nowait(warn)
+                        except queue.Full:
+                            pass
                 return
             except queue.Full:
                 # Still no space, drop the line itself.
-                dropped_lines += 1
-                if dropped_lines % 200 == 1:
-                    warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
+                with dropped_lock:
+                    dropped_lines += 1
+                    warn_count = dropped_lines
+                if warn_count % 200 == 1:
+                    warn = f"[WARN] output queue full; dropped {warn_count} line(s)\n"
                     try:
                         line_queue.put_nowait(warn)
                     except queue.Full:

--- a/scripts/run_pytest_stream_and_log.py
+++ b/scripts/run_pytest_stream_and_log.py
@@ -117,7 +117,6 @@ def main():
                 warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
                 try:
                     line_queue.put_nowait(warn)
-                    return
                 except queue.Full:
                     pass
 

--- a/scripts/run_pytest_stream_and_log.py
+++ b/scripts/run_pytest_stream_and_log.py
@@ -97,33 +97,43 @@ def main():
                 except queue.Full:
                     try:
                         line_queue.get_nowait()
+                        dropped_lines += 1
                     except queue.Empty:
-                        pass
-            return
+                        time.sleep(0.005)
 
         try:
             line_queue.put_nowait(value)
             return
         except queue.Full:
-            dropped_lines += 1
             # Drop the oldest line to make room (best-effort).
+            evicted = False
             try:
                 line_queue.get_nowait()
+                evicted = True
             except queue.Empty:
-                return
+                pass
 
-            # Occasionally report that output was dropped to preserve transparency.
-            if dropped_lines % 200 == 1:
-                warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
-                try:
-                    line_queue.put_nowait(warn)
-                except queue.Full:
-                    pass
+            if evicted:
+                dropped_lines += 1
+                if dropped_lines % 200 == 1:
+                    warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
+                    try:
+                        line_queue.put_nowait(warn)
+                    except queue.Full:
+                        pass
 
             try:
                 line_queue.put_nowait(value)
+                return
             except queue.Full:
-                # Still no space, drop the line.
+                # Still no space, drop the line itself.
+                dropped_lines += 1
+                if dropped_lines % 200 == 1:
+                    warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
+                    try:
+                        line_queue.put_nowait(warn)
+                    except queue.Full:
+                        pass
                 return
 
     def _reader_worker() -> None:

--- a/scripts/run_pytest_stream_and_log.py
+++ b/scripts/run_pytest_stream_and_log.py
@@ -82,24 +82,50 @@ def main():
         )
 
     line_queue: "queue.Queue[str | None]" = queue.Queue(maxsize=4096)
+    dropped_lines = 0
 
     def _safe_queue_put(value: str | None) -> None:
-        while True:
-            try:
-                line_queue.put(value, timeout=0.1)
-                return
-            except queue.Full:
-                # Avoid unbounded memory growth when producer is faster than consumer.
-                if p.poll() is not None:
+        nonlocal dropped_lines
+        # Never block the reader thread when the queue is full.
+        # Blocking here can deadlock when the child process fills its stdout pipe.
+        if value is None:
+            # Ensure the sentinel is delivered by dropping older lines if needed.
+            while True:
+                try:
+                    line_queue.put_nowait(None)
+                    return
+                except queue.Full:
                     try:
                         line_queue.get_nowait()
                     except queue.Empty:
                         pass
-                    try:
-                        line_queue.put_nowait(value)
-                    except queue.Full:
-                        pass
+            return
+
+        try:
+            line_queue.put_nowait(value)
+            return
+        except queue.Full:
+            dropped_lines += 1
+            # Drop the oldest line to make room (best-effort).
+            try:
+                line_queue.get_nowait()
+            except queue.Empty:
+                return
+
+            # Occasionally report that output was dropped to preserve transparency.
+            if dropped_lines % 200 == 1:
+                warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
+                try:
+                    line_queue.put_nowait(warn)
                     return
+                except queue.Full:
+                    pass
+
+            try:
+                line_queue.put_nowait(value)
+            except queue.Full:
+                # Still no space, drop the line.
+                return
 
     def _reader_worker() -> None:
         try:

--- a/scripts/run_pytest_stream_and_log.py
+++ b/scripts/run_pytest_stream_and_log.py
@@ -33,6 +33,21 @@ def ensure_log_path(logpath: str):
         os.makedirs(d, exist_ok=True)
 
 
+def _queue_maxsize() -> int:
+    raw = os.environ.get("PYTEST_STREAM_QUEUE_MAX")
+    if not raw:
+        return 4096
+    try:
+        value = int(raw)
+    except ValueError:
+        return 4096
+    if value < 256:
+        return 256
+    if value > 65536:
+        return 65536
+    return value
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--test", required=True)
@@ -81,7 +96,7 @@ def main():
             start_new_session=True,
         )
 
-    line_queue: "queue.Queue[str | None]" = queue.Queue(maxsize=4096)
+    line_queue: "queue.Queue[str | None]" = queue.Queue(maxsize=_queue_maxsize())
     dropped_lines = 0
 
     def _safe_queue_put(value: str | None) -> None:

--- a/scripts/run_pytest_stream_and_log.py
+++ b/scripts/run_pytest_stream_and_log.py
@@ -115,15 +115,15 @@ def main():
 
             if evicted:
                 dropped_lines += 1
-                if dropped_lines % 200 == 1:
+
+            try:
+                line_queue.put_nowait(value)
+                if evicted and dropped_lines % 200 == 1:
                     warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
                     try:
                         line_queue.put_nowait(warn)
                     except queue.Full:
                         pass
-
-            try:
-                line_queue.put_nowait(value)
                 return
             except queue.Full:
                 # Still no space, drop the line itself.

--- a/scripts/run_pytest_stream_and_log.py
+++ b/scripts/run_pytest_stream_and_log.py
@@ -99,9 +99,10 @@ def main():
     line_queue: "queue.Queue[str | None]" = queue.Queue(maxsize=_queue_maxsize())
     dropped_lines = 0
     dropped_lock = threading.Lock()
+    last_warned = 0
 
     def _safe_queue_put(value: str | None) -> None:
-        nonlocal dropped_lines
+        nonlocal dropped_lines, last_warned
         # Never block the reader thread when the queue is full.
         # Blocking here can deadlock when the child process fills its stdout pipe.
         if value is None:
@@ -139,7 +140,10 @@ def main():
                 if evicted:
                     with dropped_lock:
                         warn_count = dropped_lines
-                    if warn_count % 200 == 1:
+                        should_warn = warn_count % 200 == 1 and warn_count != last_warned
+                        if should_warn:
+                            last_warned = warn_count
+                    if should_warn:
                         warn = f"[WARN] output queue full; dropped {warn_count} line(s)\n"
                         try:
                             line_queue.put_nowait(warn)
@@ -151,7 +155,10 @@ def main():
                 with dropped_lock:
                     dropped_lines += 1
                     warn_count = dropped_lines
-                if warn_count % 200 == 1:
+                    should_warn = warn_count % 200 == 1 and warn_count != last_warned
+                    if should_warn:
+                        last_warned = warn_count
+                if should_warn:
                     warn = f"[WARN] output queue full; dropped {warn_count} line(s)\n"
                     try:
                         line_queue.put_nowait(warn)

--- a/scripts/run_pytest_stream_and_log_v2.py
+++ b/scripts/run_pytest_stream_and_log_v2.py
@@ -37,6 +37,21 @@ def ensure_log_path(logpath: str):
         os.makedirs(d, exist_ok=True)
 
 
+def _queue_maxsize() -> int:
+    raw = os.environ.get("PYTEST_STREAM_QUEUE_MAX")
+    if not raw:
+        return 4096
+    try:
+        value = int(raw)
+    except ValueError:
+        return 4096
+    if value < 256:
+        return 256
+    if value > 65536:
+        return 65536
+    return value
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--test", required=True)
@@ -120,7 +135,7 @@ def main():
             start_new_session=True,
         )
 
-    line_queue: "queue.Queue[str | None]" = queue.Queue(maxsize=4096)
+    line_queue: "queue.Queue[str | None]" = queue.Queue(maxsize=_queue_maxsize())
     dropped_lines = 0
     dropped_lock = threading.Lock()
 

--- a/scripts/run_pytest_stream_and_log_v2.py
+++ b/scripts/run_pytest_stream_and_log_v2.py
@@ -136,34 +136,43 @@ def main():
                 except queue.Full:
                     try:
                         line_queue.get_nowait()
+                        dropped_lines += 1
                     except queue.Empty:
-                        pass
-            return
+                        time.sleep(0.005)
 
         try:
             line_queue.put_nowait(value)
             return
         except queue.Full:
-            dropped_lines += 1
             # Drop the oldest line to make room (best-effort).
+            evicted = False
             try:
                 line_queue.get_nowait()
+                evicted = True
             except queue.Empty:
-                return
+                pass
 
-            # Occasionally report that output was dropped to preserve transparency.
-            if dropped_lines % 200 == 1:
-                warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
-                try:
-                    line_queue.put_nowait(warn)
-                    return
-                except queue.Full:
-                    pass
+            if evicted:
+                dropped_lines += 1
+                if dropped_lines % 200 == 1:
+                    warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
+                    try:
+                        line_queue.put_nowait(warn)
+                    except queue.Full:
+                        pass
 
             try:
                 line_queue.put_nowait(value)
+                return
             except queue.Full:
                 # Still no space, drop the line.
+                dropped_lines += 1
+                if dropped_lines % 200 == 1:
+                    warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
+                    try:
+                        line_queue.put_nowait(warn)
+                    except queue.Full:
+                        pass
                 return
 
     def _reader_worker() -> None:

--- a/scripts/run_pytest_stream_and_log_v2.py
+++ b/scripts/run_pytest_stream_and_log_v2.py
@@ -154,15 +154,15 @@ def main():
 
             if evicted:
                 dropped_lines += 1
-                if dropped_lines % 200 == 1:
+
+            try:
+                line_queue.put_nowait(value)
+                if evicted and dropped_lines % 200 == 1:
                     warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
                     try:
                         line_queue.put_nowait(warn)
                     except queue.Full:
                         pass
-
-            try:
-                line_queue.put_nowait(value)
                 return
             except queue.Full:
                 # Still no space, drop the line.

--- a/scripts/run_pytest_stream_and_log_v2.py
+++ b/scripts/run_pytest_stream_and_log_v2.py
@@ -131,15 +131,15 @@ def main():
             # Ensure the sentinel is delivered by dropping older lines if needed.
             while True:
                 try:
-                    line_queue.put_nowait(None)
+                    line_queue.put(None, timeout=0.2)
                     return
                 except queue.Full:
                     try:
-                        line_queue.get_nowait()
+                        line_queue.get(timeout=0.2)
                         with dropped_lock:
                             dropped_lines += 1
                     except queue.Empty:
-                        time.sleep(0.005)
+                        continue
 
         try:
             line_queue.put_nowait(value)

--- a/scripts/run_pytest_stream_and_log_v2.py
+++ b/scripts/run_pytest_stream_and_log_v2.py
@@ -140,6 +140,7 @@ def main():
     dropped_lock = threading.Lock()
 
     def _safe_queue_put(value: str | None) -> None:
+        nonlocal dropped_lines
         # Never block the reader thread when the queue is full.
         # Blocking here can deadlock when the child process fills its stdout pipe.
         if value is None:

--- a/scripts/run_pytest_stream_and_log_v2.py
+++ b/scripts/run_pytest_stream_and_log_v2.py
@@ -138,9 +138,10 @@ def main():
     line_queue: "queue.Queue[str | None]" = queue.Queue(maxsize=_queue_maxsize())
     dropped_lines = 0
     dropped_lock = threading.Lock()
+    last_warned = 0
 
     def _safe_queue_put(value: str | None) -> None:
-        nonlocal dropped_lines
+        nonlocal dropped_lines, last_warned
         # Never block the reader thread when the queue is full.
         # Blocking here can deadlock when the child process fills its stdout pipe.
         if value is None:
@@ -181,7 +182,10 @@ def main():
                 if evicted:
                     with dropped_lock:
                         warn_count = dropped_lines
-                    if warn_count % 200 == 1:
+                        should_warn = warn_count % 200 == 1 and warn_count != last_warned
+                        if should_warn:
+                            last_warned = warn_count
+                    if should_warn:
                         warn = f"[WARN] output queue full; dropped {warn_count} line(s)\n"
                         try:
                             line_queue.put_nowait(warn)
@@ -193,7 +197,10 @@ def main():
                 with dropped_lock:
                     dropped_lines += 1
                     warn_count = dropped_lines
-                if warn_count % 200 == 1:
+                    should_warn = warn_count % 200 == 1 and warn_count != last_warned
+                    if should_warn:
+                        last_warned = warn_count
+                if should_warn:
                     warn = f"[WARN] output queue full; dropped {warn_count} line(s)\n"
                     try:
                         line_queue.put_nowait(warn)

--- a/scripts/run_pytest_stream_and_log_v2.py
+++ b/scripts/run_pytest_stream_and_log_v2.py
@@ -121,24 +121,50 @@ def main():
         )
 
     line_queue: "queue.Queue[str | None]" = queue.Queue(maxsize=4096)
+    dropped_lines = 0
 
     def _safe_queue_put(value: str | None) -> None:
-        while True:
-            try:
-                line_queue.put(value, timeout=0.1)
-                return
-            except queue.Full:
-                # Apply bounded backpressure and avoid unbounded memory use.
-                if p.poll() is not None:
+        nonlocal dropped_lines
+        # Never block the reader thread when the queue is full.
+        # Blocking here can deadlock when the child process fills its stdout pipe.
+        if value is None:
+            # Ensure the sentinel is delivered by dropping older lines if needed.
+            while True:
+                try:
+                    line_queue.put_nowait(None)
+                    return
+                except queue.Full:
                     try:
                         line_queue.get_nowait()
                     except queue.Empty:
                         pass
-                    try:
-                        line_queue.put_nowait(value)
-                    except queue.Full:
-                        pass
+            return
+
+        try:
+            line_queue.put_nowait(value)
+            return
+        except queue.Full:
+            dropped_lines += 1
+            # Drop the oldest line to make room (best-effort).
+            try:
+                line_queue.get_nowait()
+            except queue.Empty:
+                return
+
+            # Occasionally report that output was dropped to preserve transparency.
+            if dropped_lines % 200 == 1:
+                warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
+                try:
+                    line_queue.put_nowait(warn)
                     return
+                except queue.Full:
+                    pass
+
+            try:
+                line_queue.put_nowait(value)
+            except queue.Full:
+                # Still no space, drop the line.
+                return
 
     def _reader_worker() -> None:
         try:

--- a/scripts/run_pytest_stream_and_log_v2.py
+++ b/scripts/run_pytest_stream_and_log_v2.py
@@ -147,15 +147,18 @@ def main():
             # Ensure the sentinel is delivered by dropping older lines if needed.
             while True:
                 try:
-                    line_queue.put(None, timeout=0.2)
+                    line_queue.put_nowait(None)
                     return
                 except queue.Full:
+                    evicted = False
                     try:
-                        line_queue.get(timeout=0.2)
+                        line_queue.get_nowait()
+                        evicted = True
+                    except queue.Empty:
+                        time.sleep(0.001)
+                    if evicted:
                         with dropped_lock:
                             dropped_lines += 1
-                    except queue.Empty:
-                        continue
 
         try:
             line_queue.put_nowait(value)

--- a/scripts/run_pytest_stream_and_log_v2.py
+++ b/scripts/run_pytest_stream_and_log_v2.py
@@ -122,9 +122,9 @@ def main():
 
     line_queue: "queue.Queue[str | None]" = queue.Queue(maxsize=4096)
     dropped_lines = 0
+    dropped_lock = threading.Lock()
 
     def _safe_queue_put(value: str | None) -> None:
-        nonlocal dropped_lines
         # Never block the reader thread when the queue is full.
         # Blocking here can deadlock when the child process fills its stdout pipe.
         if value is None:
@@ -136,7 +136,8 @@ def main():
                 except queue.Full:
                     try:
                         line_queue.get_nowait()
-                        dropped_lines += 1
+                        with dropped_lock:
+                            dropped_lines += 1
                     except queue.Empty:
                         time.sleep(0.005)
 
@@ -153,22 +154,28 @@ def main():
                 pass
 
             if evicted:
-                dropped_lines += 1
+                with dropped_lock:
+                    dropped_lines += 1
 
             try:
                 line_queue.put_nowait(value)
-                if evicted and dropped_lines % 200 == 1:
-                    warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
-                    try:
-                        line_queue.put_nowait(warn)
-                    except queue.Full:
-                        pass
+                if evicted:
+                    with dropped_lock:
+                        warn_count = dropped_lines
+                    if warn_count % 200 == 1:
+                        warn = f"[WARN] output queue full; dropped {warn_count} line(s)\n"
+                        try:
+                            line_queue.put_nowait(warn)
+                        except queue.Full:
+                            pass
                 return
             except queue.Full:
                 # Still no space, drop the line.
-                dropped_lines += 1
-                if dropped_lines % 200 == 1:
-                    warn = f"[WARN] output queue full; dropped {dropped_lines} line(s)\n"
+                with dropped_lock:
+                    dropped_lines += 1
+                    warn_count = dropped_lines
+                if warn_count % 200 == 1:
+                    warn = f"[WARN] output queue full; dropped {warn_count} line(s)\n"
                     try:
                         line_queue.put_nowait(warn)
                     except queue.Full:

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -2,13 +2,14 @@
 import pytest
 import os
 import sys
-import hashlib
+import json
 
 # Adiciona a raiz do projeto ao path
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, project_root)
 
-from utils.caching import get_files_to_process, _calculate_hash
+from utils.caching import get_files_to_process, _calculate_hash  # noqa: E402
+import utils.caching as caching  # noqa: E402
 
 # --- Fixture: Preparando o Ambiente de Teste ---
 
@@ -90,3 +91,70 @@ def test_get_files_to_process_no_changes(temp_docs_dir):
     assert not files_to_process # Outra forma de verificar se a lista está vazia
 
 
+def test_get_files_to_process_skips_hash_when_metadata_unchanged(temp_docs_dir, monkeypatch):
+    file_a_path = os.path.join(temp_docs_dir, "relatorio_a.xlsx")
+    file_b_path = os.path.join(temp_docs_dir, "relatorio_b.xlsx")
+
+    st_a = os.stat(file_a_path)
+    st_b = os.stat(file_b_path)
+
+    cache = {
+        "relatorio_a.xlsx": {
+            "sha256": _calculate_hash(file_a_path),
+            "size": st_a.st_size,
+            "mtime_ns": st_a.st_mtime_ns,
+        },
+        "relatorio_b.xlsx": {
+            "sha256": _calculate_hash(file_b_path),
+            "size": st_b.st_size,
+            "mtime_ns": st_b.st_mtime_ns,
+        },
+    }
+
+    def boom(*args, **kwargs):  # noqa: ARG001
+        raise AssertionError("unexpected hash computation")
+
+    monkeypatch.setattr(caching, "_calculate_hash", boom)
+
+    files_to_process = get_files_to_process(temp_docs_dir, cache)
+    assert files_to_process == []
+
+
+def test_get_files_to_process_upgrades_legacy_cache_file(tmp_path, monkeypatch):
+    docs_dir = tmp_path / "docs_entrada"
+    docs_dir.mkdir()
+
+    file_a = docs_dir / "relatorio_a.xlsx"
+    file_b = docs_dir / "relatorio_b.xlsx"
+    file_a.write_text("dados do relatorio a", encoding="utf-8")
+    file_b.write_text("dados do relatorio b", encoding="utf-8")
+
+    st_a = os.stat(str(file_a))
+    st_b = os.stat(str(file_b))
+
+    legacy_cache = {
+        "relatorio_a.xlsx": caching._calculate_hash(str(file_a)),
+        "relatorio_b.xlsx": caching._calculate_hash(str(file_b)),
+    }
+    cache_file = tmp_path / "file_cache.json"
+    cache_file.write_text(json.dumps(legacy_cache, indent=4), encoding="utf-8")
+
+    files_to_process = caching.get_files_to_process(str(docs_dir), str(cache_file))
+    assert files_to_process == []
+
+    upgraded = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert upgraded["relatorio_a.xlsx"]["sha256"] == legacy_cache["relatorio_a.xlsx"]
+    assert upgraded["relatorio_a.xlsx"]["size"] == st_a.st_size
+    assert upgraded["relatorio_a.xlsx"]["mtime_ns"] == st_a.st_mtime_ns
+    assert upgraded["relatorio_b.xlsx"]["sha256"] == legacy_cache["relatorio_b.xlsx"]
+    assert upgraded["relatorio_b.xlsx"]["size"] == st_b.st_size
+    assert upgraded["relatorio_b.xlsx"]["mtime_ns"] == st_b.st_mtime_ns
+
+    # Second run should not hash again when metadata matches.
+    def boom(*args, **kwargs):  # noqa: ARG001
+        raise AssertionError("unexpected hash computation")
+
+    monkeypatch.setattr(caching, "_calculate_hash", boom)
+
+    files_to_process = caching.get_files_to_process(str(docs_dir), str(cache_file))
+    assert files_to_process == []

--- a/tests/test_caching_atomic_save.py
+++ b/tests/test_caching_atomic_save.py
@@ -1,0 +1,38 @@
+import json
+
+import utils.caching as caching
+
+
+def test_save_cache_is_atomic_and_does_not_corrupt_existing_file(tmp_path, monkeypatch):
+    cache_file = tmp_path / "file_cache.json"
+
+    # Seed with a known-good cache file.
+    initial = {"a.xlsx": "hash_a"}
+    cache_file.write_text(json.dumps(initial, indent=4), encoding="utf-8")
+    original_text = cache_file.read_text(encoding="utf-8")
+
+    tmp_prefix = f".{cache_file.name}.tmp."
+
+    def bad_dump(obj, fh, indent=4):  # noqa: ARG001
+        # Simulate a crash mid-write.
+        fh.write("{")
+        fh.flush()
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(caching.json, "dump", bad_dump)
+
+    # save_cache should not raise; it should keep the original file intact.
+    caching.save_cache({"b.xlsx": "hash_b"}, str(cache_file))
+
+    assert cache_file.read_text(encoding="utf-8") == original_text
+    leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(tmp_prefix)]
+    assert leftovers == []
+
+
+def test_save_cache_writes_valid_json(tmp_path):
+    cache_file = tmp_path / "file_cache.json"
+    data = {"a.xlsx": "hash_a", "b.xlsx": "hash_b"}
+    caching.save_cache(data, str(cache_file))
+
+    loaded = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert loaded == data

--- a/tests/test_cli_enhancement_manager_atomic_save.py
+++ b/tests/test_cli_enhancement_manager_atomic_save.py
@@ -1,0 +1,50 @@
+import json
+import os
+import sys
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import interface.cli_enhancement_manager as cli_mgr_mod  # noqa: E402
+
+
+def test_cli_enhancement_settings_save_is_atomic_on_failure(tmp_path, monkeypatch):
+    mgr = cli_mgr_mod.CLIEnhancementManager()
+    mgr.settings_file = str(tmp_path / "cli_enhancements.json")
+
+    initial = {"enhanced_table_printer": True}
+    original_text = json.dumps(initial, indent=2, ensure_ascii=False)
+    with open(mgr.settings_file, "w", encoding="utf-8") as f:
+        f.write(original_text)
+
+    base_name = os.path.basename(mgr.settings_file)
+    tmp_prefix = f".{base_name}.tmp."
+
+    def bad_dump(_obj, fh, indent=2, ensure_ascii=False):  # noqa: ARG001
+        fh.write("{")
+        fh.flush()
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cli_mgr_mod.json, "dump", bad_dump)
+
+    mgr.settings = {"debug_output": True}
+    mgr._save_settings()
+
+    with open(mgr.settings_file, "r", encoding="utf-8") as f:
+        assert f.read() == original_text
+    leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(tmp_prefix)]
+    assert leftovers == []
+
+
+def test_cli_enhancement_settings_save_writes_valid_json(tmp_path):
+    mgr = cli_mgr_mod.CLIEnhancementManager()
+    mgr.settings_file = str(tmp_path / "cli_enhancements.json")
+
+    mgr.settings = {"debug_output": False, "version": "1.0"}
+    mgr._save_settings()
+
+    with open(mgr.settings_file, "r", encoding="utf-8") as f:
+        loaded = json.load(f)
+    assert loaded == mgr.settings
+

--- a/tests/test_command_handlers_save_settings.py
+++ b/tests/test_command_handlers_save_settings.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import interface.command_handlers as command_handlers  # noqa: E402
+
+
+def test_save_settings_handler_delegates_to_config_manager(monkeypatch, capsys):
+    called = {"settings": None}
+
+    def _fake_save_settings(settings):
+        called["settings"] = settings
+
+    monkeypatch.setattr(command_handlers, "save_settings", _fake_save_settings)
+
+    payload = {"k": "v"}
+    command_handlers._save_settings_handler(payload)
+
+    assert called["settings"] == payload
+    out = capsys.readouterr().out
+    assert "Configuracoes salvas" in out
+

--- a/tests/test_config_manager_atomic_save.py
+++ b/tests/test_config_manager_atomic_save.py
@@ -1,0 +1,48 @@
+import json
+import os
+import sys
+
+import pytest
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import core.config_manager as config_manager  # noqa: E402
+
+
+def test_save_settings_is_atomic_and_does_not_corrupt_existing_file(tmp_path, monkeypatch):
+    settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(config_manager, "USER_SETTINGS_FILE", str(settings_path))
+
+    initial = {"a": 1}
+    settings_path.write_text(json.dumps(initial, indent=4, ensure_ascii=False), encoding="utf-8")
+    original_text = settings_path.read_text(encoding="utf-8")
+
+    tmp_prefix = f".{settings_path.name}.tmp."
+
+    def bad_dump(obj, fh, indent=4, ensure_ascii=False):  # noqa: ARG001
+        fh.write("{")
+        fh.flush()
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(config_manager.json, "dump", bad_dump)
+
+    with pytest.raises(RuntimeError):
+        config_manager.save_settings({"b": 2})
+
+    assert settings_path.read_text(encoding="utf-8") == original_text
+    leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(tmp_prefix)]
+    assert leftovers == []
+
+
+def test_save_settings_writes_valid_json(tmp_path, monkeypatch):
+    settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(config_manager, "USER_SETTINGS_FILE", str(settings_path))
+
+    data = {"a": 1, "b": {"nested": True}}
+    config_manager.save_settings(data)
+
+    loaded = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert loaded == data
+

--- a/tests/test_database_optimized_alias_views.py
+++ b/tests/test_database_optimized_alias_views.py
@@ -1,0 +1,36 @@
+# tests/test_database_optimized_alias_views.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from armazenamento import database
+from armazenamento.database_optimized import disable_optimized_import, enable_optimized_import
+
+
+def test_optimized_insert_resolves_view_alias_ssas(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "test.db")
+
+    database.initialize_database(db_path, "config/schema.sql")
+
+    enable_optimized_import()
+    try:
+        df = pd.DataFrame(
+            {
+                "numero_ssa": ["123456789"],
+                "data_cadastro": [pd.Timestamp("2025-01-01")],
+                "situacao": ["TESTE"],
+                "descricao_ssa": ["ok"],
+            }
+        )
+
+        ok = database.insert_dataframe_with_smart_upsert(df, db_path, table_name="ssas")
+        assert ok is True
+
+        with database.get_db_connection(db_path) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM ssa_table").fetchone()[0]
+        assert count == 1
+    finally:
+        disable_optimized_import()
+

--- a/tests/test_filter_cache_locking.py
+++ b/tests/test_filter_cache_locking.py
@@ -26,13 +26,18 @@ def test_filter_cache_uses_lock_for_all_mutations_and_reads():
     assert spy.enter_count == 0
     cache.put("df1", [["x"]], "contains", df)
     assert spy.enter_count >= 1
+    assert spy.enter_count == spy.exit_count
 
+    before_get = spy.enter_count
     hit = cache.get("df1", [["x"]], "contains")
     assert isinstance(hit, pd.DataFrame)
+    assert spy.enter_count > before_get
+    assert spy.enter_count == spy.exit_count
 
+    before_stats = spy.enter_count
     stats = cache.get_stats()
     assert stats["hits"] >= 1
+    assert spy.enter_count > before_stats
 
     cache.clear()
     assert spy.enter_count == spy.exit_count
-

--- a/tests/test_filter_cache_locking.py
+++ b/tests/test_filter_cache_locking.py
@@ -1,0 +1,38 @@
+import pandas as pd
+
+from gui.cache.filter_cache import FilterCache
+
+
+class _SpyLock:
+    def __init__(self) -> None:
+        self.enter_count = 0
+        self.exit_count = 0
+
+    def __enter__(self):
+        self.enter_count += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exit_count += 1
+        return False
+
+
+def test_filter_cache_uses_lock_for_all_mutations_and_reads():
+    spy = _SpyLock()
+    cache = FilterCache(max_size=2, lock=spy)
+
+    df = pd.DataFrame({"a": [1, 2]})
+
+    assert spy.enter_count == 0
+    cache.put("df1", [["x"]], "contains", df)
+    assert spy.enter_count >= 1
+
+    hit = cache.get("df1", [["x"]], "contains")
+    assert isinstance(hit, pd.DataFrame)
+
+    stats = cache.get_stats()
+    assert stats["hits"] >= 1
+
+    cache.clear()
+    assert spy.enter_count == spy.exit_count
+

--- a/tests/test_filter_error_skips_modal_in_pytest.py
+++ b/tests/test_filter_error_skips_modal_in_pytest.py
@@ -1,0 +1,35 @@
+import os
+
+import pytest
+
+pytest.importorskip("PyQt6", reason="Dependencia PyQt6 indisponivel no ambiente de teste")
+
+from unittest.mock import patch
+
+from gui.mixins.filter_gui_ssa_mixin import FilterGUISSAMixin
+
+
+class _DummyStatusLabel:
+    def __init__(self) -> None:
+        self.text_value = ""
+
+    def setText(self, value: str) -> None:
+        self.text_value = value
+
+
+class _DummyWindow(FilterGUISSAMixin):
+    def __init__(self) -> None:
+        self.status_label = _DummyStatusLabel()
+
+
+def test_on_filter_error_skips_modal_dialog_in_pytest(monkeypatch):
+    # Be explicit even though pytest sets this env var.
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", os.environ.get("PYTEST_CURRENT_TEST") or "1")
+
+    win = _DummyWindow()
+    with patch("gui.mixins.filter_gui_ssa_mixin.QMessageBox.critical") as critical:
+        win.on_filter_error("boom")
+
+    assert critical.called is False
+    assert win.status_label.text_value == "Status: Erro ao aplicar filtro."
+

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -444,12 +444,21 @@ class TestGUIFilterLogic:
             idx for idx, ctx in enumerate(self.window._tab_contexts)
             if ctx.get("tab_kind") == "filters"
         )
+        main_tab_idx = next(
+            idx for idx, ctx in enumerate(self.window._tab_contexts)
+            if ctx.get("tab_kind") == "main"
+        )
 
         with patch.object(self.window, "apply_theme", wraps=self.window.apply_theme) as apply_mock:
             self.window.main_tabs.setCurrentIndex(filter_tab_idx)
             QApplication.processEvents()
+            # Switch away and back: after the first bind, the same theme should not be re-applied.
+            self.window.main_tabs.setCurrentIndex(main_tab_idx)
+            QApplication.processEvents()
+            self.window.main_tabs.setCurrentIndex(filter_tab_idx)
+            QApplication.processEvents()
 
-        assert apply_mock.call_count == 0
+        assert apply_mock.call_count == 1
 
     def test_filters_tab_switch_and_responsavel_materialization_smoke_latency(self):
         heavy_df = self._build_heavy_filters_df(rows=1200)
@@ -538,6 +547,41 @@ class TestGUIFilterLogic:
         QApplication.processEvents()
         assert getattr(self.window, "_current_theme", None) == current_theme
         assert self.window.main_tabs.currentIndex() == main_tab_idx
+
+    def test_theme_switch_reapplies_on_tab_bind_for_inactive_tab(self):
+        """Theme updates must re-style both tabs, even when switched after the change."""
+        filter_tab_idx = next(
+            idx for idx, ctx in enumerate(self.window._tab_contexts)
+            if ctx.get("tab_kind") == "filters"
+        )
+        main_tab_idx = next(
+            idx for idx, ctx in enumerate(self.window._tab_contexts)
+            if ctx.get("tab_kind") == "main"
+        )
+        filters_ctx = next(ctx for ctx in self.window._tab_contexts if ctx.get("tab_kind") == "filters")
+        main_ctx = next(ctx for ctx in self.window._tab_contexts if ctx.get("tab_kind") == "main")
+
+        current_theme = getattr(self.window, "_current_theme", "gruvbox") or "gruvbox"
+        other_theme = "windows7" if current_theme != "windows7" else "gruvbox"
+
+        initial_main_css = main_ctx["search_input"].styleSheet() or ""
+        assert initial_main_css
+        assert not (filters_ctx["search_label"].styleSheet() or "")
+
+        # Switching to the filters tab should re-apply the current theme to that tab's widgets.
+        self.window.main_tabs.setCurrentIndex(filter_tab_idx)
+        QApplication.processEvents()
+        assert "font-weight" in (filters_ctx["search_label"].styleSheet() or "")
+
+        # Apply a different theme while on filters tab, then switch back to main.
+        self.window.apply_theme(other_theme)
+        QApplication.processEvents()
+        self.window.main_tabs.setCurrentIndex(main_tab_idx)
+        QApplication.processEvents()
+
+        # The main tab widgets must get re-themed on bind (previously could keep stale QSS).
+        assert getattr(self.window, "_current_theme", None) == other_theme
+        assert (main_ctx["search_input"].styleSheet() or "") != initial_main_css
 
     def test_switch_to_filters_tab_cancels_pending_search_debounce(self):
         self.window.search_input.setText("Teste A")

--- a/tests/test_gui_preferences_atomic_write.py
+++ b/tests/test_gui_preferences_atomic_write.py
@@ -1,0 +1,28 @@
+import os
+
+
+def test_persist_gui_preferences_uses_atomic_writer(monkeypatch, tmp_path):
+    from gui import gui_ssa
+
+    monkeypatch.setattr(gui_ssa, "project_root", str(tmp_path))
+    monkeypatch.setattr(gui_ssa, "GUI_MAIN_PREFERENCES", {"x": 1})
+
+    calls = []
+
+    def _fake_atomic(path, data, *, indent=2, ensure_ascii=False):
+        calls.append((path, data, indent, ensure_ascii))
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("{}")
+
+    monkeypatch.setattr(gui_ssa, "atomic_write_json_file", _fake_atomic)
+
+    gui_ssa.SSAMainWindow._persist_gui_preferences(object())
+
+    assert calls
+    path, data, indent, ensure_ascii = calls[0]
+    assert path == os.path.join(str(tmp_path), "config", "gui_main_preferences.json")
+    assert data == {"x": 1}
+    assert indent == 2
+    assert ensure_ascii is False
+

--- a/tests/test_import_cache_integrity.py
+++ b/tests/test_import_cache_integrity.py
@@ -1,0 +1,38 @@
+# tests/test_import_cache_integrity.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.app_logic import run_importer_logic
+
+
+def test_cache_not_updated_when_extraction_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    docs_dir = tmp_path / "docs_entrada"
+    docs_dir.mkdir()
+    (docs_dir / "broken.xlsx").write_text("not an xlsx file", encoding="utf-8")
+
+    data_dir = tmp_path / "data"
+
+    # Path safety allowlist is computed at import-time. Ensure tmp_path is allowed
+    # so this test is stable across platforms/pytest tempdir layouts.
+    from utils import path_safety
+
+    monkeypatch.setattr(
+        path_safety,
+        "ALLOWED_ROOTS",
+        list(path_safety.ALLOWED_ROOTS) + [tmp_path],
+    )
+
+    updated = run_importer_logic(
+        docs_dir=str(docs_dir),
+        data_dir=str(data_dir),
+        db_name="test.db",
+        table_name="ssa_table",
+        force_import=True,
+    )
+
+    assert updated is False
+    assert not (data_dir / "file_cache.json").exists()
+

--- a/tests/test_import_cancel_before_insert.py
+++ b/tests/test_import_cancel_before_insert.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.app_logic import run_importer_logic
+
+
+def test_should_cancel_can_abort_before_db_insert(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    docs_dir = tmp_path / "docs_entrada"
+    docs_dir.mkdir()
+    (docs_dir / "file_0.xlsx").write_bytes(b"dummy")
+    (docs_dir / "file_1.xlsx").write_bytes(b"dummy")
+
+    data_dir = tmp_path / "data"
+
+    # Ensure path safety allowlist includes this tmp path.
+    from utils import path_safety
+
+    monkeypatch.setattr(
+        path_safety,
+        "ALLOWED_ROOTS",
+        list(path_safety.ALLOWED_ROOTS) + [tmp_path],
+    )
+
+    import core.app_logic as app_logic
+
+    # Make integrity checks deterministic and cheap.
+    monkeypatch.setattr(app_logic.database, "repair_database_if_needed", lambda *a, **k: True)
+    monkeypatch.setattr(
+        app_logic.database,
+        "verify_database_integrity",
+        lambda *a, **k: {
+            "is_valid": True,
+            "database_accessible": True,
+            "table_exists": True,
+            "schema_valid": True,
+            "data_consistent": True,
+            "disk_space_sufficient": True,
+            "warnings": [],
+            "issues": [],
+        },
+    )
+
+    # Avoid real Excel parsing: return a minimal valid DataFrame.
+    def fake_extract_data_from_excel(file_path: str, *, should_cancel=None):
+        assert should_cancel is not None
+        return pd.DataFrame(
+            {
+                "numero_ssa": [123456789],
+                "data_cadastro": [pd.Timestamp("2025-01-01")],
+                "situacao": ["TESTE"],
+                "descricao_ssa": ["ok"],
+            }
+        )
+
+    monkeypatch.setattr(app_logic.extractor, "extract_data_from_excel", fake_extract_data_from_excel)
+
+    monkeypatch.setattr(
+        app_logic.database,
+        "validate_dataframe_before_insert",
+        lambda *a, **k: {"is_valid": True, "violations": [], "invalid_by_column": {}, "issues": []},
+    )
+    monkeypatch.setattr(app_logic.database, "ensure_column_exists", lambda *a, **k: None)
+
+    insert_count = {"n": 0}
+
+    def fake_insert_dataframe_with_smart_upsert(*args, **kwargs):
+        insert_count["n"] += 1
+        return True
+
+    monkeypatch.setattr(app_logic.database, "insert_dataframe_with_smart_upsert", fake_insert_dataframe_with_smart_upsert)
+
+    cancel_calls = {"n": 0}
+
+    def should_cancel() -> bool:
+        # run_importer_logic consults should_cancel before each file (1),
+        # _import_single_file consults after extraction/df copy (2),
+        # then again before DB insert (3). We cancel at (3).
+        cancel_calls["n"] += 1
+        return cancel_calls["n"] >= 3
+
+    updated = run_importer_logic(
+        docs_dir=str(docs_dir),
+        data_dir=str(data_dir),
+        db_name="test.db",
+        table_name="ssa_table",
+        force_import=True,
+        should_cancel=should_cancel,
+    )
+
+    assert updated is False
+    assert insert_count["n"] == 0
+

--- a/tests/test_import_cancellation.py
+++ b/tests/test_import_cancellation.py
@@ -1,0 +1,78 @@
+# tests/test_import_cancellation.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.app_logic import run_importer_logic
+
+
+def test_should_cancel_stops_between_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    docs_dir = tmp_path / "docs_entrada"
+    docs_dir.mkdir()
+    for i in range(5):
+        (docs_dir / f"file_{i}.xlsx").write_bytes(b"dummy")
+
+    data_dir = tmp_path / "data"
+
+    # Ensure path safety allowlist includes this tmp path.
+    from utils import path_safety
+
+    monkeypatch.setattr(
+        path_safety,
+        "ALLOWED_ROOTS",
+        list(path_safety.ALLOWED_ROOTS) + [tmp_path],
+    )
+
+    insert_count = {"n": 0}
+
+    def fake_extract_data_from_excel(file_path: str):
+        # Minimal valid payload for _import_single_file validation rules.
+        return pd.DataFrame(
+            {
+                "numero_ssa": [123456789],
+                "data_cadastro": [pd.Timestamp("2025-01-01")],
+                "situacao": ["TESTE"],
+                "descricao_ssa": ["ok"],
+            }
+        )
+
+    def fake_insert_dataframe_with_smart_upsert(df, db_path, table_name):
+        insert_count["n"] += 1
+        return True
+
+    # Avoid real Excel parsing and DB writes: focus on cancellation + cache behavior.
+    import core.app_logic as app_logic
+
+    monkeypatch.setattr(app_logic.extractor, "extract_data_from_excel", fake_extract_data_from_excel)
+    monkeypatch.setattr(app_logic.database, "insert_dataframe_with_smart_upsert", fake_insert_dataframe_with_smart_upsert)
+
+    cancel_flag = {"cancel": False}
+
+    def progress_callback(event_type, data):
+        if event_type == "file_success" and not cancel_flag["cancel"]:
+            cancel_flag["cancel"] = True
+
+    def should_cancel() -> bool:
+        return bool(cancel_flag["cancel"])
+
+    updated = run_importer_logic(
+        docs_dir=str(docs_dir),
+        data_dir=str(data_dir),
+        db_name="test.db",
+        table_name="ssa_table",
+        force_import=True,
+        should_cancel=should_cancel,
+        progress_callback=progress_callback,
+    )
+
+    assert updated is True
+    cache_path = data_dir / "file_cache.json"
+    assert cache_path.exists()
+    cache = json.loads(cache_path.read_text(encoding="utf-8"))
+
+    assert insert_count["n"] == 1
+    assert len(cache) == 1

--- a/tests/test_import_cancellation.py
+++ b/tests/test_import_cancellation.py
@@ -29,7 +29,8 @@ def test_should_cancel_stops_between_files(tmp_path: Path, monkeypatch: pytest.M
 
     insert_count = {"n": 0}
 
-    def fake_extract_data_from_excel(file_path: str):
+    def fake_extract_data_from_excel(file_path: str, *, should_cancel=None):
+        assert should_cancel is not None
         # Minimal valid payload for _import_single_file validation rules.
         return pd.DataFrame(
             {

--- a/tests/test_load_data_skips_modal_loader_missing_in_pytest.py
+++ b/tests/test_load_data_skips_modal_loader_missing_in_pytest.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class _StateSink:
+    def __init__(self):
+        self.calls = []
+        self.value = None
+
+    def setText(self, value):
+        self.calls.append(("setText", value))
+        self.value = value
+
+    def setVisible(self, value):
+        self.calls.append(("setVisible", bool(value)))
+        self.value = bool(value)
+
+    def setEnabled(self, value):
+        self.calls.append(("setEnabled", bool(value)))
+        self.value = bool(value)
+
+
+class _DummyTimer:
+    def stop(self):
+        return None
+
+
+def test_load_data_skips_modal_when_loader_missing_under_pytest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from gui import gui_ssa
+
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "1")
+
+    db_path = tmp_path / "ssas.db"
+    db_path.write_bytes(b"dummy")
+
+    monkeypatch.setattr(gui_ssa, "DB_PATH", str(db_path))
+    monkeypatch.setattr(gui_ssa, "DataLoaderWorker", None)
+    monkeypatch.setattr(gui_ssa.QMessageBox, "critical", lambda *a, **k: pytest.fail("QMessageBox.critical called"))
+
+    dummy = type("Dummy", (), {})()
+    dummy.status_label = _StateSink()
+    dummy.progress_bar = _StateSink()
+    dummy.load_button = _StateSink()
+    dummy.search_button = _StateSink()
+    dummy._debounce_timer = _DummyTimer()
+    dummy._data_load_request_seq = 0
+    dummy._active_data_load_request_id = None
+    dummy.data_loader_thread = None
+
+    dummy._prune_retired_data_loader_workers = lambda: None
+    dummy._invalidate_active_filter_request = lambda *a, **k: None
+    dummy._cancel_active_filter_worker = lambda *a, **k: None
+    dummy._cleanup_data_loader_worker = lambda *a, **k: True
+
+    gui_ssa.SSAMainWindow.load_data(dummy)
+
+    assert dummy.status_label.value == "Status: Erro ao carregar dados."
+    assert dummy.progress_bar.value is False
+    assert dummy.load_button.value is True
+    assert dummy.search_button.value is True
+

--- a/tests/test_main_skip_import.py
+++ b/tests/test_main_skip_import.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_main_skip_import_does_not_call_importer(monkeypatch: pytest.MonkeyPatch) -> None:
+    import core.app_logic as app_logic
+    import interface.cli as cli
+    import main
+
+    def unexpected_import(*args, **kwargs):  # noqa: ARG001
+        raise AssertionError("run_importer_logic should not be called when --skip-import is set")
+
+    called = {"n": 0}
+
+    def fake_start_cli_loop(db_path: str, table_name: str) -> None:  # noqa: ARG001
+        called["n"] += 1
+
+    monkeypatch.setattr(app_logic, "run_importer_logic", unexpected_import)
+    monkeypatch.setattr(cli, "start_cli_loop", fake_start_cli_loop)
+
+    main.main(cli_args=["--skip-import", "--log-level", "CRITICAL"])
+    assert called["n"] == 1
+
+
+def test_main_skip_import_conflicts_with_force_rescan() -> None:
+    import main
+
+    with pytest.raises(SystemExit) as excinfo:
+        main.main(cli_args=["--skip-import", "--force-rescan"])
+
+    assert excinfo.value.code == 2
+

--- a/tests/test_open_docs_folder_nonblocking.py
+++ b/tests/test_open_docs_folder_nonblocking.py
@@ -22,6 +22,7 @@ def test_open_docs_folder_uses_qdesktopservices_when_available(monkeypatch, tmp_
             return True
 
     monkeypatch.setattr(gui_ssa, "QDesktopServices", DummyQDesktopServices)
+    DummyQDesktopServices.called.clear()
     monkeypatch.setattr(gui_ssa.subprocess, "run", lambda *a, **k: pytest.fail("subprocess.run called"))
     monkeypatch.setattr(gui_ssa.subprocess, "Popen", lambda *a, **k: pytest.fail("subprocess.Popen called"))
     monkeypatch.setattr(gui_ssa.QMessageBox, "warning", lambda *a, **k: pytest.fail("QMessageBox.warning called"))

--- a/tests/test_open_docs_folder_nonblocking.py
+++ b/tests/test_open_docs_folder_nonblocking.py
@@ -34,6 +34,9 @@ def test_open_docs_folder_uses_qdesktopservices_when_available(monkeypatch, tmp_
 def test_open_docs_folder_missing_skips_modal_under_pytest(monkeypatch, tmp_path):
     from gui import gui_ssa
 
+    if not getattr(gui_ssa, "QT_AVAILABLE", False):
+        pytest.skip("Qt not available in this test environment")
+
     # Ensure the guard condition is active even if pytest env var is not set for some runner.
     monkeypatch.setenv("PYTEST_CURRENT_TEST", "1")
 
@@ -41,4 +44,3 @@ def test_open_docs_folder_missing_skips_modal_under_pytest(monkeypatch, tmp_path
     monkeypatch.setattr(gui_ssa.QMessageBox, "warning", lambda *a, **k: pytest.fail("QMessageBox.warning called"))
 
     gui_ssa.SSAMainWindow.open_docs_folder(object())
-

--- a/tests/test_open_docs_folder_nonblocking.py
+++ b/tests/test_open_docs_folder_nonblocking.py
@@ -1,0 +1,44 @@
+import pytest
+
+
+def test_open_docs_folder_uses_qdesktopservices_when_available(monkeypatch, tmp_path):
+    # Import inside the test so skip logic can inspect QT availability.
+    from gui import gui_ssa
+
+    if not getattr(gui_ssa, "QT_AVAILABLE", False):
+        pytest.skip("Qt not available in this test environment")
+
+    docs_dir = tmp_path / "docs_entrada"
+    docs_dir.mkdir()
+
+    monkeypatch.setattr(gui_ssa, "project_root", str(tmp_path))
+
+    class DummyQDesktopServices:
+        called = []
+
+        @staticmethod
+        def openUrl(url):
+            DummyQDesktopServices.called.append(url)
+            return True
+
+    monkeypatch.setattr(gui_ssa, "QDesktopServices", DummyQDesktopServices)
+    monkeypatch.setattr(gui_ssa.subprocess, "run", lambda *a, **k: pytest.fail("subprocess.run called"))
+    monkeypatch.setattr(gui_ssa.subprocess, "Popen", lambda *a, **k: pytest.fail("subprocess.Popen called"))
+    monkeypatch.setattr(gui_ssa.QMessageBox, "warning", lambda *a, **k: pytest.fail("QMessageBox.warning called"))
+
+    gui_ssa.SSAMainWindow.open_docs_folder(object())
+
+    assert DummyQDesktopServices.called, "Expected QDesktopServices.openUrl to be used"
+
+
+def test_open_docs_folder_missing_skips_modal_under_pytest(monkeypatch, tmp_path):
+    from gui import gui_ssa
+
+    # Ensure the guard condition is active even if pytest env var is not set for some runner.
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "1")
+
+    monkeypatch.setattr(gui_ssa, "project_root", str(tmp_path))
+    monkeypatch.setattr(gui_ssa.QMessageBox, "warning", lambda *a, **k: pytest.fail("QMessageBox.warning called"))
+
+    gui_ssa.SSAMainWindow.open_docs_folder(object())
+

--- a/tests/test_rescan_progress_dialog.py
+++ b/tests/test_rescan_progress_dialog.py
@@ -26,14 +26,14 @@ def test_rescan_progress_dialog_reject_emits_cancel_once_and_closes():
     QApplication.processEvents()
 
     assert len(emitted) == 1
-    assert dlg.result() == int(QDialog.DialogCode.Rejected)
-    # Dialog may remain visible while cancel is in progress.
-    assert dlg.isVisible() in (True, False)
+    assert dlg._cancel_requested is True
+    assert dlg.isVisible() is True
 
-    # Second reject should not emit cancel again.
+    # Second reject should close without emitting cancel again.
     dlg.reject()
     QApplication.processEvents()
     assert len(emitted) == 1
+    assert dlg.result() == int(QDialog.DialogCode.Rejected)
 
 
 def test_rescan_progress_dialog_reject_after_finished_does_not_emit_cancel():

--- a/tests/test_rescan_progress_dialog.py
+++ b/tests/test_rescan_progress_dialog.py
@@ -1,0 +1,50 @@
+import pytest
+
+pytest.importorskip(
+    "PyQt6", reason="Dependencia PyQt6 indisponivel no ambiente de teste"
+)
+from PyQt6.QtWidgets import QApplication, QDialog  # noqa: E402
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def test_rescan_progress_dialog_reject_emits_cancel_once_and_closes():
+    from gui.widgets.rescan_progress_dialog import RescanProgressDialog  # noqa: E402
+
+    dlg = RescanProgressDialog()
+    emitted = []
+    dlg.cancel_requested.connect(lambda: emitted.append(1))
+
+    dlg.show()
+    QApplication.processEvents()
+
+    dlg.reject()
+    QApplication.processEvents()
+
+    assert len(emitted) == 1
+    assert dlg.result() == int(QDialog.DialogCode.Rejected)
+    assert not dlg.isVisible()
+
+    # Second reject should not emit cancel again.
+    dlg.reject()
+    QApplication.processEvents()
+    assert len(emitted) == 1
+
+
+def test_rescan_progress_dialog_reject_after_finished_does_not_emit_cancel():
+    from gui.widgets.rescan_progress_dialog import RescanProgressDialog  # noqa: E402
+
+    dlg = RescanProgressDialog()
+    emitted = []
+    dlg.cancel_requested.connect(lambda: emitted.append(1))
+
+    dlg.set_finished(True)
+    dlg.reject()
+    QApplication.processEvents()
+
+    assert emitted == []
+

--- a/tests/test_rescan_progress_dialog.py
+++ b/tests/test_rescan_progress_dialog.py
@@ -27,7 +27,8 @@ def test_rescan_progress_dialog_reject_emits_cancel_once_and_closes():
 
     assert len(emitted) == 1
     assert dlg.result() == int(QDialog.DialogCode.Rejected)
-    assert not dlg.isVisible()
+    # Dialog may remain visible while cancel is in progress.
+    assert dlg.isVisible() in (True, False)
 
     # Second reject should not emit cancel again.
     dlg.reject()
@@ -47,4 +48,3 @@ def test_rescan_progress_dialog_reject_after_finished_does_not_emit_cancel():
     QApplication.processEvents()
 
     assert emitted == []
-

--- a/tests/test_rescan_worker_cleanup.py
+++ b/tests/test_rescan_worker_cleanup.py
@@ -1,0 +1,50 @@
+import os
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt6", reason="Dependencia PyQt6 indisponivel no ambiente de teste")
+from PyQt6.QtWidgets import QApplication
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import gui.workers.rescan_worker as rescan_worker_mod  # noqa: E402
+from gui.workers.rescan_worker import RescanWorker  # noqa: E402
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def test_rescan_worker_cleanup_does_not_hang_when_logger_cleanup_fails(monkeypatch):
+    worker = RescanWorker("main.py", project_root)
+    emitted = []
+    worker.finished_error.connect(emitted.append)
+
+    def _boom(**_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(rescan_worker_mod, "run_importer_logic", _boom)
+
+    real_remove = worker.logger.removeHandler
+
+    def _bad_remove(_handler):
+        raise ValueError("remove failed")
+
+    worker.logger.removeHandler = _bad_remove
+    try:
+        worker.run()
+    finally:
+        worker.logger.removeHandler = real_remove
+        try:
+            worker.logger.removeHandler(worker.log_handler)
+        except Exception:
+            pass
+
+    assert emitted
+    assert "boom" in emitted[0]
+

--- a/tests/test_rescan_worker_cleanup.py
+++ b/tests/test_rescan_worker_cleanup.py
@@ -46,5 +46,4 @@ def test_rescan_worker_cleanup_does_not_hang_when_logger_cleanup_fails(monkeypat
             pass
 
     assert emitted
-    assert "boom" in emitted[0]
-
+    assert emitted[0] == "Erro ao executar reescaneamento."

--- a/tests/test_rescan_worker_cleanup.py
+++ b/tests/test_rescan_worker_cleanup.py
@@ -1,18 +1,12 @@
-import os
-import sys
-
 import pytest
 
 pytest.importorskip("PyQt6", reason="Dependencia PyQt6 indisponivel no ambiente de teste")
 from PyQt6.QtWidgets import QApplication
 
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-if project_root not in sys.path:
-    sys.path.insert(0, project_root)
-
 import gui.workers.rescan_worker as rescan_worker_mod  # noqa: E402
 from gui.workers.rescan_worker import RescanWorker  # noqa: E402
 
+project_root = "pythonpath-configured"
 
 @pytest.fixture(scope="module", autouse=True)
 def qapp():

--- a/tests/test_robust_logger_threadsafe_singleton.py
+++ b/tests/test_robust_logger_threadsafe_singleton.py
@@ -1,0 +1,46 @@
+import threading
+import time
+
+import utils.robust_logging as robust_logging
+
+
+def test_get_robust_logger_is_thread_safe_singleton(monkeypatch):
+    robust_logging._robust_logger = None
+
+    created = {"count": 0}
+
+    class _StubRobustLogger:
+        def __init__(self, _config_path=None):
+            created["count"] += 1
+            # Widen race window for non-thread-safe implementations.
+            time.sleep(0.05)
+
+        def get_logger(self, *_args, **_kwargs):
+            raise AssertionError("not used")
+
+    monkeypatch.setattr(robust_logging, "RobustLogger", _StubRobustLogger)
+
+    barrier = threading.Barrier(2)
+    results = []
+    errors = []
+
+    def _worker():
+        try:
+            barrier.wait(timeout=2.0)
+            results.append(robust_logging.get_robust_logger("x"))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    t1 = threading.Thread(target=_worker)
+    t2 = threading.Thread(target=_worker)
+    t1.start()
+    t2.start()
+    t1.join(timeout=2.0)
+    t2.join(timeout=2.0)
+
+    assert errors == []
+    assert len(results) == 2
+    assert results[0] is results[1]
+    assert created["count"] == 1
+    # Do not leak stub instance to other tests in the same process.
+    robust_logging._robust_logger = None

--- a/tests/test_robust_logger_threadsafe_singleton.py
+++ b/tests/test_robust_logger_threadsafe_singleton.py
@@ -38,6 +38,8 @@ def test_get_robust_logger_is_thread_safe_singleton(monkeypatch):
     t1.join(timeout=2.0)
     t2.join(timeout=2.0)
 
+    assert not t1.is_alive(), "t1 did not complete in time"
+    assert not t2.is_alive(), "t2 did not complete in time"
     assert errors == []
     assert len(results) == 2
     assert results[0] is results[1]

--- a/tests/test_robust_logger_threadsafe_singleton.py
+++ b/tests/test_robust_logger_threadsafe_singleton.py
@@ -5,7 +5,7 @@ import utils.robust_logging as robust_logging
 
 
 def test_get_robust_logger_is_thread_safe_singleton(monkeypatch):
-    robust_logging._robust_logger = None
+    monkeypatch.setattr(robust_logging, "_robust_logger", None)
 
     created = {"count": 0}
 
@@ -42,5 +42,3 @@ def test_get_robust_logger_is_thread_safe_singleton(monkeypatch):
     assert len(results) == 2
     assert results[0] is results[1]
     assert created["count"] == 1
-    # Do not leak stub instance to other tests in the same process.
-    robust_logging._robust_logger = None

--- a/utils/caching.py
+++ b/utils/caching.py
@@ -182,7 +182,11 @@ def get_files_to_process(docs_dir: str, cache_or_path: Union[str, Dict[str, Any]
 
         current_hash = _calculate_hash(file_path)
         if not current_hash:
-            logger.warning(f"Hash não pôde ser calculado para {file_path}. Arquivo será pulado.")
+            logger.warning(
+                "Hash não pôde ser calculado para %s; reenfileirando para processamento para evitar perda silenciosa.",
+                file_path,
+            )
+            files_to_process.append(file_path)
             continue
 
         if not cached_sha:

--- a/utils/caching.py
+++ b/utils/caching.py
@@ -9,9 +9,39 @@ import os
 import json
 import hashlib
 import logging
+import tempfile
+from contextlib import suppress
 from typing import List, Dict, Union
 
 logger = logging.getLogger(__name__)
+
+def _atomic_write_json(cache: Dict[str, str], cache_file: str) -> None:
+    """Write JSON atomically to avoid corrupted/truncated cache files.
+
+    This protects against crashes mid-write and reduces risk when multiple runs
+    touch the same cache file.
+    """
+    target_dir = os.path.dirname(cache_file) or "."
+    base_name = os.path.basename(cache_file) or "cache.json"
+    os.makedirs(target_dir, exist_ok=True)
+
+    fd = None
+    tmp_path = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(prefix=f".{base_name}.tmp.", dir=target_dir)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(cache, f, indent=4)
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError as exc:
+                logger.debug("fsync failed for cache temp file (%s): %s", tmp_path, exc)
+        os.replace(tmp_path, cache_file)
+        tmp_path = None
+    finally:
+        if tmp_path:
+            with suppress(Exception):
+                os.remove(tmp_path)
 
 def get_all_xlsx_files(directory: str) -> List[str]:
     """Obtem todos os arquivos .xlsx em um diretorio."""
@@ -54,23 +84,23 @@ def load_cache(cache_file: str) -> Dict[str, str]:
         logger.debug(f"Arquivo de cache '{cache_file}' não encontrado.")
         return {}
     try:
-        with open(cache_file, 'r') as f:
+        with open(cache_file, 'r', encoding='utf-8') as f:
             cache = json.load(f)
         logger.debug(f"Cache carregado com {len(cache)} entradas.")
         return cache
-    except (json.JSONDecodeError, IOError) as e:
+    except (json.JSONDecodeError, UnicodeDecodeError, IOError) as e:
         logger.warning(f"Erro ao carregar cache de '{cache_file}': {e}. Iniciando novo cache.")
         return {}
 
 def save_cache(cache: Dict[str, str], cache_file: str):
     """Salva o cache em um arquivo JSON."""
     try:
-        os.makedirs(os.path.dirname(cache_file), exist_ok=True)
-        with open(cache_file, 'w') as f:
-            json.dump(cache, f, indent=4)
+        _atomic_write_json(cache, cache_file)
         logger.debug(f"Cache salvo em '{cache_file}'.")
-    except IOError as e:
-        logger.error(f"Erro ao salvar cache em '{cache_file}': {e}")
+    except Exception as e:  # noqa: BLE001
+        # Cache nao eh critico para a importacao; nao deve derrubar o processo.
+        # Ainda assim, logamos o erro para diagnostico.
+        logger.exception("Erro ao salvar cache em '%s': %s", cache_file, e)
 
 def get_files_to_process(docs_dir: str, cache_or_path: Union[str, Dict[str, str]]) -> List[str]:
     """

--- a/utils/caching.py
+++ b/utils/caching.py
@@ -30,6 +30,7 @@ def _atomic_write_json(cache: Dict[str, Any], cache_file: str) -> None:
     try:
         fd, tmp_path = tempfile.mkstemp(prefix=f".{base_name}.tmp.", dir=target_dir)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
+            fd = None  # ownership transferred to file object
             json.dump(cache, f, indent=4)
             f.flush()
             try:
@@ -39,6 +40,9 @@ def _atomic_write_json(cache: Dict[str, Any], cache_file: str) -> None:
         os.replace(tmp_path, cache_file)
         tmp_path = None
     finally:
+        if fd is not None:
+            with suppress(Exception):
+                os.close(fd)
         if tmp_path:
             with suppress(Exception):
                 os.remove(tmp_path)

--- a/utils/caching.py
+++ b/utils/caching.py
@@ -11,11 +11,11 @@ import hashlib
 import logging
 import tempfile
 from contextlib import suppress
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Any, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-def _atomic_write_json(cache: Dict[str, str], cache_file: str) -> None:
+def _atomic_write_json(cache: Dict[str, Any], cache_file: str) -> None:
     """Write JSON atomically to avoid corrupted/truncated cache files.
 
     This protects against crashes mid-write and reduces risk when multiple runs
@@ -42,6 +42,18 @@ def _atomic_write_json(cache: Dict[str, str], cache_file: str) -> None:
         if tmp_path:
             with suppress(Exception):
                 os.remove(tmp_path)
+
+
+def _safe_file_stat(file_path: str) -> Optional[Tuple[int, int]]:
+    """Return (size, mtime_ns) for a file, or None if stat fails."""
+    try:
+        st = os.stat(file_path)
+    except OSError as exc:
+        logger.warning("Falha ao acessar metadados de '%s': %s", file_path, exc)
+        return None
+
+    mtime_ns = getattr(st, "st_mtime_ns", int(st.st_mtime * 1_000_000_000))
+    return int(st.st_size), int(mtime_ns)
 
 def get_all_xlsx_files(directory: str) -> List[str]:
     """Obtem todos os arquivos .xlsx em um diretorio."""
@@ -78,7 +90,7 @@ def _calculate_hash(file_path: str, block_size: int = 65536) -> str:
         logger.error(f"Erro ao ler o arquivo {file_path} para hashing: {e}")
         return ""
 
-def load_cache(cache_file: str) -> Dict[str, str]:
+def load_cache(cache_file: str) -> Dict[str, Any]:
     """Carrega o cache de um arquivo JSON."""
     if not os.path.exists(cache_file):
         logger.debug(f"Arquivo de cache '{cache_file}' não encontrado.")
@@ -92,7 +104,7 @@ def load_cache(cache_file: str) -> Dict[str, str]:
         logger.warning(f"Erro ao carregar cache de '{cache_file}': {e}. Iniciando novo cache.")
         return {}
 
-def save_cache(cache: Dict[str, str], cache_file: str):
+def save_cache(cache: Dict[str, Any], cache_file: str):
     """Salva o cache em um arquivo JSON."""
     try:
         _atomic_write_json(cache, cache_file)
@@ -102,7 +114,7 @@ def save_cache(cache: Dict[str, str], cache_file: str):
         # Ainda assim, logamos o erro para diagnostico.
         logger.exception("Erro ao salvar cache em '%s': %s", cache_file, e)
 
-def get_files_to_process(docs_dir: str, cache_or_path: Union[str, Dict[str, str]]) -> List[str]:
+def get_files_to_process(docs_dir: str, cache_or_path: Union[str, Dict[str, Any]]) -> List[str]:
     """
     Compara hashes atuais com o cache para determinar arquivos modificados/novos.
 
@@ -110,27 +122,85 @@ def get_files_to_process(docs_dir: str, cache_or_path: Union[str, Dict[str, str]
         List[str]: Lista de caminhos completos para arquivos que precisam ser processados.
     """
     logger.debug("Iniciando comparação de arquivos com cache...")
-    # Aceita tanto um caminho para cache (str) quanto um dicionário já carregado
+    # Aceita tanto um caminho para cache (str) quanto um dicionario ja carregado
+    cache_file_path = None
     if isinstance(cache_or_path, dict):
-        current_cache = cache_or_path
+        current_cache: Dict[str, Any] = cache_or_path
     else:
+        cache_file_path = cache_or_path
         current_cache = load_cache(cache_or_path)
+
+    # Avoid mutating the caller-provided cache dict.
+    updated_cache: Dict[str, Any] = dict(current_cache)
+    cache_updated = False
+
     all_xlsx_files = get_all_xlsx_files(docs_dir)
 
     files_to_process = []
     for file_path in all_xlsx_files:
         filename = os.path.basename(file_path)
-        current_hash = _calculate_hash(file_path)
+        stat_sig = _safe_file_stat(file_path)
+        if stat_sig is None:
+            continue
+        size, mtime_ns = stat_sig
 
+        cached_entry = current_cache.get(filename)
+        if cached_entry is None:
+            files_to_process.append(file_path)
+            continue
+
+        cached_sha = None
+        cached_size = None
+        cached_mtime_ns = None
+        if isinstance(cached_entry, str):
+            cached_sha = cached_entry
+        elif isinstance(cached_entry, dict):
+            sha_val = cached_entry.get("sha256")
+            size_val = cached_entry.get("size")
+            mtime_val = cached_entry.get("mtime_ns")
+            if isinstance(sha_val, str):
+                cached_sha = sha_val
+            if isinstance(size_val, int):
+                cached_size = size_val
+            if isinstance(mtime_val, int):
+                cached_mtime_ns = mtime_val
+
+        # Fast path: metadata matches and we have a sha.
+        if (
+            isinstance(cached_sha, str)
+            and cached_sha
+            and cached_size is not None
+            and cached_mtime_ns is not None
+            and cached_size == size
+            and cached_mtime_ns == mtime_ns
+        ):
+            continue
+
+        current_hash = _calculate_hash(file_path)
         if not current_hash:
             logger.warning(f"Hash não pôde ser calculado para {file_path}. Arquivo será pulado.")
             continue
 
-        # Se o arquivo não está no cache ou o hash mudou, precisa ser processado
-        if filename not in current_cache or current_cache[filename] != current_hash:
+        if not cached_sha:
             files_to_process.append(file_path)
+            continue
+
+        if current_hash != cached_sha:
+            files_to_process.append(file_path)
+            continue
+
+        # Hash matches: refresh cache entry with metadata for future fast paths.
+        new_entry = {"sha256": current_hash, "size": size, "mtime_ns": mtime_ns}
+        if updated_cache.get(filename) != new_entry:
+            updated_cache[filename] = new_entry
+            cache_updated = True
 
     logger.info(f"{len(files_to_process)} arquivo(s) identificado(s) para processamento (novos ou modificados).")
+
+    # Persist cache upgrades even when nothing is imported, so subsequent runs can
+    # avoid hashing every file.
+    if cache_file_path and cache_updated:
+        save_cache(updated_cache, cache_file_path)
     return files_to_process
 
 def update_cache_for_files(file_paths: List[str], cache_file: str):
@@ -147,9 +217,13 @@ def update_cache_for_files(file_paths: List[str], cache_file: str):
     updated = False
     for file_path in file_paths:
         filename = os.path.basename(file_path)
+        stat_sig = _safe_file_stat(file_path)
+        if stat_sig is None:
+            continue
+        size, mtime_ns = stat_sig
         file_hash = _calculate_hash(file_path)
         if file_hash: # Só atualiza se o hash foi calculado com sucesso
-            current_cache[filename] = file_hash
+            current_cache[filename] = {"sha256": file_hash, "size": size, "mtime_ns": mtime_ns}
             updated = True
         else:
             logger.warning(f"Não foi possível atualizar o cache para {file_path} (hash falhou).")

--- a/utils/caching.py
+++ b/utils/caching.py
@@ -145,6 +145,11 @@ def get_files_to_process(docs_dir: str, cache_or_path: Union[str, Dict[str, Any]
         filename = os.path.basename(file_path)
         stat_sig = _safe_file_stat(file_path)
         if stat_sig is None:
+            logger.warning(
+                "Metadados indisponiveis para '%s'; reenfileirando para processamento.",
+                file_path,
+            )
+            files_to_process.append(file_path)
             continue
         size, mtime_ns = stat_sig
 

--- a/utils/robust_logging.py
+++ b/utils/robust_logging.py
@@ -20,7 +20,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Optional, Any, Union
+from typing import Dict, Optional, Any
 from collections import deque
 import threading
 
@@ -463,12 +463,16 @@ class RobustLogger:
 
 # Instância global do sistema de logging
 _robust_logger = None
+_robust_logger_lock = threading.Lock()
 
 def get_robust_logger(config_path: Optional[str] = None) -> RobustLogger:
     """Retorna instância global do sistema de logging robusto."""
     global _robust_logger
     if _robust_logger is None:
-        _robust_logger = RobustLogger(config_path)
+        # Protect lazy initialization to avoid races when called from multiple threads.
+        with _robust_logger_lock:
+            if _robust_logger is None:
+                _robust_logger = RobustLogger(config_path)
     return _robust_logger
 
 


### PR DESCRIPTION
## **User description**
### **User description**
Replace closed PR #29. Adjust queue backpressure accounting, ensure optimized mode disables in finally.

### **PR Type**
Bug fix, Enhancement, Tests

### **Description**
- **Queue backpressure and deadlock prevention**: Refactored queue handling in pytest streaming scripts to use non-blocking puts with line dropping strategy when queue is full, ensuring sentinel delivery and preventing deadlocks

- **Import flow and cancellation support**: Added cooperative cancellation mechanism throughout import pipeline with `should_cancel` callbacks at file boundaries and DB operations; implemented `--skip-import` CLI flag with proper cleanup in finally blocks

- **Atomic file operations**: Implemented atomic JSON writes with temporary files and fsync across config manager, caching, CLI settings, and GUI preferences to prevent file corruption

- **Worker lifecycle improvements**: Enhanced rescan worker cleanup with proper exception handling, added cancellation support via signals, and implemented worker retention lists with configurable limits

- **SQL safety and optimization**: Added view alias resolution, SQL identifier validation, chunked SSA lookups respecting SQLite limits, and SAVEPOINT/ROLLBACK support for batch operations

- **Thread-safety enhancements**: Added threading locks to filter cache operations and implemented double-checked locking pattern for robust logger singleton initialization

- **Cache format upgrade**: Enhanced cache to store size and mtime_ns metadata with fast-path checking to skip hashing when files unchanged; added legacy format upgrade logic

- **UI improvements**: Fixed theme application to only mark active tabs, added non-blocking folder opening via QDesktopServices, and implemented pytest environment detection to skip modal dialogs during tests

- **Comprehensive test coverage**: Added 20+ new tests covering cancellation, atomic writes, thread-safety, cache integrity, worker cleanup, and pytest-specific behaviors

### Diagram Walkthrough

```mermaid
flowchart LR
  A["Import Flow<br/>with Cancellation"] -->|"should_cancel<br/>callbacks"| B["File Processing<br/>& DB Operations"]
  C["Queue Backpressure<br/>Handling"] -->|"Non-blocking puts<br/>& line dropping"| D["Pytest Streaming<br/>Scripts"]
  E["Atomic Write<br/>Operations"] -->|"Temp files<br/>& fsync"| F["Config/Cache/<br/>CLI Settings"]
  G["Worker Lifecycle<br/>Management"] -->|"Cleanup in<br/>finally blocks"| H["Rescan Worker<br/>& Signals"]
  I["SQL Safety<br/>& Optimization"] -->|"View alias<br/>resolution"| J["Database<br/>Operations"]
  K["Thread-Safety<br/>Improvements"] -->|"Locks &<br/>Singleton"| L["Filter Cache<br/>& Logger"]
```

<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>gui_ssa.py</strong><dd><code>Worker lifecycle, atomic writes, and rescan cancellation improvements</code></dd></summary>
<hr>

gui/gui_ssa.py

<ul><li>Added import of <code>atomic_write_json_file</code> and new Qt classes (<code>QUrl</code>, <br><code>QDesktopServices</code>)<br> <li> Introduced global worker retention lists for rescan workers with <br>configurable limits<br> <li> Added <code>MONO_FONT_FAMILY</code> constant with cross-platform monospace font <br>fallbacks<br> <li> Replaced manual JSON file writes with atomic writes to prevent <br>corruption<br> <li> Optimized SSA normalization with new vectorized <br><code>_normalize_ssa_series()</code> method<br> <li> Enhanced parent traversal loop detection with cycle prevention (max 50 <br>iterations)<br> <li> Improved rescan worker lifecycle management with proper cleanup and <br>cancellation support<br> <li> Added non-blocking folder opening via <code>QDesktopServices</code> with <br>platform-specific fallbacks<br> <li> Fixed theme application to only mark active tab as themed, preventing <br>stale styles<br> <li> Added pytest environment detection to skip modal dialogs during <br>automated tests</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-30fa49e70815fa188cb9b7aae97fd9b6243ae424a147e71dedab3d6194bb3667">+267/-67</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app_logic.py</strong><dd><code>Cancellation support and progress callback refactoring</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/app_logic.py

<ul><li>Added <code>should_cancel</code> optional callback parameter to <br><code>run_importer_logic()</code> and <code>_import_single_file()</code><br> <li> Implemented cooperative cancellation checks at file boundaries and <br>before DB operations<br> <li> Refactored progress callback handling with centralized <br><code>_emit_progress()</code> wrapper<br> <li> Added early bailout optimization when filter mask becomes empty<br> <li> Improved error handling to distinguish cancellation from other <br>extraction errors<br> <li> Enhanced exception handling with proper error type normalization</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-f232a1ebd2e68d7307317d4b52e4db7b49e8106e5a659a9766b451093a7cab0e">+93/-107</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>database_optimized.py</strong><dd><code>SQL safety and lookup optimization improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armazenamento/database_optimized.py

<ul><li>Added <code>_resolve_physical_table()</code> function to map legacy view aliases to <br>physical tables<br> <li> Implemented SQL identifier validation before executing dynamic queries<br> <li> Optimized SSA lookup to use chunked queries respecting SQLite variable <br>limits<br> <li> Changed from full table scan to targeted lookup of only needed SSA <br>values<br> <li> Added SAVEPOINT/ROLLBACK support for batch update operations<br> <li> Improved parameterized queries to prevent SQL injection</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-38e5adf685fd50fd9be52e55285b63dd3f2102eb8aa67b4976475c10e62ada21">+76/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>caching.py</strong><dd><code>Atomic writes and cache format upgrade</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/caching.py

<ul><li>Added atomic JSON write function <code>_atomic_write_json()</code> using temp files <br>and fsync<br> <li> Implemented <code>_safe_file_stat()</code> helper for robust file metadata access<br> <li> Enhanced cache format to store size and mtime_ns alongside SHA256 hash<br> <li> Implemented fast-path metadata checking to skip hashing when file <br>unchanged<br> <li> Added cache format upgrade logic for legacy string-only cache entries<br> <li> Improved error handling with better logging for cache failures</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-9967a86a568cf27106bd4f98e9c633dd43c61dfd0dd188e4bc311256feb70832">+130/-18</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>extractor.py</strong><dd><code>Cancellation support and error handling improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extracao/extractor.py

<ul><li>Added <code>should_cancel</code> optional callback parameter to <br><code>extract_data_from_excel()</code><br> <li> Implemented cancellation checks at strategic points (sheet iteration, <br>header search, normalization)<br> <li> Changed return behavior to raise <code>ExtractionError</code> instead of returning <br>None<br> <li> Added distinction between empty files (return empty DataFrame) and <br>missing headers (raise error)<br> <li> Improved error messages with file basename for clarity<br> <li> Enhanced exception handling with proper error chaining</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-e77707d2348a83a9af996c32f6f520af6945877b4fe650631e7a7a031a8c386f">+55/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config_manager.py</strong><dd><code>Atomic file operations for config management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/config_manager.py

<ul><li>Added <code>atomic_write_json_file()</code> public function for safe JSON writes<br> <li> Implemented <code>_atomic_write_json_file()</code> using temporary files and fsync<br> <li> Added <code>_atomic_copy_file()</code> for safe default file creation<br> <li> Replaced all manual JSON writes with atomic write calls<br> <li> Improved error handling with RuntimeError for critical config <br>restoration failures</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-b922428b6ae5ece0d80773f599f75999b3d61747937aef52311160a3d69d6ae8">+71/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cli_enhancement_manager.py</strong><dd><code>Atomic writes and file locking for CLI settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

interface/cli_enhancement_manager.py

<ul><li>Implemented atomic JSON write with temporary files and fsync<br> <li> Added platform-specific file locking (fcntl on POSIX, msvcrt on <br>Windows)<br> <li> Improved error handling with best-effort approach for lock failures<br> <li> Fixed trailing whitespace in status report</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-2a5b3963dec699b86fc325884c908fb11aa61fc6159a11be8fc38fb6ad83650a">+49/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rescan_worker.py</strong><dd><code>Rescan worker cancellation and cleanup improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/workers/rescan_worker.py

<ul><li>Added <code>should_cancel</code> lambda callback to <code>run_importer_logic()</code> call<br> <li> Wrapped logger cleanup in finally block with exception suppression<br> <li> Added <code>handler_added</code> flag to track successful handler attachment<br> <li> Improved cleanup robustness to prevent deadlocks during exception <br>handling</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-71eb4234e934f76c6916e76ec844b9e5fd57f994828a7c5e2a5aa8fd0c36c22e">+13/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rescan_progress_dialog.py</strong><dd><code>Rescan progress dialog cancellation support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/widgets/rescan_progress_dialog.py

<ul><li>Added <code>cancel_requested</code> pyqtSignal for cooperative cancellation<br> <li> Added <code>_cancel_requested</code> and <code>_finished</code> state flags<br> <li> Implemented <code>reject()</code> override to emit cancel signal and close <br>immediately<br> <li> Prevents modal dialog from trapping user during long-running <br>operations</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-ce47992fdabcd917877a74a2cfc259549d598bbbaaf465d2c41ad457edb33005">+23/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>command_handlers.py</strong><dd><code>Settings save delegation to config manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

interface/command_handlers.py

<ul><li>Updated <code>_save_settings_handler()</code> to use <code>save_settings()</code> from <br>core.config_manager<br> <li> Removed manual JSON file handling in favor of centralized atomic write <br>function<br> <li> Improved error handling with generic Exception catch</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-956d25b76b50ef330a6ef24e3a64d4df38b468e50bf6d3d67c824a134f6abd11">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>robust_logging.py</strong><dd><code>Add thread-safe singleton pattern to robust logger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/robust_logging.py

<ul><li>Removed unused <code>Union</code> type import from typing module<br> <li> Added <code>_robust_logger_lock</code> threading lock for thread-safe lazy <br>initialization<br> <li> Modified <code>get_robust_logger</code> function to use double-checked locking <br>pattern<br> <li> Ensures only one <code>RobustLogger</code> instance is created even when called <br>concurrently from multiple threads</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-4080b5797702669ecf535825fc1d21cf9c3d405881941061543907a4a38e3007">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>filter_gui_ssa_mixin.py</strong><dd><code>Skip filter error modal dialog during pytest execution</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/mixins/filter_gui_ssa_mixin.py

<ul><li>Modified <code>on_filter_error</code> method to skip modal dialog when <br><code>PYTEST_CURRENT_TEST</code> environment variable is set<br> <li> Added conditional check to prevent <code>QMessageBox.critical</code> from being <br>called during pytest execution<br> <li> Added debug logging when modal is skipped to indicate pytest <br>environment detection<br> <li> Status label is still updated with error message regardless of modal <br>display</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-b9a488bc6480f0abf63816c5b3226f8ca2ae8bbf4ca104f07e0855285c110b8f">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Dead code removal and import flow refactoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.py

<ul><li>Removed dead code function <code>_load_external_run_importer()</code> that always <br>returned None<br> <li> Added <code>--skip-import</code> CLI flag to bypass initial data import and use <br>existing database<br> <li> Wrapped directory listing operations with debug-level checks and <br>exception handling<br> <li> Refactored optimized import mode initialization with proper flag <br>tracking and cleanup<br> <li> Ensured <code>disable_optimized_import()</code> is called in finally block to <br>guarantee cleanup<br> <li> Added validation to prevent conflicting <code>--skip-import</code> and <br><code>--force-rescan</code> flags<br> <li> Improved error messages for invalid log levels</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1">+169/-174</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>filter_cache.py</strong><dd><code>Thread-safety improvements for filter cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui/cache/filter_cache.py

<ul><li>Added threading.Lock to protect cache internal state from race <br>conditions<br> <li> Wrapped all cache operations (get, put, clear, stats) with lock <br>protection<br> <li> Moved result copy outside lock to minimize critical section duration<br> <li> Added lock parameter to constructor for dependency injection</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-f629d4e8c6ec13b9b329daa7a2dbd4bec44480eae01f29d58bd97483c16a7d07">+48/-34</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run_pytest_stream_and_log.py</strong><dd><code>Queue backpressure and deadlock prevention improvements</code>&nbsp; &nbsp; </dd></summary>
<hr>

scripts/run_pytest_stream_and_log.py

<ul><li>Refactored queue backpressure handling to use non-blocking puts<br> <li> Implemented line dropping strategy when queue is full to prevent <br>deadlocks<br> <li> Added dropped line counter with periodic warnings<br> <li> Ensured sentinel (None) is always delivered by evicting older lines if <br>needed</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-7366f310c392487cead3d67711629c86178b9c755623477716bac53c498e533f">+44/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run_pytest_stream_and_log_v2.py</strong><dd><code>Queue backpressure and deadlock prevention improvements</code>&nbsp; &nbsp; </dd></summary>
<hr>

scripts/run_pytest_stream_and_log_v2.py

<ul><li>Refactored queue backpressure handling to use non-blocking puts<br> <li> Implemented line dropping strategy when queue is full to prevent <br>deadlocks<br> <li> Added dropped line counter with periodic warnings<br> <li> Ensured sentinel (None) is always delivered by evicting older lines if <br>needed</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-5f5635b36b628c40de00f7a543dc76d5d96aacd254659592aa8d5601bc05a286">+44/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test_caching.py</strong><dd><code>Cache optimization test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_caching.py

<ul><li>Added test for fast-path metadata checking that skips hash computation<br> <li> Added test for legacy cache format upgrade with metadata enrichment<br> <li> Verified that upgraded cache prevents re-hashing on subsequent runs</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-e57945cd50529ced9f0b8aa12022ab5140a6c706d74ecfd05280778f707d3d36">+70/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_gui_filter_logic.py</strong><dd><code>Theme application and tab binding test improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_gui_filter_logic.py

<ul><li>Updated theme application test to verify single application on first <br>bind<br> <li> Added test for theme re-application when switching between tabs<br> <li> Added comprehensive test for theme updates affecting inactive tabs on <br>bind</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-5f3abcfb07e583ad9b10f7052a43f5029993921c667d491cda5ef88461bebe1c">+45/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_import_cancel_before_insert.py</strong><dd><code>Import cancellation test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_import_cancel_before_insert.py

<ul><li>New test file verifying cancellation before database insert<br> <li> Tests that <code>should_cancel</code> callback can abort import at critical points<br> <li> Verifies no database inserts occur when cancelled before insert phase</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-f4f05cafdcd97714af675d22ab6ce598880d72f39e7e2a81f09d45602687ce98">+96/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_import_cancellation.py</strong><dd><code>Import cancellation between files test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_import_cancellation.py

<ul><li>New test file verifying cancellation between file processing<br> <li> Tests that import stops after first file when <code>should_cancel</code> returns <br>True<br> <li> Verifies cache is properly updated for processed files before <br>cancellation</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-3ebcb2607e96fcee787fac67e81249dbe811cb5947564185148a62325342f90c">+79/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_load_data_skips_modal_loader_missing_in_pytest.py</strong><dd><code>Pytest modal dialog skip test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_load_data_skips_modal_loader_missing_in_pytest.py

<ul><li>New test file verifying modal dialog is skipped when <br><code>PYTEST_CURRENT_TEST</code> is set<br> <li> Tests that <code>DataLoaderWorker</code> missing error is handled gracefully in <br>pytest<br> <li> Verifies UI state is properly updated without modal blocking</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-1e4721a79f513f340377dbb4e601b92f7610954948ccdc55ae281092ee6974d0">+64/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_rescan_worker_cleanup.py</strong><dd><code>Rescan worker cleanup robustness test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_rescan_worker_cleanup.py

<ul><li>New test file verifying rescan worker cleanup doesn't hang on logger <br>errors<br> <li> Tests that worker.run() completes even when removeHandler() fails<br> <li> Verifies error messages are properly emitted despite cleanup failures</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-b027089a03fcb8cdb6c53868c554f3ddb3269d5f8bb82ef992d30f3c5427acd5">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_open_docs_folder_nonblocking.py</strong><dd><code>Tests for docs folder opening with Qt integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_open_docs_folder_nonblocking.py

<ul><li>Added two new test functions for the <code>open_docs_folder</code> method in <br><code>SSAMainWindow</code><br> <li> First test verifies that <code>QDesktopServices.openUrl</code> is used when <br>available instead of subprocess calls<br> <li> Second test ensures that missing docs folder skips modal dialogs when <br>running under pytest<br> <li> Both tests use monkeypatching to mock Qt components and verify <br>expected behavior</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-80207cea7114ac08f38dd38fd615048c514220678fae0b735e41461e1a8b5030">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_cli_enhancement_manager_atomic_save.py</strong><dd><code>Tests for atomic settings save in CLI enhancement manager</code></dd></summary>
<hr>

tests/test_cli_enhancement_manager_atomic_save.py

<ul><li>Added two test functions for <code>CLIEnhancementManager</code> settings <br>persistence<br> <li> First test verifies atomic save behavior: original file remains intact <br>if JSON dump fails mid-write<br> <li> Second test confirms that valid JSON is written correctly to the <br>settings file<br> <li> Tests use monkeypatching to simulate write failures and verify cleanup <br>of temporary files</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-526741bf934d1a269aeb7ba760b2b5417a9c672d1c288d127f88e71ffb14c3bb">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_config_manager_atomic_save.py</strong><dd><code>Tests for atomic settings save in config manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_config_manager_atomic_save.py

<ul><li>Added two test functions for <code>config_manager.save_settings</code> atomic write <br>behavior<br> <li> First test verifies that original settings file is not corrupted when <br>JSON dump fails<br> <li> Second test confirms that valid JSON settings are written and can be <br>loaded correctly<br> <li> Tests use monkeypatching to simulate write failures and verify no <br>temporary file leftovers</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-82355d90ba45251f19225343baef034a6e24d0771470bcfae19f7d0e265b7b19">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_caching_atomic_save.py</strong><dd><code>Tests for atomic cache file save operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_caching_atomic_save.py

<ul><li>Added two test functions for <code>caching.save_cache</code> atomic write behavior<br> <li> First test verifies that cache file remains intact when JSON dump <br>fails mid-write<br> <li> Second test confirms that valid JSON cache data is written and loaded <br>correctly<br> <li> Tests simulate write failures and verify cleanup of temporary files</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-8f51480e82e9f9780d756dd51ca3eeac1cb61795c7b3d7d222e3a33f0af97c68">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_robust_logger_threadsafe_singleton.py</strong><dd><code>Test for thread-safe singleton logger initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_robust_logger_threadsafe_singleton.py

<ul><li>Added test for thread-safe singleton pattern in <code>get_robust_logger</code> <br>function<br> <li> Test uses threading barriers to create race conditions and verify only <br>one logger instance is created<br> <li> Verifies that multiple concurrent calls return the same logger <br>instance<br> <li> Uses monkeypatching to stub the <code>RobustLogger</code> class and track <br>instantiation count</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-51a48c7d485338c4294870280120af7c9e5062343ef990d831f129c49b5aa683">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_rescan_progress_dialog.py</strong><dd><code>Tests for rescan progress dialog signal emission</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_rescan_progress_dialog.py

<ul><li>Added two test functions for <code>RescanProgressDialog</code> behavior<br> <li> First test verifies that <code>reject()</code> emits <code>cancel_requested</code> signal once <br>and closes the dialog<br> <li> Second test confirms that <code>reject()</code> after <code>set_finished(True)</code> does not <br>emit the cancel signal<br> <li> Tests use PyQt6 fixtures and signal connections to verify expected <br>behavior</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-5a4b58c284fbf8650769454a1a6ae502db41f06d2ca3e7cf05a82cbd1904708f">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_import_cache_integrity.py</strong><dd><code>Test cache not updated on import extraction failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_import_cache_integrity.py

<ul><li>Added test for cache integrity when extraction fails during import<br> <li> Test creates a broken XLSX file and verifies that cache is not updated <br>on failure<br> <li> Uses monkeypatching to allow temporary directory in path safety <br>allowlist<br> <li> Confirms that <code>run_importer_logic</code> returns <code>False</code> and no cache file is <br>created</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-9b35ebe1934a78f386f6b4fd7bc5753b2bd949c9621d63e4bc7f6ab20b231361">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_main_skip_import.py</strong><dd><code>Tests for main function skip-import flag handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_main_skip_import.py

<ul><li>Added two test functions for <code>main</code> function behavior with <code>--skip-import</code> <br>flag<br> <li> First test verifies that <code>run_importer_logic</code> is not called when <br><code>--skip-import</code> is set<br> <li> Second test confirms that <code>--skip-import</code> conflicts with <code>--force-rescan</code> <br>and exits with code 2<br> <li> Tests use monkeypatching to stub importer and CLI functions</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-dd43ec912517c10cbed98e1606479156c4d00151e2f5fc9f9fe97e99ddfbf8ba">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_filter_error_skips_modal_in_pytest.py</strong><dd><code>Test filter error skips modal dialog in pytest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_filter_error_skips_modal_in_pytest.py

<ul><li>Added test for <code>FilterGUISSAMixin.on_filter_error</code> method behavior <br>during pytest<br> <li> Test verifies that <code>QMessageBox.critical</code> is not called when <br><code>PYTEST_CURRENT_TEST</code> environment variable is set<br> <li> Confirms that status label is still updated with error message even <br>when modal is skipped<br> <li> Uses mocking to verify modal dialog is not invoked</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-75419e015f24b48def3bb1b24e4ed3bcb8818377198b10ef8394018dc932d706">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_database_optimized_alias_views.py</strong><dd><code>Test optimized import resolves view alias correctly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_database_optimized_alias_views.py

<ul><li>Added test for optimized import with view alias resolution in database<br> <li> Test enables optimized import mode, inserts a dataframe, and verifies <br>data is correctly inserted<br> <li> Confirms that view alias <code>ssas</code> is resolved to actual table <code>ssa_table</code><br> <li> Uses try/finally to ensure optimized mode is disabled after test</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-6818d57414d2c66f22e0daaeba5277c929565a691c12a3d01f9b097f14e9b6cd">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_filter_cache_locking.py</strong><dd><code>Test filter cache uses lock for thread safety</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_filter_cache_locking.py

<ul><li>Added test for <code>FilterCache</code> lock usage during mutations and reads<br> <li> Test uses a spy lock to track <code>__enter__</code> and <code>__exit__</code> calls<br> <li> Verifies that lock is acquired for <code>put</code>, <code>get</code>, <code>get_stats</code>, and <code>clear</code> <br>operations<br> <li> Confirms that lock enter and exit counts are balanced</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-0dfa59196572fd2fbfb2e41ab367a3dcbf5905fc5832ea9d433d1b0252be134e">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_gui_preferences_atomic_write.py</strong><dd><code>Test GUI preferences use atomic write function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_gui_preferences_atomic_write.py

<ul><li>Added test for <code>SSAMainWindow._persist_gui_preferences</code> atomic write <br>behavior<br> <li> Test mocks <code>atomic_write_json_file</code> to verify it is called with correct <br>parameters<br> <li> Confirms that preferences are written to correct path with proper <br>formatting options<br> <li> Verifies that <code>indent=2</code> and <code>ensure_ascii=False</code> are passed to atomic <br>writer</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-cf2a2ea8dc9921e649db39705d9830e73849163832c06c18ce86248622dcd3ed">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_command_handlers_save_settings.py</strong><dd><code>Test command handler delegates to config manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_command_handlers_save_settings.py

<ul><li>Added test for <code>_save_settings_handler</code> command handler delegation<br> <li> Test mocks <code>save_settings</code> function to verify it is called with correct <br>payload<br> <li> Confirms that handler prints success message "Configuracoes salvas" to <br>stdout<br> <li> Uses capsys fixture to capture and verify console output</ul>

</details>

  </td>
  <td><a href="https://github.com/mauriciomenon/SSA_Consulta_Rapida/pull/30/files#diff-c14bba5754584609a9d397bdad3591010a8921fa6da9b1ed461badafbf103d56">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>


___

## **CodeAnt-AI Description**
Make rescans cancelable, avoid modal deadlocks in tests, and make config/cache writes atomic

### What Changed
- GUI: Rescan (reimport) runs in a worker that can be cancelled from the progress dialog; closing the dialog no longer blocks the UI and long-running rescan workers are retained and pruned instead of causing hangs
- CLI/main: Added --skip-import to start the app without running the initial import; startup logs avoid expensive full directory listings in normal runs
- File safety: Settings, GUI preferences and various cache files are written atomically (temp file + rename + fsync when possible) to prevent truncated/corrupted files after crashes
- Import pipeline: Import and extractor now support cooperative cancellation (callbacks) so an ongoing import can stop cleanly before heavy DB operations; progress callbacks are made robust against exceptions
- Caching and performance: File cache entries now store hash, size and mtime to avoid re-hashing unchanged files; SSA normalization and several filter/search paths are vectorized for faster UI filtering and lookup
- Concurrency/robustness: Filter cache made thread-safe for use from worker threads; rescan worker log attachment and cleanup hardened to avoid leaving handlers or causing deadlocks
- Database: Optimized import now resolves legacy view aliases to the physical table, validates SQL identifiers, uses chunked IN lookups and uses SAVEPOINT/ROLLBACK for safe batch updates

### Impact
`✅ Fewer GUI freezes during rescans and window close`
`✅ Shorter startup when using --skip-import`
`✅ Lower risk of corrupted settings or caches`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
