### PR TITLE
STABILITY_PATCH: stabilize filter buttons and cross-tab state sync

### DIFF
--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -2,7 +2,7 @@
 
 This handoff is ready to reuse in the next conversation.
 
-## CURRENT TRUTH 2026-03-04 01:02 - authoritative block
+## CURRENT TRUTH 2026-03-04 01:39 - authoritative block
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice delivered:
@@ -16,6 +16,7 @@ This handoff is ready to reuse in the next conversation.
   8. column-filter row now exposes `Aplicar`, `Limpar`, and `Ocultar`.
   9. clear-search button text/scope now explicit (`Limpar Busca` + tooltip).
   10. clear-search button enabled-state now stays synchronized between tabs.
+  11. undo button enabled-state now stays synchronized between tabs.
 - What changed:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: clear-state reset and undo snapshot hooks for activate/deactivate column filter.
   2. `gui/gui_ssa.py`: debounce minimum floor and undo snapshot hook in header context apply.
@@ -31,6 +32,8 @@ This handoff is ready to reuse in the next conversation.
   12. `tests/test_gui_filter_logic.py`: added regression `test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs`.
   13. `gui/mixins/filter_gui_ssa_mixin.py` + `gui/mixins/tab_context_gui_ssa_mixin.py`: centralized clear-button enabled-state sync across tab contexts.
   14. `tests/test_gui_filter_logic.py`: added regression `test_clear_filter_button_state_syncs_across_tabs_without_switch`.
+  15. `gui/mixins/filter_gui_ssa_mixin.py`: centralized undo-button enabled-state sync across tab contexts.
+  16. `tests/test_gui_filter_logic.py`: added regression `test_undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore`.
 - Validation:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
@@ -41,14 +44,16 @@ This handoff is ready to reuse in the next conversation.
   7. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "default_column_filter_rows_show_apply_clear_and_hide_buttons or column_filter_buttons_flow or column_filter_row_clear_button_clears_value_without_hiding_row or clear_all_filters_global_restores_default_column_filter_keys or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `5 passed`
   8. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or test_clear_filter_clears_only_general_search_and_keeps_advanced_filters or test_clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
   9. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter_button_state_syncs_across_tabs_without_switch or clear_filter_button_reflects_active_filters or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
-  10. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean
+  10. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore or clear_advanced_filters_forces_refresh_when_pending_schedule or test_header_context_menu_apply_stores_undo_snapshot"`: `3 passed`
+  11. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean
 - Evidence:
   1. `2c7982b1` (`STABILITY_PATCH`: filter state stabilization package).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
   3. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
   4. `776c5905` (`STABILITY_PATCH`: tooltip encoding fix and 3-button row behavior).
   5. `182c51b0` (`STABILITY_PATCH`: clear-search button wording clarity).
-  6. pending in this working slice (`STABILITY_PATCH`: cross-tab clear-button state sync).
+  6. `50bf94f0` (`STABILITY_PATCH`: cross-tab clear-button state sync).
+  7. pending in this working slice (`STABILITY_PATCH`: cross-tab undo-button state sync).
 - Deferred non-blocking:
   1. broad repository-wide non-ASCII normalization remains deferred because most findings are legacy localized strings and require controlled transversal policy.
 - Local residue status:

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -2,7 +2,7 @@
 
 This handoff is ready to reuse in the next conversation.
 
-## CURRENT TRUTH 2026-03-04 01:39 - authoritative block
+## CURRENT TRUTH 2026-03-04 01:44 - authoritative block
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice delivered:
@@ -17,6 +17,8 @@ This handoff is ready to reuse in the next conversation.
   9. clear-search button text/scope now explicit (`Limpar Busca` + tooltip).
   10. clear-search button enabled-state now stays synchronized between tabs.
   11. undo button enabled-state now stays synchronized between tabs.
+  12. search apply/clear controls now route through tab-specific handlers (`main` and `filters`) with same functional behavior.
+  13. regex safety guard in column-filter path is stricter to reduce catastrophic regex patterns.
 - What changed:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: clear-state reset and undo snapshot hooks for activate/deactivate column filter.
   2. `gui/gui_ssa.py`: debounce minimum floor and undo snapshot hook in header context apply.
@@ -34,6 +36,9 @@ This handoff is ready to reuse in the next conversation.
   14. `tests/test_gui_filter_logic.py`: added regression `test_clear_filter_button_state_syncs_across_tabs_without_switch`.
   15. `gui/mixins/filter_gui_ssa_mixin.py`: centralized undo-button enabled-state sync across tab contexts.
   16. `tests/test_gui_filter_logic.py`: added regression `test_undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore`.
+  17. `gui/gui_ssa.py` + `gui/mixins/filter_gui_ssa_mixin.py`: search apply/clear now call dedicated per-tab handlers.
+  18. `gui/mixins/filter_gui_ssa_mixin.py`: regex guard hardening in `_build_column_mask`.
+  19. `tests/test_gui_filter_logic.py`: added regressions `test_search_buttons_route_to_tab_specific_handlers` and `test_build_column_mask_blocks_heavy_regex_patterns`.
 - Validation:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
@@ -45,7 +50,8 @@ This handoff is ready to reuse in the next conversation.
   8. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or test_clear_filter_clears_only_general_search_and_keeps_advanced_filters or test_clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
   9. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter_button_state_syncs_across_tabs_without_switch or clear_filter_button_reflects_active_filters or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
   10. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore or clear_advanced_filters_forces_refresh_when_pending_schedule or test_header_context_menu_apply_stores_undo_snapshot"`: `3 passed`
-  11. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean
+  11. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "search_buttons_route_to_tab_specific_handlers or clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or clear_filter_button_state_syncs_across_tabs_without_switch or build_column_mask_blocks_heavy_regex_patterns"`: `4 passed`
+  12. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> issue(P4 regex safety) -> clean
 - Evidence:
   1. `2c7982b1` (`STABILITY_PATCH`: filter state stabilization package).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
@@ -53,7 +59,8 @@ This handoff is ready to reuse in the next conversation.
   4. `776c5905` (`STABILITY_PATCH`: tooltip encoding fix and 3-button row behavior).
   5. `182c51b0` (`STABILITY_PATCH`: clear-search button wording clarity).
   6. `50bf94f0` (`STABILITY_PATCH`: cross-tab clear-button state sync).
-  7. pending in this working slice (`STABILITY_PATCH`: cross-tab undo-button state sync).
+  7. `32fca7c1` (`STABILITY_PATCH`: cross-tab undo-button state sync).
+  8. pending in this working slice (`STABILITY_PATCH`: tab-specific search handlers + regex guard hardening).
 - Deferred non-blocking:
   1. broad repository-wide non-ASCII normalization remains deferred because most findings are legacy localized strings and require controlled transversal policy.
 - Local residue status:

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -2,7 +2,7 @@
 
 This handoff is ready to reuse in the next conversation.
 
-## CURRENT TRUTH 2026-03-04 00:25 - authoritative block
+## CURRENT TRUTH 2026-03-04 01:02 - authoritative block
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice delivered:
@@ -15,6 +15,7 @@ This handoff is ready to reuse in the next conversation.
   7. week tooltip encoding issue fixed.
   8. column-filter row now exposes `Aplicar`, `Limpar`, and `Ocultar`.
   9. clear-search button text/scope now explicit (`Limpar Busca` + tooltip).
+  10. clear-search button enabled-state now stays synchronized between tabs.
 - What changed:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: clear-state reset and undo snapshot hooks for activate/deactivate column filter.
   2. `gui/gui_ssa.py`: debounce minimum floor and undo snapshot hook in header context apply.
@@ -28,6 +29,8 @@ This handoff is ready to reuse in the next conversation.
   10. `tests/test_gui_filter_logic.py`: updated row-control parsing and added regression `test_column_filter_row_clear_button_clears_value_without_hiding_row`.
   11. `gui/gui_ssa.py`: clear-search button renamed to `Limpar Busca` and tooltip clarifies scope.
   12. `tests/test_gui_filter_logic.py`: added regression `test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs`.
+  13. `gui/mixins/filter_gui_ssa_mixin.py` + `gui/mixins/tab_context_gui_ssa_mixin.py`: centralized clear-button enabled-state sync across tab contexts.
+  14. `tests/test_gui_filter_logic.py`: added regression `test_clear_filter_button_state_syncs_across_tabs_without_switch`.
 - Validation:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
@@ -37,13 +40,15 @@ This handoff is ready to reuse in the next conversation.
   6. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_all_filters_global_resets_full_filter_state_matrix or clear_all_filters_global_restores_default_column_filter_keys or clear_all_filters_global_resets_exclude_and_advanced_filters"`: `3 passed`
   7. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "default_column_filter_rows_show_apply_clear_and_hide_buttons or column_filter_buttons_flow or column_filter_row_clear_button_clears_value_without_hiding_row or clear_all_filters_global_restores_default_column_filter_keys or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `5 passed`
   8. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or test_clear_filter_clears_only_general_search_and_keeps_advanced_filters or test_clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
-  9. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean
+  9. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter_button_state_syncs_across_tabs_without_switch or clear_filter_button_reflects_active_filters or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
+  10. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean
 - Evidence:
   1. `2c7982b1` (`STABILITY_PATCH`: filter state stabilization package).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
   3. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
   4. `776c5905` (`STABILITY_PATCH`: tooltip encoding fix and 3-button row behavior).
   5. `182c51b0` (`STABILITY_PATCH`: clear-search button wording clarity).
+  6. pending in this working slice (`STABILITY_PATCH`: cross-tab clear-button state sync).
 - Deferred non-blocking:
   1. broad repository-wide non-ASCII normalization remains deferred because most findings are legacy localized strings and require controlled transversal policy.
 - Local residue status:

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -2,7 +2,7 @@
 
 This handoff is ready to reuse in the next conversation.
 
-## CURRENT TRUTH 2026-03-04 00:14 - authoritative block
+## CURRENT TRUTH 2026-03-04 00:25 - authoritative block
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice delivered:
@@ -14,6 +14,7 @@ This handoff is ready to reuse in the next conversation.
   6. global clear for all filters now restores default column-filter key baseline.
   7. week tooltip encoding issue fixed.
   8. column-filter row now exposes `Aplicar`, `Limpar`, and `Ocultar`.
+  9. clear-search button text/scope now explicit (`Limpar Busca` + tooltip).
 - What changed:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: clear-state reset and undo snapshot hooks for activate/deactivate column filter.
   2. `gui/gui_ssa.py`: debounce minimum floor and undo snapshot hook in header context apply.
@@ -25,6 +26,8 @@ This handoff is ready to reuse in the next conversation.
   8. `gui/mixins/filter_gui_ssa_mixin.py`: added row-level `Limpar` button (clear value, keep row visible) and kept `Ocultar` as visual-only action.
   9. `gui/widgets/filter_help_dialog.py`: help text aligned with three button actions.
   10. `tests/test_gui_filter_logic.py`: updated row-control parsing and added regression `test_column_filter_row_clear_button_clears_value_without_hiding_row`.
+  11. `gui/gui_ssa.py`: clear-search button renamed to `Limpar Busca` and tooltip clarifies scope.
+  12. `tests/test_gui_filter_logic.py`: added regression `test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs`.
 - Validation:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
@@ -33,12 +36,14 @@ This handoff is ready to reuse in the next conversation.
   5. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_header_context_menu_apply_stores_undo_snapshot"`: `1 passed`
   6. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_all_filters_global_resets_full_filter_state_matrix or clear_all_filters_global_restores_default_column_filter_keys or clear_all_filters_global_resets_exclude_and_advanced_filters"`: `3 passed`
   7. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "default_column_filter_rows_show_apply_clear_and_hide_buttons or column_filter_buttons_flow or column_filter_row_clear_button_clears_value_without_hiding_row or clear_all_filters_global_restores_default_column_filter_keys or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `5 passed`
-  8. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean
+  8. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or test_clear_filter_clears_only_general_search_and_keeps_advanced_filters or test_clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
+  9. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean
 - Evidence:
   1. `2c7982b1` (`STABILITY_PATCH`: filter state stabilization package).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
   3. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
   4. `776c5905` (`STABILITY_PATCH`: tooltip encoding fix and 3-button row behavior).
+  5. `182c51b0` (`STABILITY_PATCH`: clear-search button wording clarity).
 - Deferred non-blocking:
   1. broad repository-wide non-ASCII normalization remains deferred because most findings are legacy localized strings and require controlled transversal policy.
 - Local residue status:

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -60,7 +60,7 @@ This handoff is ready to reuse in the next conversation.
   5. `182c51b0` (`STABILITY_PATCH`: clear-search button wording clarity).
   6. `50bf94f0` (`STABILITY_PATCH`: cross-tab clear-button state sync).
   7. `32fca7c1` (`STABILITY_PATCH`: cross-tab undo-button state sync).
-  8. pending in this working slice (`STABILITY_PATCH`: tab-specific search handlers + regex guard hardening).
+  8. `fcc3715e` (`STABILITY_PATCH`: tab-specific search handlers + regex guard hardening).
 - Deferred non-blocking:
   1. broad repository-wide non-ASCII normalization remains deferred because most findings are legacy localized strings and require controlled transversal policy.
 - Local residue status:

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -2,7 +2,7 @@
 
 This handoff is ready to reuse in the next conversation.
 
-## CURRENT TRUTH 2026-03-04 01:44 - authoritative block
+## CURRENT TRUTH 2026-03-04 06:29 - authoritative block
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice delivered:
@@ -19,6 +19,7 @@ This handoff is ready to reuse in the next conversation.
   11. undo button enabled-state now stays synchronized between tabs.
   12. search apply/clear controls now route through tab-specific handlers (`main` and `filters`) with same functional behavior.
   13. regex safety guard in column-filter path is stricter to reduce catastrophic regex patterns.
+  14. PR #43 triage closed for `BUG_REAL` findings with targeted minimal patches.
 - What changed:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: clear-state reset and undo snapshot hooks for activate/deactivate column filter.
   2. `gui/gui_ssa.py`: debounce minimum floor and undo snapshot hook in header context apply.
@@ -39,6 +40,11 @@ This handoff is ready to reuse in the next conversation.
   17. `gui/gui_ssa.py` + `gui/mixins/filter_gui_ssa_mixin.py`: search apply/clear now call dedicated per-tab handlers.
   18. `gui/mixins/filter_gui_ssa_mixin.py`: regex guard hardening in `_build_column_mask`.
   19. `tests/test_gui_filter_logic.py`: added regressions `test_search_buttons_route_to_tab_specific_handlers` and `test_build_column_mask_blocks_heavy_regex_patterns`.
+  20. `gui/mixins/filter_gui_ssa_mixin.py`: global clear now also resets OR-group metadata (`_column_or_groups`/`_column_to_or_group`).
+  21. `gui/mixins/filter_gui_ssa_mixin.py`: `_mk_remove_line` updated to deterministic state init (no broad silent `except`).
+  22. `gui/gui_ssa.py`: debounce parse fallback now logs explicit warning and uses narrow exception class.
+  23. `gui/mixins/tab_context_gui_ssa_mixin.py`: removed duplicate `_sync_clear_filter_button_state()` call in bind flow.
+  24. `tests/test_gui_filter_logic.py`: added regression `test_clear_all_filters_global_resets_or_group_metadata`.
 - Validation:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
@@ -51,7 +57,8 @@ This handoff is ready to reuse in the next conversation.
   9. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter_button_state_syncs_across_tabs_without_switch or clear_filter_button_reflects_active_filters or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
   10. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore or clear_advanced_filters_forces_refresh_when_pending_schedule or test_header_context_menu_apply_stores_undo_snapshot"`: `3 passed`
   11. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "search_buttons_route_to_tab_specific_handlers or clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or clear_filter_button_state_syncs_across_tabs_without_switch or build_column_mask_blocks_heavy_regex_patterns"`: `4 passed`
-  12. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> issue(P4 regex safety) -> clean
+  12. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_all_filters_global_resets_or_group_metadata or clear_all_filters_global_resets_full_filter_state_matrix or clear_all_filters_global_restores_default_column_filter_keys or clear_filter_button_state_syncs_across_tabs_without_switch or undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore"`: `5 passed`
+  13. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> issue(P4 regex safety) -> clean -> clean -> clean -> clean -> clean -> clean
 - Evidence:
   1. `2c7982b1` (`STABILITY_PATCH`: filter state stabilization package).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
@@ -61,6 +68,7 @@ This handoff is ready to reuse in the next conversation.
   6. `50bf94f0` (`STABILITY_PATCH`: cross-tab clear-button state sync).
   7. `32fca7c1` (`STABILITY_PATCH`: cross-tab undo-button state sync).
   8. `fcc3715e` (`STABILITY_PATCH`: tab-specific search handlers + regex guard hardening).
+  9. pending in this working slice (`STABILITY_PATCH`: PR #43 bug-real triage fixes).
 - Deferred non-blocking:
   1. broad repository-wide non-ASCII normalization remains deferred because most findings are legacy localized strings and require controlled transversal policy.
 - Local residue status:

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -38,7 +38,7 @@ This handoff is ready to reuse in the next conversation.
   1. `2c7982b1` (`STABILITY_PATCH`: filter state stabilization package).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
   3. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
-  4. pending in current working slice (tooltip + 3-button row patch not committed yet).
+  4. `776c5905` (`STABILITY_PATCH`: tooltip encoding fix and 3-button row behavior).
 - Deferred non-blocking:
   1. broad repository-wide non-ASCII normalization remains deferred because most findings are legacy localized strings and require controlled transversal policy.
 - Local residue status:

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -2,7 +2,7 @@
 
 This handoff is ready to reuse in the next conversation.
 
-## CURRENT TRUTH 2026-03-04 00:07 - authoritative block
+## CURRENT TRUTH 2026-03-04 00:14 - authoritative block
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice delivered:
@@ -12,6 +12,8 @@ This handoff is ready to reuse in the next conversation.
   4. help text aligned to real behavior (`Aplicar` + `Ocultar`).
   5. deferred header context-menu apply + undo end-to-end regression is now covered by direct test.
   6. global clear for all filters now restores default column-filter key baseline.
+  7. week tooltip encoding issue fixed.
+  8. column-filter row now exposes `Aplicar`, `Limpar`, and `Ocultar`.
 - What changed:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: clear-state reset and undo snapshot hooks for activate/deactivate column filter.
   2. `gui/gui_ssa.py`: debounce minimum floor and undo snapshot hook in header context apply.
@@ -19,6 +21,10 @@ This handoff is ready to reuse in the next conversation.
   4. `gui/widgets/filter_help_dialog.py`: updated filter-help wording.
   5. `gui/mixins/filter_gui_ssa_mixin.py`: `_clear_all_filters_global` now uses `_column_filter_default_columns()` for column-key reset.
   6. `tests/test_gui_filter_logic.py`: added regression `test_clear_all_filters_global_restores_default_column_filter_keys`.
+  7. `gui/gui_ssa.py`: week tooltip text normalized to `Semana ISO atual`.
+  8. `gui/mixins/filter_gui_ssa_mixin.py`: added row-level `Limpar` button (clear value, keep row visible) and kept `Ocultar` as visual-only action.
+  9. `gui/widgets/filter_help_dialog.py`: help text aligned with three button actions.
+  10. `tests/test_gui_filter_logic.py`: updated row-control parsing and added regression `test_column_filter_row_clear_button_clears_value_without_hiding_row`.
 - Validation:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
@@ -26,13 +32,15 @@ This handoff is ready to reuse in the next conversation.
   4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter or debounce or activate_column_filter_stores_undo_snapshot or deactivate_column_filter_stores_undo_snapshot"`: `15 passed, 1 skipped`
   5. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_header_context_menu_apply_stores_undo_snapshot"`: `1 passed`
   6. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_all_filters_global_resets_full_filter_state_matrix or clear_all_filters_global_restores_default_column_filter_keys or clear_all_filters_global_resets_exclude_and_advanced_filters"`: `3 passed`
-  7. kluster auto: clean -> clean -> clean -> clean -> clean -> clean
+  7. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "default_column_filter_rows_show_apply_clear_and_hide_buttons or column_filter_buttons_flow or column_filter_row_clear_button_clears_value_without_hiding_row or clear_all_filters_global_restores_default_column_filter_keys or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `5 passed`
+  8. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean
 - Evidence:
   1. `2c7982b1` (`STABILITY_PATCH`: filter state stabilization package).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
   3. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
+  4. pending in current working slice (tooltip + 3-button row patch not committed yet).
 - Deferred non-blocking:
-  1. none in current filter-button scope.
+  1. broad repository-wide non-ASCII normalization remains deferred because most findings are legacy localized strings and require controlled transversal policy.
 - Local residue status:
   1. out-of-scope local file kept unchanged: `config/gui_main_preferences.json`
   2. stash kept unchanged: `stash@{0}` (`local-wip-config-db-before-dev-switch-20260303`)

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -2,7 +2,7 @@
 
 This handoff is ready to reuse in the next conversation.
 
-## CURRENT TRUTH 2026-03-03 23:53 - authoritative block
+## CURRENT TRUTH 2026-03-03 23:59 - authoritative block
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice delivered:
@@ -10,6 +10,7 @@ This handoff is ready to reuse in the next conversation.
   2. debounce floor increased to `1400 ms` for general search to favor explicit `Aplicar`.
   3. undo snapshot coverage expanded to missing entry points (header context apply + activate/deactivate column filter).
   4. help text aligned to real behavior (`Aplicar` + `Ocultar`).
+  5. deferred header context-menu apply + undo end-to-end regression is now covered by direct test.
 - What changed:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: clear-state reset and undo snapshot hooks for activate/deactivate column filter.
   2. `gui/gui_ssa.py`: debounce minimum floor and undo snapshot hook in header context apply.
@@ -20,11 +21,13 @@ This handoff is ready to reuse in the next conversation.
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   3. `uv run --python 3.13 ty check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter or debounce or activate_column_filter_stores_undo_snapshot or deactivate_column_filter_stores_undo_snapshot"`: `15 passed, 1 skipped`
-  5. kluster auto: clean -> clean -> clean -> clean
+  5. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_header_context_menu_apply_stores_undo_snapshot"`: `1 passed`
+  6. kluster auto: clean -> clean -> clean -> clean -> clean
 - Evidence:
   1. `2c7982b1` (`STABILITY_PATCH`: filter state stabilization package).
+  2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
 - Deferred non-blocking:
-  1. add direct Qt context-menu interaction regression for header apply + undo path.
+  1. none in current filter-button scope.
 - Local residue status:
   1. out-of-scope local file kept unchanged: `config/gui_main_preferences.json`
   2. stash kept unchanged: `stash@{0}` (`local-wip-config-db-before-dev-switch-20260303`)

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -68,7 +68,7 @@ This handoff is ready to reuse in the next conversation.
   6. `50bf94f0` (`STABILITY_PATCH`: cross-tab clear-button state sync).
   7. `32fca7c1` (`STABILITY_PATCH`: cross-tab undo-button state sync).
   8. `fcc3715e` (`STABILITY_PATCH`: tab-specific search handlers + regex guard hardening).
-  9. pending in this working slice (`STABILITY_PATCH`: PR #43 bug-real triage fixes).
+  9. `6f1ef11b` (`STABILITY_PATCH`: PR #43 bug-real triage fixes).
 - Deferred non-blocking:
   1. broad repository-wide non-ASCII normalization remains deferred because most findings are legacy localized strings and require controlled transversal policy.
 - Local residue status:

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -2,7 +2,34 @@
 
 This handoff is ready to reuse in the next conversation.
 
-## CURRENT TRUTH 2026-03-03 22:23 - authoritative block
+## CURRENT TRUTH 2026-03-03 23:53 - authoritative block
+
+- Active branch: `codex/fix-filter-buttons-state-sync`.
+- Slice delivered:
+  1. stale async state after `clear_filter` removed (`_active_filter_search_display` and `_active_filter_search_request_id` now reset).
+  2. debounce floor increased to `1400 ms` for general search to favor explicit `Aplicar`.
+  3. undo snapshot coverage expanded to missing entry points (header context apply + activate/deactivate column filter).
+  4. help text aligned to real behavior (`Aplicar` + `Ocultar`).
+- What changed:
+  1. `gui/mixins/filter_gui_ssa_mixin.py`: clear-state reset and undo snapshot hooks for activate/deactivate column filter.
+  2. `gui/gui_ssa.py`: debounce minimum floor and undo snapshot hook in header context apply.
+  3. `tests/test_gui_filter_logic.py`: added regressions for stale clear state, debounce floor, and undo snapshot entry points.
+  4. `gui/widgets/filter_help_dialog.py`: updated filter-help wording.
+- Validation:
+  1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
+  2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
+  3. `uv run --python 3.13 ty check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
+  4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter or debounce or activate_column_filter_stores_undo_snapshot or deactivate_column_filter_stores_undo_snapshot"`: `15 passed, 1 skipped`
+  5. kluster auto: clean -> clean -> clean -> clean
+- Evidence:
+  1. `2c7982b1` (`STABILITY_PATCH`: filter state stabilization package).
+- Deferred non-blocking:
+  1. add direct Qt context-menu interaction regression for header apply + undo path.
+- Local residue status:
+  1. out-of-scope local file kept unchanged: `config/gui_main_preferences.json`
+  2. stash kept unchanged: `stash@{0}` (`local-wip-config-db-before-dev-switch-20260303`)
+
+## HISTORICAL SNAPSHOT 2026-03-03 22:23 - authoritative block
 
 - Active branch: `dev`.
 - Slice delivered:

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -2,7 +2,7 @@
 
 This handoff is ready to reuse in the next conversation.
 
-## CURRENT TRUTH 2026-03-03 23:59 - authoritative block
+## CURRENT TRUTH 2026-03-04 00:07 - authoritative block
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice delivered:
@@ -11,21 +11,26 @@ This handoff is ready to reuse in the next conversation.
   3. undo snapshot coverage expanded to missing entry points (header context apply + activate/deactivate column filter).
   4. help text aligned to real behavior (`Aplicar` + `Ocultar`).
   5. deferred header context-menu apply + undo end-to-end regression is now covered by direct test.
+  6. global clear for all filters now restores default column-filter key baseline.
 - What changed:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: clear-state reset and undo snapshot hooks for activate/deactivate column filter.
   2. `gui/gui_ssa.py`: debounce minimum floor and undo snapshot hook in header context apply.
   3. `tests/test_gui_filter_logic.py`: added regressions for stale clear state, debounce floor, and undo snapshot entry points.
   4. `gui/widgets/filter_help_dialog.py`: updated filter-help wording.
+  5. `gui/mixins/filter_gui_ssa_mixin.py`: `_clear_all_filters_global` now uses `_column_filter_default_columns()` for column-key reset.
+  6. `tests/test_gui_filter_logic.py`: added regression `test_clear_all_filters_global_restores_default_column_filter_keys`.
 - Validation:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   3. `uv run --python 3.13 ty check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter or debounce or activate_column_filter_stores_undo_snapshot or deactivate_column_filter_stores_undo_snapshot"`: `15 passed, 1 skipped`
   5. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_header_context_menu_apply_stores_undo_snapshot"`: `1 passed`
-  6. kluster auto: clean -> clean -> clean -> clean -> clean
+  6. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_all_filters_global_resets_full_filter_state_matrix or clear_all_filters_global_restores_default_column_filter_keys or clear_all_filters_global_resets_exclude_and_advanced_filters"`: `3 passed`
+  7. kluster auto: clean -> clean -> clean -> clean -> clean -> clean
 - Evidence:
   1. `2c7982b1` (`STABILITY_PATCH`: filter state stabilization package).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
+  3. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
 - Deferred non-blocking:
   1. none in current filter-button scope.
 - Local residue status:

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -2,7 +2,34 @@
 
 Use this file to migrate context to a new chat without losing execution quality.
 
-## CURRENT TRUTH 2026-03-03 22:23 - start from here
+## CURRENT TRUTH 2026-03-03 23:53 - start from here
+
+- Active branch: `codex/fix-filter-buttons-state-sync`.
+- Slice status:
+  1. high-risk stale async state after `Limpar Filtro` fixed.
+  2. medium-risk undo snapshot gaps for column filter entry points fixed.
+  3. debounce floor increased to encourage explicit `Aplicar` usage.
+- Runtime change summary:
+  1. `gui/mixins/filter_gui_ssa_mixin.py`: `clear_filter` now resets `_active_filter_search_display` and `_active_filter_search_request_id`.
+  2. `gui/gui_ssa.py`: general search debounce now enforces minimum `1400 ms`.
+  3. `gui/gui_ssa.py` + `gui/mixins/filter_gui_ssa_mixin.py`: undo snapshot capture added in header context apply and activate/deactivate column filter paths.
+  4. `gui/widgets/filter_help_dialog.py`: help text aligned with real button behavior (`Aplicar` + `Ocultar`).
+- Validation snapshot:
+  1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
+  2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
+  3. `uv run --python 3.13 ty check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
+  4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter or debounce or activate_column_filter_stores_undo_snapshot or deactivate_column_filter_stores_undo_snapshot"`: `15 passed, 1 skipped`
+  5. kluster auto: clean -> clean -> clean -> clean
+- Evidence commit:
+  1. `2c7982b1` (`STABILITY_PATCH`).
+- Next cycle:
+  1. add direct GUI interaction regression for header context-menu apply + undo end-to-end.
+  2. keep no-layout-change policy and minimal-scope slices.
+- Local residue contract:
+  1. keep out-of-scope file unchanged: `config/gui_main_preferences.json`.
+  2. keep stash untouched: `stash@{0}` (`local-wip-config-db-before-dev-switch-20260303`).
+
+## HISTORICAL SNAPSHOT 2026-03-03 22:23 - start from here
 
 - Active branch: `dev`.
 - Slice status:

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -52,7 +52,7 @@ Use this file to migrate context to a new chat without losing execution quality.
   5. `182c51b0` (`STABILITY_PATCH`: clear-search button wording clarity).
   6. `50bf94f0` (`STABILITY_PATCH`: cross-tab clear-button state sync).
   7. `32fca7c1` (`STABILITY_PATCH`: cross-tab undo-button state sync).
-  8. pending in this working slice (`STABILITY_PATCH`: tab-specific search handlers + regex guard hardening).
+  8. `fcc3715e` (`STABILITY_PATCH`: tab-specific search handlers + regex guard hardening).
 - Next cycle:
   1. keep no-layout-change policy and minimal-scope slices.
   2. monitor for regressions around async filter state and request-scoped display markers.

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -2,7 +2,7 @@
 
 Use this file to migrate context to a new chat without losing execution quality.
 
-## CURRENT TRUTH 2026-03-04 01:44 - start from here
+## CURRENT TRUTH 2026-03-04 06:29 - start from here
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice status:
@@ -17,6 +17,8 @@ Use this file to migrate context to a new chat without losing execution quality.
   9. undo button enabled-state now syncs between both tabs, including advanced-filter clear/restore flow.
   10. search apply/clear buttons now route through dedicated handlers per tab (`main` and `filters`) with equivalent behavior.
   11. regex safety guard in column filter path tightened to reduce catastrophic regex risk.
+  12. PR #43 feedback triage executed; all `BUG_REAL` comments fixed in minimal patch.
+  13. non-blocking/noise PR comments classified with explicit status (`DECISAO_INTENCIONAL`, `NAO_BLOQUEANTE_DEFERIDO`, `FALSO_POSITIVO`).
 - Runtime change summary:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: `clear_filter` now resets `_active_filter_search_display` and `_active_filter_search_request_id`.
   2. `gui/gui_ssa.py`: general search debounce now enforces minimum `1400 ms`.
@@ -31,6 +33,9 @@ Use this file to migrate context to a new chat without losing execution quality.
   11. `gui/mixins/filter_gui_ssa_mixin.py`: undo-state sync helper now updates all `undo_filter_btn` widgets across tab contexts.
   12. `gui/gui_ssa.py` + `gui/mixins/filter_gui_ssa_mixin.py`: search apply/clear now use tab-specific handlers while keeping same filtering behavior.
   13. `gui/mixins/filter_gui_ssa_mixin.py`: regex guard added (`meta_char_count` and alternation+quantifier block) for safer fallback to literal search.
+  14. `gui/mixins/filter_gui_ssa_mixin.py`: `_clear_all_filters_global` now resets `_column_or_groups`/`_column_to_or_group` using `_reset_or_groups()`.
+  15. `gui/mixins/filter_gui_ssa_mixin.py`: `_mk_remove_line` no longer hides errors with broad silent `except`.
+  16. `gui/gui_ssa.py` + `gui/mixins/tab_context_gui_ssa_mixin.py`: debounce parse fallback now logs explicitly and bind flow no longer duplicates clear-button sync call.
 - Validation snapshot:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
@@ -43,7 +48,8 @@ Use this file to migrate context to a new chat without losing execution quality.
   9. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter_button_state_syncs_across_tabs_without_switch or clear_filter_button_reflects_active_filters or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
   10. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore or clear_advanced_filters_forces_refresh_when_pending_schedule or test_header_context_menu_apply_stores_undo_snapshot"`: `3 passed`
   11. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "search_buttons_route_to_tab_specific_handlers or clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or clear_filter_button_state_syncs_across_tabs_without_switch or build_column_mask_blocks_heavy_regex_patterns"`: `4 passed`
-  12. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> issue(P4 regex safety) -> clean
+  12. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_all_filters_global_resets_or_group_metadata or clear_all_filters_global_resets_full_filter_state_matrix or clear_all_filters_global_restores_default_column_filter_keys or clear_filter_button_state_syncs_across_tabs_without_switch or undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore"`: `5 passed`
+  13. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> issue(P4 regex safety) -> clean -> clean -> clean -> clean -> clean -> clean
 - Evidence commit:
   1. `2c7982b1` (`STABILITY_PATCH`).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
@@ -53,6 +59,7 @@ Use this file to migrate context to a new chat without losing execution quality.
   6. `50bf94f0` (`STABILITY_PATCH`: cross-tab clear-button state sync).
   7. `32fca7c1` (`STABILITY_PATCH`: cross-tab undo-button state sync).
   8. `fcc3715e` (`STABILITY_PATCH`: tab-specific search handlers + regex guard hardening).
+  9. pending in this working slice (`STABILITY_PATCH`: PR #43 bug-real triage fixes).
 - Next cycle:
   1. keep no-layout-change policy and minimal-scope slices.
   2. monitor for regressions around async filter state and request-scoped display markers.

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -2,7 +2,7 @@
 
 Use this file to migrate context to a new chat without losing execution quality.
 
-## CURRENT TRUTH 2026-03-04 00:07 - start from here
+## CURRENT TRUTH 2026-03-04 00:14 - start from here
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice status:
@@ -11,12 +11,16 @@ Use this file to migrate context to a new chat without losing execution quality.
   3. debounce floor increased to encourage explicit `Aplicar` usage.
   4. deferred header context-menu apply + undo end-to-end regression added and validated.
   5. global clear now restores default column-filter baseline (no hardcoded subset).
+  6. week tooltip encoding issue fixed; column-filter row now has 3 actions (`Aplicar`, `Limpar`, `Ocultar`).
 - Runtime change summary:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: `clear_filter` now resets `_active_filter_search_display` and `_active_filter_search_request_id`.
   2. `gui/gui_ssa.py`: general search debounce now enforces minimum `1400 ms`.
   3. `gui/gui_ssa.py` + `gui/mixins/filter_gui_ssa_mixin.py`: undo snapshot capture added in header context apply and activate/deactivate column filter paths.
   4. `gui/widgets/filter_help_dialog.py`: help text aligned with real button behavior (`Aplicar` + `Ocultar`).
   5. `gui/mixins/filter_gui_ssa_mixin.py`: `_clear_all_filters_global` now resets column keys from `_column_filter_default_columns()`.
+  6. `gui/gui_ssa.py`: week tooltip normalized to `Semana ISO atual`.
+  7. `gui/mixins/filter_gui_ssa_mixin.py`: per-row column filter now has dedicated `Limpar` action that clears value without hiding row.
+  8. `gui/widgets/filter_help_dialog.py`: filter-help updated to describe three row actions.
 - Validation snapshot:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
@@ -24,11 +28,14 @@ Use this file to migrate context to a new chat without losing execution quality.
   4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter or debounce or activate_column_filter_stores_undo_snapshot or deactivate_column_filter_stores_undo_snapshot"`: `15 passed, 1 skipped`
   5. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_header_context_menu_apply_stores_undo_snapshot"`: `1 passed`
   6. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_all_filters_global_resets_full_filter_state_matrix or clear_all_filters_global_restores_default_column_filter_keys or clear_all_filters_global_resets_exclude_and_advanced_filters"`: `3 passed`
-  7. kluster auto: clean -> clean -> clean -> clean -> clean -> clean
+  7. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "default_column_filter_rows_show_apply_clear_and_hide_buttons or column_filter_buttons_flow or column_filter_row_clear_button_clears_value_without_hiding_row or clear_all_filters_global_restores_default_column_filter_keys or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `5 passed`
+  8. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean
 - Evidence commit:
   1. `2c7982b1` (`STABILITY_PATCH`).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
   3. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
+- Next evidence commit:
+  1. pending in this working slice (tooltip + 3-button row patch not committed yet).
 - Next cycle:
   1. keep no-layout-change policy and minimal-scope slices.
   2. monitor for regressions around async filter state and request-scoped display markers.

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -2,7 +2,7 @@
 
 Use this file to migrate context to a new chat without losing execution quality.
 
-## CURRENT TRUTH 2026-03-04 01:39 - start from here
+## CURRENT TRUTH 2026-03-04 01:44 - start from here
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice status:
@@ -15,6 +15,8 @@ Use this file to migrate context to a new chat without losing execution quality.
   7. clear-search button wording clarified (`Limpar Busca`) with explicit scope tooltip.
   8. clear-search button enabled-state sync now updates both tabs in same cycle.
   9. undo button enabled-state now syncs between both tabs, including advanced-filter clear/restore flow.
+  10. search apply/clear buttons now route through dedicated handlers per tab (`main` and `filters`) with equivalent behavior.
+  11. regex safety guard in column filter path tightened to reduce catastrophic regex risk.
 - Runtime change summary:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: `clear_filter` now resets `_active_filter_search_display` and `_active_filter_search_request_id`.
   2. `gui/gui_ssa.py`: general search debounce now enforces minimum `1400 ms`.
@@ -27,6 +29,8 @@ Use this file to migrate context to a new chat without losing execution quality.
   9. `gui/gui_ssa.py`: clear-search button text and tooltip now state explicit scope (search only).
   10. `gui/mixins/filter_gui_ssa_mixin.py` + `gui/mixins/tab_context_gui_ssa_mixin.py`: clear-search button state now syncs across both tab contexts via centralized helper.
   11. `gui/mixins/filter_gui_ssa_mixin.py`: undo-state sync helper now updates all `undo_filter_btn` widgets across tab contexts.
+  12. `gui/gui_ssa.py` + `gui/mixins/filter_gui_ssa_mixin.py`: search apply/clear now use tab-specific handlers while keeping same filtering behavior.
+  13. `gui/mixins/filter_gui_ssa_mixin.py`: regex guard added (`meta_char_count` and alternation+quantifier block) for safer fallback to literal search.
 - Validation snapshot:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
@@ -38,7 +42,8 @@ Use this file to migrate context to a new chat without losing execution quality.
   8. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or test_clear_filter_clears_only_general_search_and_keeps_advanced_filters or test_clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
   9. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter_button_state_syncs_across_tabs_without_switch or clear_filter_button_reflects_active_filters or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
   10. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore or clear_advanced_filters_forces_refresh_when_pending_schedule or test_header_context_menu_apply_stores_undo_snapshot"`: `3 passed`
-  11. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean
+  11. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "search_buttons_route_to_tab_specific_handlers or clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or clear_filter_button_state_syncs_across_tabs_without_switch or build_column_mask_blocks_heavy_regex_patterns"`: `4 passed`
+  12. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> issue(P4 regex safety) -> clean
 - Evidence commit:
   1. `2c7982b1` (`STABILITY_PATCH`).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
@@ -46,7 +51,8 @@ Use this file to migrate context to a new chat without losing execution quality.
   4. `776c5905` (`STABILITY_PATCH`: tooltip encoding fix and 3-button row behavior).
   5. `182c51b0` (`STABILITY_PATCH`: clear-search button wording clarity).
   6. `50bf94f0` (`STABILITY_PATCH`: cross-tab clear-button state sync).
-  7. pending in this working slice (`STABILITY_PATCH`: cross-tab undo-button state sync).
+  7. `32fca7c1` (`STABILITY_PATCH`: cross-tab undo-button state sync).
+  8. pending in this working slice (`STABILITY_PATCH`: tab-specific search handlers + regex guard hardening).
 - Next cycle:
   1. keep no-layout-change policy and minimal-scope slices.
   2. monitor for regressions around async filter state and request-scoped display markers.

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -2,7 +2,7 @@
 
 Use this file to migrate context to a new chat without losing execution quality.
 
-## CURRENT TRUTH 2026-03-04 01:02 - start from here
+## CURRENT TRUTH 2026-03-04 01:39 - start from here
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice status:
@@ -14,6 +14,7 @@ Use this file to migrate context to a new chat without losing execution quality.
   6. week tooltip encoding issue fixed; column-filter row now has 3 actions (`Aplicar`, `Limpar`, `Ocultar`).
   7. clear-search button wording clarified (`Limpar Busca`) with explicit scope tooltip.
   8. clear-search button enabled-state sync now updates both tabs in same cycle.
+  9. undo button enabled-state now syncs between both tabs, including advanced-filter clear/restore flow.
 - Runtime change summary:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: `clear_filter` now resets `_active_filter_search_display` and `_active_filter_search_request_id`.
   2. `gui/gui_ssa.py`: general search debounce now enforces minimum `1400 ms`.
@@ -25,6 +26,7 @@ Use this file to migrate context to a new chat without losing execution quality.
   8. `gui/widgets/filter_help_dialog.py`: filter-help updated to describe three row actions.
   9. `gui/gui_ssa.py`: clear-search button text and tooltip now state explicit scope (search only).
   10. `gui/mixins/filter_gui_ssa_mixin.py` + `gui/mixins/tab_context_gui_ssa_mixin.py`: clear-search button state now syncs across both tab contexts via centralized helper.
+  11. `gui/mixins/filter_gui_ssa_mixin.py`: undo-state sync helper now updates all `undo_filter_btn` widgets across tab contexts.
 - Validation snapshot:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
@@ -35,14 +37,16 @@ Use this file to migrate context to a new chat without losing execution quality.
   7. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "default_column_filter_rows_show_apply_clear_and_hide_buttons or column_filter_buttons_flow or column_filter_row_clear_button_clears_value_without_hiding_row or clear_all_filters_global_restores_default_column_filter_keys or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `5 passed`
   8. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or test_clear_filter_clears_only_general_search_and_keeps_advanced_filters or test_clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
   9. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter_button_state_syncs_across_tabs_without_switch or clear_filter_button_reflects_active_filters or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
-  10. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean
+  10. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore or clear_advanced_filters_forces_refresh_when_pending_schedule or test_header_context_menu_apply_stores_undo_snapshot"`: `3 passed`
+  11. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean
 - Evidence commit:
   1. `2c7982b1` (`STABILITY_PATCH`).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
   3. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
   4. `776c5905` (`STABILITY_PATCH`: tooltip encoding fix and 3-button row behavior).
   5. `182c51b0` (`STABILITY_PATCH`: clear-search button wording clarity).
-  6. pending in this working slice (`STABILITY_PATCH`: cross-tab clear-button state sync).
+  6. `50bf94f0` (`STABILITY_PATCH`: cross-tab clear-button state sync).
+  7. pending in this working slice (`STABILITY_PATCH`: cross-tab undo-button state sync).
 - Next cycle:
   1. keep no-layout-change policy and minimal-scope slices.
   2. monitor for regressions around async filter state and request-scoped display markers.

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -2,7 +2,7 @@
 
 Use this file to migrate context to a new chat without losing execution quality.
 
-## CURRENT TRUTH 2026-03-03 23:59 - start from here
+## CURRENT TRUTH 2026-03-04 00:07 - start from here
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice status:
@@ -10,21 +10,25 @@ Use this file to migrate context to a new chat without losing execution quality.
   2. medium-risk undo snapshot gaps for column filter entry points fixed.
   3. debounce floor increased to encourage explicit `Aplicar` usage.
   4. deferred header context-menu apply + undo end-to-end regression added and validated.
+  5. global clear now restores default column-filter baseline (no hardcoded subset).
 - Runtime change summary:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: `clear_filter` now resets `_active_filter_search_display` and `_active_filter_search_request_id`.
   2. `gui/gui_ssa.py`: general search debounce now enforces minimum `1400 ms`.
   3. `gui/gui_ssa.py` + `gui/mixins/filter_gui_ssa_mixin.py`: undo snapshot capture added in header context apply and activate/deactivate column filter paths.
   4. `gui/widgets/filter_help_dialog.py`: help text aligned with real button behavior (`Aplicar` + `Ocultar`).
+  5. `gui/mixins/filter_gui_ssa_mixin.py`: `_clear_all_filters_global` now resets column keys from `_column_filter_default_columns()`.
 - Validation snapshot:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   3. `uv run --python 3.13 ty check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter or debounce or activate_column_filter_stores_undo_snapshot or deactivate_column_filter_stores_undo_snapshot"`: `15 passed, 1 skipped`
   5. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_header_context_menu_apply_stores_undo_snapshot"`: `1 passed`
-  6. kluster auto: clean -> clean -> clean -> clean -> clean
+  6. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_all_filters_global_resets_full_filter_state_matrix or clear_all_filters_global_restores_default_column_filter_keys or clear_all_filters_global_resets_exclude_and_advanced_filters"`: `3 passed`
+  7. kluster auto: clean -> clean -> clean -> clean -> clean -> clean
 - Evidence commit:
   1. `2c7982b1` (`STABILITY_PATCH`).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
+  3. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
 - Next cycle:
   1. keep no-layout-change policy and minimal-scope slices.
   2. monitor for regressions around async filter state and request-scoped display markers.

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -2,13 +2,14 @@
 
 Use this file to migrate context to a new chat without losing execution quality.
 
-## CURRENT TRUTH 2026-03-03 23:53 - start from here
+## CURRENT TRUTH 2026-03-03 23:59 - start from here
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice status:
   1. high-risk stale async state after `Limpar Filtro` fixed.
   2. medium-risk undo snapshot gaps for column filter entry points fixed.
   3. debounce floor increased to encourage explicit `Aplicar` usage.
+  4. deferred header context-menu apply + undo end-to-end regression added and validated.
 - Runtime change summary:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: `clear_filter` now resets `_active_filter_search_display` and `_active_filter_search_request_id`.
   2. `gui/gui_ssa.py`: general search debounce now enforces minimum `1400 ms`.
@@ -19,12 +20,14 @@ Use this file to migrate context to a new chat without losing execution quality.
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   3. `uv run --python 3.13 ty check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter or debounce or activate_column_filter_stores_undo_snapshot or deactivate_column_filter_stores_undo_snapshot"`: `15 passed, 1 skipped`
-  5. kluster auto: clean -> clean -> clean -> clean
+  5. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_header_context_menu_apply_stores_undo_snapshot"`: `1 passed`
+  6. kluster auto: clean -> clean -> clean -> clean -> clean
 - Evidence commit:
   1. `2c7982b1` (`STABILITY_PATCH`).
+  2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
 - Next cycle:
-  1. add direct GUI interaction regression for header context-menu apply + undo end-to-end.
-  2. keep no-layout-change policy and minimal-scope slices.
+  1. keep no-layout-change policy and minimal-scope slices.
+  2. monitor for regressions around async filter state and request-scoped display markers.
 - Local residue contract:
   1. keep out-of-scope file unchanged: `config/gui_main_preferences.json`.
   2. keep stash untouched: `stash@{0}` (`local-wip-config-db-before-dev-switch-20260303`).

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -59,7 +59,7 @@ Use this file to migrate context to a new chat without losing execution quality.
   6. `50bf94f0` (`STABILITY_PATCH`: cross-tab clear-button state sync).
   7. `32fca7c1` (`STABILITY_PATCH`: cross-tab undo-button state sync).
   8. `fcc3715e` (`STABILITY_PATCH`: tab-specific search handlers + regex guard hardening).
-  9. pending in this working slice (`STABILITY_PATCH`: PR #43 bug-real triage fixes).
+  9. `6f1ef11b` (`STABILITY_PATCH`: PR #43 bug-real triage fixes).
 - Next cycle:
   1. keep no-layout-change policy and minimal-scope slices.
   2. monitor for regressions around async filter state and request-scoped display markers.

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -2,7 +2,7 @@
 
 Use this file to migrate context to a new chat without losing execution quality.
 
-## CURRENT TRUTH 2026-03-04 00:14 - start from here
+## CURRENT TRUTH 2026-03-04 00:25 - start from here
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice status:
@@ -12,6 +12,7 @@ Use this file to migrate context to a new chat without losing execution quality.
   4. deferred header context-menu apply + undo end-to-end regression added and validated.
   5. global clear now restores default column-filter baseline (no hardcoded subset).
   6. week tooltip encoding issue fixed; column-filter row now has 3 actions (`Aplicar`, `Limpar`, `Ocultar`).
+  7. clear-search button wording clarified (`Limpar Busca`) with explicit scope tooltip.
 - Runtime change summary:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: `clear_filter` now resets `_active_filter_search_display` and `_active_filter_search_request_id`.
   2. `gui/gui_ssa.py`: general search debounce now enforces minimum `1400 ms`.
@@ -21,6 +22,7 @@ Use this file to migrate context to a new chat without losing execution quality.
   6. `gui/gui_ssa.py`: week tooltip normalized to `Semana ISO atual`.
   7. `gui/mixins/filter_gui_ssa_mixin.py`: per-row column filter now has dedicated `Limpar` action that clears value without hiding row.
   8. `gui/widgets/filter_help_dialog.py`: filter-help updated to describe three row actions.
+  9. `gui/gui_ssa.py`: clear-search button text and tooltip now state explicit scope (search only).
 - Validation snapshot:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
@@ -29,12 +31,14 @@ Use this file to migrate context to a new chat without losing execution quality.
   5. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_header_context_menu_apply_stores_undo_snapshot"`: `1 passed`
   6. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_all_filters_global_resets_full_filter_state_matrix or clear_all_filters_global_restores_default_column_filter_keys or clear_all_filters_global_resets_exclude_and_advanced_filters"`: `3 passed`
   7. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "default_column_filter_rows_show_apply_clear_and_hide_buttons or column_filter_buttons_flow or column_filter_row_clear_button_clears_value_without_hiding_row or clear_all_filters_global_restores_default_column_filter_keys or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `5 passed`
-  8. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean
+  8. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or test_clear_filter_clears_only_general_search_and_keeps_advanced_filters or test_clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
+  9. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean
 - Evidence commit:
   1. `2c7982b1` (`STABILITY_PATCH`).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
   3. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
   4. `776c5905` (`STABILITY_PATCH`: tooltip encoding fix and 3-button row behavior).
+  5. `182c51b0` (`STABILITY_PATCH`: clear-search button wording clarity).
 - Next cycle:
   1. keep no-layout-change policy and minimal-scope slices.
   2. monitor for regressions around async filter state and request-scoped display markers.

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -2,7 +2,7 @@
 
 Use this file to migrate context to a new chat without losing execution quality.
 
-## CURRENT TRUTH 2026-03-04 00:25 - start from here
+## CURRENT TRUTH 2026-03-04 01:02 - start from here
 
 - Active branch: `codex/fix-filter-buttons-state-sync`.
 - Slice status:
@@ -13,6 +13,7 @@ Use this file to migrate context to a new chat without losing execution quality.
   5. global clear now restores default column-filter baseline (no hardcoded subset).
   6. week tooltip encoding issue fixed; column-filter row now has 3 actions (`Aplicar`, `Limpar`, `Ocultar`).
   7. clear-search button wording clarified (`Limpar Busca`) with explicit scope tooltip.
+  8. clear-search button enabled-state sync now updates both tabs in same cycle.
 - Runtime change summary:
   1. `gui/mixins/filter_gui_ssa_mixin.py`: `clear_filter` now resets `_active_filter_search_display` and `_active_filter_search_request_id`.
   2. `gui/gui_ssa.py`: general search debounce now enforces minimum `1400 ms`.
@@ -23,6 +24,7 @@ Use this file to migrate context to a new chat without losing execution quality.
   7. `gui/mixins/filter_gui_ssa_mixin.py`: per-row column filter now has dedicated `Limpar` action that clears value without hiding row.
   8. `gui/widgets/filter_help_dialog.py`: filter-help updated to describe three row actions.
   9. `gui/gui_ssa.py`: clear-search button text and tooltip now state explicit scope (search only).
+  10. `gui/mixins/filter_gui_ssa_mixin.py` + `gui/mixins/tab_context_gui_ssa_mixin.py`: clear-search button state now syncs across both tab contexts via centralized helper.
 - Validation snapshot:
   1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
   2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
@@ -32,13 +34,15 @@ Use this file to migrate context to a new chat without losing execution quality.
   6. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_all_filters_global_resets_full_filter_state_matrix or clear_all_filters_global_restores_default_column_filter_keys or clear_all_filters_global_resets_exclude_and_advanced_filters"`: `3 passed`
   7. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "default_column_filter_rows_show_apply_clear_and_hide_buttons or column_filter_buttons_flow or column_filter_row_clear_button_clears_value_without_hiding_row or clear_all_filters_global_restores_default_column_filter_keys or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `5 passed`
   8. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or test_clear_filter_clears_only_general_search_and_keeps_advanced_filters or test_clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
-  9. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean
+  9. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter_button_state_syncs_across_tabs_without_switch or clear_filter_button_reflects_active_filters or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
+  10. kluster auto: clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean -> clean
 - Evidence commit:
   1. `2c7982b1` (`STABILITY_PATCH`).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
   3. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
   4. `776c5905` (`STABILITY_PATCH`: tooltip encoding fix and 3-button row behavior).
   5. `182c51b0` (`STABILITY_PATCH`: clear-search button wording clarity).
+  6. pending in this working slice (`STABILITY_PATCH`: cross-tab clear-button state sync).
 - Next cycle:
   1. keep no-layout-change policy and minimal-scope slices.
   2. monitor for regressions around async filter state and request-scoped display markers.

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -34,8 +34,7 @@ Use this file to migrate context to a new chat without losing execution quality.
   1. `2c7982b1` (`STABILITY_PATCH`).
   2. `22bbd3dc` (`STABILITY_PATCH`: follow-up regression for header context-menu undo path).
   3. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
-- Next evidence commit:
-  1. pending in this working slice (tooltip + 3-button row patch not committed yet).
+  4. `776c5905` (`STABILITY_PATCH`: tooltip encoding fix and 3-button row behavior).
 - Next cycle:
   1. keep no-layout-change policy and minimal-scope slices.
   2. monitor for regressions around async filter state and request-scoped display markers.

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -26,7 +26,11 @@ Validation:
 Diagnostic scan:
 1. global scan for mojibake patterns in `*.py` completed.
 2. no remaining mojibake pattern found in touched runtime/test files after this patch.
-3. legacy non-ASCII text still exists in historical scripts/tests; not all are encoding errors and broad normalization remains deferred to avoid high-risk transversal changes.
+3. deferred note (approved): "existem muitos caracteres nao-ASCII legados em scripts/tests antigos (texto PT-BR), mas isso nao e necessariamente erro de codificacao; normalizei apenas erros reais neste slice para evitar mudanca transversal de alto risco."
+4. where to clean in future controlled slice:
+   - `scripts_manutencao/*.py`
+   - `tests/teste_*.py`
+   - legacy CLI/script text blocks under `interface/cli.py` and `interface/command_handlers.py`
 
 Decision and scope:
 1. this is a `STABILITY_PATCH` focused on user-visible filter button behavior and encoding fix in GUI tooltip.

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -3,6 +3,29 @@
 This file tracks post-merge hardening and cleanup for the recovery branch.
 Scope is split by priority to keep delivery safe and incremental.
 
+## Update 2026-03-04 (clear-search button wording clarity)
+
+Session timestamp:
+1. start: `2026-03-04 00:23:12 -0300`
+2. end: `2026-03-04 00:25:01 -0300`
+
+Delivered in this slice:
+1. `gui/gui_ssa.py`: changed clear-search button text from `Limpar Filtro` to `Limpar Busca`.
+2. `gui/gui_ssa.py`: added explicit tooltip clarifying that only general search is cleared.
+3. `tests/test_gui_filter_logic.py`: added regression `test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs`.
+
+Validation:
+1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py tests/test_gui_filter_logic.py`: pass
+2. `uv run --python 3.13 ruff check gui/gui_ssa.py tests/test_gui_filter_logic.py`: pass
+3. `uv run --python 3.13 ty check gui/gui_ssa.py tests/test_gui_filter_logic.py`: pass
+4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or test_clear_filter_clears_only_general_search_and_keeps_advanced_filters or test_clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
+5. kluster auto review run in this slice: clean -> clean
+
+Decision and scope:
+1. this is a low-risk `STABILITY_PATCH` for UX wording clarity only; no filter logic behavior change.
+2. local residues kept out of scope: `config/gui_main_preferences.json` and `stash@{0}`.
+3. evidence commit: `182c51b0` (`STABILITY_PATCH`: clear-search button wording clarity).
+
 ## Update 2026-03-04 (tooltip encoding fix and column-filter 3-button row)
 
 Session timestamp:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -3,6 +3,29 @@
 This file tracks post-merge hardening and cleanup for the recovery branch.
 Scope is split by priority to keep delivery safe and incremental.
 
+## Update 2026-03-04 (cross-tab sync for undo button state)
+
+Session timestamp:
+1. start: `2026-03-04 01:20:00 -0300`
+2. end: `2026-03-04 01:39:47 -0300`
+
+Delivered in this slice:
+1. `gui/mixins/filter_gui_ssa_mixin.py`: added centralized helpers to sync `undo_filter_btn` enabled-state across all tab contexts.
+2. `gui/mixins/filter_gui_ssa_mixin.py`: `_update_undo_button_state` now updates all tab undo buttons, not only active tab.
+3. `tests/test_gui_filter_logic.py`: added regression `test_undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore`.
+
+Validation:
+1. `uv run --python 3.13 python -m py_compile gui/mixins/filter_gui_ssa_mixin.py tests/test_gui_filter_logic.py`: pass
+2. `uv run --python 3.13 ruff check gui/mixins/filter_gui_ssa_mixin.py tests/test_gui_filter_logic.py`: pass
+3. `uv run --python 3.13 ty check gui/mixins/filter_gui_ssa_mixin.py tests/test_gui_filter_logic.py`: pass
+4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore or clear_advanced_filters_forces_refresh_when_pending_schedule or test_header_context_menu_apply_stores_undo_snapshot"`: `3 passed`
+5. kluster auto review run in this slice: clean
+
+Decision and scope:
+1. this is a `STABILITY_PATCH` for undo-state consistency and advanced-filter undo coverage.
+2. no layout/positioning changes.
+3. local residues kept out of scope: `config/gui_main_preferences.json` and `stash@{0}`.
+
 ## Update 2026-03-04 (cross-tab sync for clear-search button state)
 
 Session timestamp:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -3,6 +3,31 @@
 This file tracks post-merge hardening and cleanup for the recovery branch.
 Scope is split by priority to keep delivery safe and incremental.
 
+## Update 2026-03-04 (global clear baseline consistency in filter buttons)
+
+Session timestamp:
+1. start: `2026-03-04 00:00:27 -0300`
+2. end: `2026-03-04 00:07:25 -0300`
+
+Delivered in this slice:
+1. `gui/mixins/filter_gui_ssa_mixin.py`: `_clear_all_filters_global` now resets column filters using `_column_filter_default_columns()` instead of hardcoded subset.
+2. `tests/test_gui_filter_logic.py`: added regression `test_clear_all_filters_global_restores_default_column_filter_keys`.
+
+Validation:
+1. `uv run --python 3.13 python -m py_compile gui/mixins/filter_gui_ssa_mixin.py tests/test_gui_filter_logic.py`: pass
+2. `uv run --python 3.13 ruff check gui/mixins/filter_gui_ssa_mixin.py tests/test_gui_filter_logic.py`: pass
+3. `uv run --python 3.13 ty check gui/mixins/filter_gui_ssa_mixin.py tests/test_gui_filter_logic.py`: pass
+4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_all_filters_global_resets_full_filter_state_matrix or clear_all_filters_global_restores_default_column_filter_keys or clear_all_filters_global_resets_exclude_and_advanced_filters"`: `3 passed`
+5. kluster auto review run in this slice: clean
+
+Decision and scope:
+1. this is a `STABILITY_PATCH` to remove inconsistent reset behavior between related clear actions.
+2. runtime outside filter-clear path unchanged.
+3. local residues kept out of scope: `config/gui_main_preferences.json` and `stash@{0}`.
+
+Evidence commit:
+1. `98269107` (`STABILITY_PATCH`: global clear baseline consistency).
+
 ## Update 2026-03-03 (follow-up regression for header context-menu undo path)
 
 Session timestamp:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -3,6 +3,37 @@
 This file tracks post-merge hardening and cleanup for the recovery branch.
 Scope is split by priority to keep delivery safe and incremental.
 
+## Update 2026-03-03 (filter buttons stability hardening on feature branch)
+
+Session timestamp:
+1. start: `2026-03-03 23:46:42 -0300`
+2. end: `2026-03-03 23:53:25 -0300`
+
+Delivered in this slice:
+1. fixed high-risk stale async state after `clear_filter` by resetting request-scoped search markers in `gui/mixins/filter_gui_ssa_mixin.py`.
+2. raised effective general-search debounce floor to `1400 ms` in `gui/gui_ssa.py` to encourage explicit `Aplicar`.
+3. completed undo snapshot coverage for column filter activation/deactivation and header context-menu apply path.
+4. aligned help text to real column-filter controls (`Aplicar` + `Ocultar`) in `gui/widgets/filter_help_dialog.py`.
+5. added focused regressions in `tests/test_gui_filter_logic.py` for stale state clear path, debounce floor, and undo snapshots in column filter entry points.
+
+Validation:
+1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
+2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
+3. `uv run --python 3.13 ty check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
+4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter or debounce or activate_column_filter_stores_undo_snapshot or deactivate_column_filter_stores_undo_snapshot"`: `15 passed, 1 skipped`
+5. kluster auto review runs in this slice: clean -> clean -> clean -> clean
+
+Decision and scope:
+1. this is a `STABILITY_PATCH` focused on filter-state consistency and undo coverage with minimal behavioral changes.
+2. branch used by explicit approval: `codex/fix-filter-buttons-state-sync`.
+3. local residues kept out of scope: `config/gui_main_preferences.json` and `stash@{0}`.
+
+Deferred non-blocking:
+1. add a direct regression for the full Qt header context-menu interaction path that asserts undo snapshot behavior end-to-end (current coverage validates internal entry points and data path).
+
+Evidence commit:
+1. `2c7982b1` (`STABILITY_PATCH`: runtime + tests for filter-state hardening).
+
 ## Update 2026-03-03 (slice G targeted regression coverage for A/B/C)
 
 Session timestamp:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -3,6 +3,36 @@
 This file tracks post-merge hardening and cleanup for the recovery branch.
 Scope is split by priority to keep delivery safe and incremental.
 
+## Update 2026-03-04 (tooltip encoding fix and column-filter 3-button row)
+
+Session timestamp:
+1. start: `2026-03-04 00:08:50 -0300`
+2. end: `2026-03-04 00:14:10 -0300`
+
+Delivered in this slice:
+1. `gui/gui_ssa.py`: fixed corrupted week tooltip text and simplified to `Semana ISO atual`.
+2. `gui/mixins/filter_gui_ssa_mixin.py`: column-filter row now has `Aplicar`, `Limpar`, `Ocultar`.
+3. `gui/mixins/filter_gui_ssa_mixin.py`: `Limpar` clears current column value and reapplies filters without hiding the row.
+4. `gui/widgets/filter_help_dialog.py`: help text updated to reflect `Aplicar + Limpar + Ocultar`.
+5. `tests/test_gui_filter_logic.py`: updated control parser and added regression `test_column_filter_row_clear_button_clears_value_without_hiding_row`.
+
+Validation:
+1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
+2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
+3. `uv run --python 3.13 ty check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py gui/widgets/filter_help_dialog.py tests/test_gui_filter_logic.py`: pass
+4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "default_column_filter_rows_show_apply_clear_and_hide_buttons or column_filter_buttons_flow or column_filter_row_clear_button_clears_value_without_hiding_row or clear_all_filters_global_restores_default_column_filter_keys or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `5 passed`
+5. kluster auto review run in this slice: clean
+
+Diagnostic scan:
+1. global scan for mojibake patterns in `*.py` completed.
+2. no remaining mojibake pattern found in touched runtime/test files after this patch.
+3. legacy non-ASCII text still exists in historical scripts/tests; not all are encoding errors and broad normalization remains deferred to avoid high-risk transversal changes.
+
+Decision and scope:
+1. this is a `STABILITY_PATCH` focused on user-visible filter button behavior and encoding fix in GUI tooltip.
+2. no change in startup/import policy or out-of-scope modules.
+3. local residues kept out of scope: `config/gui_main_preferences.json` and `stash@{0}`.
+
 ## Update 2026-03-04 (global clear baseline consistency in filter buttons)
 
 Session timestamp:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -3,6 +3,31 @@
 This file tracks post-merge hardening and cleanup for the recovery branch.
 Scope is split by priority to keep delivery safe and incremental.
 
+## Update 2026-03-04 (tab-specific search handlers and regex guard hardening)
+
+Session timestamp:
+1. start: `2026-03-04 01:40:00 -0300`
+2. end: `2026-03-04 01:44:21 -0300`
+
+Delivered in this slice:
+1. `gui/gui_ssa.py`: search controls now route through dedicated per-tab handlers (`main`/`filters`) for `Aplicar` and `Limpar Busca`.
+2. `gui/mixins/filter_gui_ssa_mixin.py`: added dedicated handler methods `_on_general_search_apply_clicked` and `_on_general_search_clear_clicked`.
+3. `gui/mixins/filter_gui_ssa_mixin.py`: strengthened regex safety guard in `_build_column_mask` (`meta_char_count` and alternation+quantifier blocking).
+4. `tests/test_gui_filter_logic.py`: added regression `test_search_buttons_route_to_tab_specific_handlers`.
+5. `tests/test_gui_filter_logic.py`: added regression `test_build_column_mask_blocks_heavy_regex_patterns`.
+
+Validation:
+1. `uv run --python 3.13 python -m py_compile gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py tests/test_gui_filter_logic.py`: pass
+2. `uv run --python 3.13 ruff check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py tests/test_gui_filter_logic.py`: pass
+3. `uv run --python 3.13 ty check gui/gui_ssa.py gui/mixins/filter_gui_ssa_mixin.py tests/test_gui_filter_logic.py`: pass
+4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "search_buttons_route_to_tab_specific_handlers or clear_search_button_label_and_tooltip_are_explicit_on_both_tabs or clear_filter_button_state_syncs_across_tabs_without_switch or build_column_mask_blocks_heavy_regex_patterns"`: `4 passed`
+5. kluster auto review run in this slice: clean -> issue(P4 regex safety) -> clean
+
+Decision and scope:
+1. this is a `STABILITY_PATCH` focused on handler identity per tab and safety hardening for regex filter path.
+2. no layout/positioning change.
+3. local residues kept out of scope: `config/gui_main_preferences.json` and `stash@{0}`.
+
 ## Update 2026-03-04 (cross-tab sync for undo button state)
 
 Session timestamp:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -3,6 +3,40 @@
 This file tracks post-merge hardening and cleanup for the recovery branch.
 Scope is split by priority to keep delivery safe and incremental.
 
+## Update 2026-03-04 (PR #43 comments triage: real bugs fixed, noise deferred)
+
+Session timestamp:
+1. start: `2026-03-04 06:27:03 -0300`
+2. end: `2026-03-04 06:29:30 -0300`
+
+Delivered in this slice:
+1. `gui/mixins/filter_gui_ssa_mixin.py`: `_clear_all_filters_global` now resets OR-group metadata via `_reset_or_groups()`.
+2. `gui/mixins/filter_gui_ssa_mixin.py`: `_mk_remove_line` no longer uses broad silent `except Exception`.
+3. `gui/gui_ssa.py`: `debounce_delay` parsing now catches only `(TypeError, ValueError)` and logs explicit fallback.
+4. `gui/mixins/tab_context_gui_ssa_mixin.py`: removed duplicated `_sync_clear_filter_button_state()` call in bind flow.
+5. `tests/test_gui_filter_logic.py`: added regression `test_clear_all_filters_global_resets_or_group_metadata`.
+
+Validation:
+1. `uv run --python 3.13 python -m py_compile gui/mixins/filter_gui_ssa_mixin.py gui/mixins/tab_context_gui_ssa_mixin.py gui/gui_ssa.py tests/test_gui_filter_logic.py`: pass
+2. `uv run --python 3.13 ruff check gui/mixins/filter_gui_ssa_mixin.py gui/mixins/tab_context_gui_ssa_mixin.py gui/gui_ssa.py tests/test_gui_filter_logic.py`: pass
+3. `uv run --python 3.13 ty check gui/mixins/filter_gui_ssa_mixin.py gui/mixins/tab_context_gui_ssa_mixin.py gui/gui_ssa.py tests/test_gui_filter_logic.py`: pass
+4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_all_filters_global_resets_or_group_metadata or clear_all_filters_global_resets_full_filter_state_matrix or clear_all_filters_global_restores_default_column_filter_keys or clear_filter_button_state_syncs_across_tabs_without_switch or undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore"`: `5 passed`
+5. kluster auto review run in this slice: clean -> clean -> clean -> clean
+
+PR comment status mapping:
+1. fixed now (`BUG_REAL`): stale OR-group metadata after global clear.
+2. fixed now (`BUG_REAL`): broad/no-log fallback in debounce parse.
+3. fixed now (`BUG_REAL`): silent broad `except` in `_mk_remove_line`.
+4. fixed now (`BUG_REAL`): duplicated cross-tab clear-button sync call in bind.
+5. deferred (`DECISAO_INTENCIONAL`): make debounce floor configurable now; current fixed floor is approved policy for this lane.
+6. deferred (`NAO_BLOQUEANTE_DEFERIDO`): wide cleanup of broad `except` patterns across legacy GUI path (outside this minimal slice).
+7. rejected (`FALSO_POSITIVO`): speculative suggestions with weak/no anchored evidence (regex over-restriction claims without reproducible regression).
+
+Decision and scope:
+1. this is a `STABILITY_PATCH` focused on real, reproducible PR findings only.
+2. no layout/positioning changes.
+3. local residues kept out of scope: `config/gui_main_preferences.json` and `stash@{0}`.
+
 ## Update 2026-03-04 (tab-specific search handlers and regex guard hardening)
 
 Session timestamp:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -3,6 +3,29 @@
 This file tracks post-merge hardening and cleanup for the recovery branch.
 Scope is split by priority to keep delivery safe and incremental.
 
+## Update 2026-03-04 (cross-tab sync for clear-search button state)
+
+Session timestamp:
+1. start: `2026-03-04 00:27:39 -0300`
+2. end: `2026-03-04 01:02:15 -0300`
+
+Delivered in this slice:
+1. `gui/mixins/filter_gui_ssa_mixin.py`: added central helpers to sync `clear_filter_button` state across all tab contexts.
+2. `gui/mixins/filter_gui_ssa_mixin.py`: replaced single-widget `clear_filter_button.setEnabled(...)` calls with shared cross-tab sync.
+3. `gui/mixins/tab_context_gui_ssa_mixin.py`: bind step now uses shared clear-button sync method.
+4. `tests/test_gui_filter_logic.py`: added regression `test_clear_filter_button_state_syncs_across_tabs_without_switch`.
+
+Validation:
+1. `uv run --python 3.13 python -m py_compile gui/mixins/filter_gui_ssa_mixin.py gui/mixins/tab_context_gui_ssa_mixin.py tests/test_gui_filter_logic.py`: pass
+2. `uv run --python 3.13 ruff check gui/mixins/filter_gui_ssa_mixin.py gui/mixins/tab_context_gui_ssa_mixin.py tests/test_gui_filter_logic.py`: pass
+3. `uv run --python 3.13 ty check gui/mixins/filter_gui_ssa_mixin.py gui/mixins/tab_context_gui_ssa_mixin.py tests/test_gui_filter_logic.py`: pass
+4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "clear_filter_button_state_syncs_across_tabs_without_switch or clear_filter_button_reflects_active_filters or clear_filter_on_filters_tab_clears_search_in_all_tabs"`: `3 passed`
+5. kluster auto review run in this slice: clean
+
+Decision and scope:
+1. this is a `STABILITY_PATCH` for state consistency only; no layout or positioning change.
+2. local residues kept out of scope: `config/gui_main_preferences.json` and `stash@{0}`.
+
 ## Update 2026-03-04 (clear-search button wording clarity)
 
 Session timestamp:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -3,6 +3,30 @@
 This file tracks post-merge hardening and cleanup for the recovery branch.
 Scope is split by priority to keep delivery safe and incremental.
 
+## Update 2026-03-03 (follow-up regression for header context-menu undo path)
+
+Session timestamp:
+1. start: `2026-03-03 23:55:05 -0300`
+2. end: `2026-03-03 23:59:04 -0300`
+
+Delivered in this slice:
+1. added direct regression in `tests/test_gui_filter_logic.py` to validate header context-menu apply path stores undo snapshot end-to-end.
+
+Validation:
+1. `uv run --python 3.13 python -m py_compile tests/test_gui_filter_logic.py`: pass
+2. `uv run --python 3.13 ruff check tests/test_gui_filter_logic.py`: pass
+3. `uv run --python 3.13 ty check tests/test_gui_filter_logic.py`: pass
+4. `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "test_header_context_menu_apply_stores_undo_snapshot"`: `1 passed`
+5. kluster auto review run in this slice: clean
+
+Decision and scope:
+1. this is a test-only `STABILITY_PATCH` follow-up to close previously deferred coverage gap.
+2. runtime behavior unchanged in this slice.
+3. local residues kept out of scope: `config/gui_main_preferences.json` and `stash@{0}`.
+
+Evidence commit:
+1. `22bbd3dc` (`STABILITY_PATCH`: header context-menu undo regression test).
+
 ## Update 2026-03-03 (filter buttons stability hardening on feature branch)
 
 Session timestamp:

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -1172,12 +1172,18 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
             search_input.setMinimumHeight(26)
         except Exception as exc:
             logger.debug("Falha ao aplicar altura minima no campo de pesquisa: %s", exc)
-        search_input.returnPressed.connect(self.initiate_filtering)
+        search_input.returnPressed.connect(
+            lambda tab=tab_kind: self._on_general_search_apply_clicked(tab)
+        )
         search_input.textChanged.connect(self._on_search_text_changed)
         search_button = QPushButton("Aplicar")
-        search_button.clicked.connect(self.initiate_filtering)
+        search_button.clicked.connect(
+            lambda _checked=False, tab=tab_kind: self._on_general_search_apply_clicked(tab)
+        )
         clear_filter_button = QPushButton("Limpar Busca")
-        clear_filter_button.clicked.connect(self.clear_filter)
+        clear_filter_button.clicked.connect(
+            lambda _checked=False, tab=tab_kind: self._on_general_search_clear_clicked(tab)
+        )
         clear_filter_button.setToolTip(
             "Limpa apenas a busca geral. Filtros de coluna e avancados continuam ativos."
         )

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -983,9 +983,13 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
         debounce_delay = gui_settings.get("debounce_delay", 250)
         try:
             debounce_delay = int(debounce_delay)
-        except Exception:
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "Valor invalido para debounce_delay nas preferencias (%s); usando fallback 250 ms.",
+                exc,
+            )
             debounce_delay = 250
-        minimum_search_debounce_ms = 1400
+        minimum_search_debounce_ms = 1400  # ms
         if debounce_delay < minimum_search_debounce_ms:
             debounce_delay = minimum_search_debounce_ms
         self._debounce_timer = QTimer(self)

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -978,8 +978,16 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
         # Larguras salvas por coluna (das configurações JSON) - mantido para compatibilidade
         self._saved_gui_column_widths = GUI_MAIN_PREFERENCES.get("column_widths", {}).copy()
 
-        # Debounce de filtro (da configuraçção JSON)
+        # Debounce de filtro (da configuracao JSON).
+        # Mantemos um piso para incentivar uso do botao "Aplicar" sem remover debounce.
         debounce_delay = gui_settings.get("debounce_delay", 250)
+        try:
+            debounce_delay = int(debounce_delay)
+        except Exception:
+            debounce_delay = 250
+        minimum_search_debounce_ms = 1400
+        if debounce_delay < minimum_search_debounce_ms:
+            debounce_delay = minimum_search_debounce_ms
         self._debounce_timer = QTimer(self)
         self._debounce_timer.setSingleShot(True)
         self._debounce_timer.setInterval(debounce_delay)
@@ -2147,7 +2155,10 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
                 else:
                     term = self.search_input.text().strip()
                 if term is not None:
-                    self._active_column_filters[col_name] = str(term).strip()
+                    normalized_term = str(term).strip()
+                    if str(self._active_column_filters.get(col_name, "")).strip() != normalized_term:
+                        self._safe_store_last_filter_state("header_context_apply_column_filter")
+                    self._active_column_filters[col_name] = normalized_term
                     self._mark_profile_as_custom()
                     self._build_column_filters_panel()
                     self._refresh_after_filter_change()

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -1176,8 +1176,11 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
         search_input.textChanged.connect(self._on_search_text_changed)
         search_button = QPushButton("Aplicar")
         search_button.clicked.connect(self.initiate_filtering)
-        clear_filter_button = QPushButton("Limpar Filtro")
+        clear_filter_button = QPushButton("Limpar Busca")
         clear_filter_button.clicked.connect(self.clear_filter)
+        clear_filter_button.setToolTip(
+            "Limpa apenas a busca geral. Filtros de coluna e avancados continuam ativos."
+        )
         clear_filter_button.setEnabled(False)
         left.addWidget(cast(Any, search_label))
         left.addWidget(cast(Any, search_input))

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -1050,7 +1050,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
         )
         self.update_derivadas_button.clicked.connect(self.update_derivadas_from_sources)
         toolbar_layout.addWidget(cast(Any, self.update_derivadas_button))
-        # Semana Atual (YYYYWW) ao lado de 'Abrir Pasta' (informativo, nção clicãvel)
+        # Semana Atual (YYYYWW) ao lado de 'Abrir Pasta' (informativo)
         try:
             from datetime import date
             y, w, _ = date.today().isocalendar()
@@ -1063,7 +1063,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
             "font-weight:600; border:1px solid palette(mid); border-radius:4px; padding:2px 6px;"
         )
         self.week_label.setStyleSheet(self._week_label_style)
-        self.week_label.setToolTip("Semana ISO atual (nção clicãvel)")
+        self.week_label.setToolTip("Semana ISO atual")
         toolbar_layout.addSpacing(6)
         toolbar_layout.addWidget(cast(Any, self.week_label))
 

--- a/gui/mixins/filter_gui_ssa_mixin.py
+++ b/gui/mixins/filter_gui_ssa_mixin.py
@@ -1308,11 +1308,10 @@ class FilterGUISSAMixin:
         self._pending_search_display = None
         self._df_last_search_filtered = pd.DataFrame()
 
-        # Limpar todos os filtros de coluna
-        if self._active_column_filters:
-            self._active_column_filters.clear()
-            for k in ("situacao", "setor_executor", "descricao_ssa"):
-                self._active_column_filters[k] = ""
+        # Limpar todos os filtros de coluna com o mesmo baseline padrao
+        self._active_column_filters = OrderedDict(
+            (col, "") for col in self._column_filter_default_columns()
+        )
 
         # Limpar filtros auxiliares/avancados
         self._exclude_ste_sca = False

--- a/gui/mixins/filter_gui_ssa_mixin.py
+++ b/gui/mixins/filter_gui_ssa_mixin.py
@@ -1000,7 +1000,7 @@ class FilterGUISSAMixin:
                 display_text = str(term)
             term_box = QLineEdit(display_text)
             self._column_filter_inputs[col] = term_box
-            # Placeholder sem conectivos OU/AND — OR agora é dedicado
+            # Placeholder sem conectivos OU/AND - OR agora e dedicado
             term_box.setPlaceholderText("Separe termos por vírgulas. Modos: foo, ^pre, suf$, =exato, ~regex, !neg")
             # Reduzido para garantir visibilidade dos botões em telas estreitas
             term_box.setMinimumWidth(220)
@@ -1049,45 +1049,94 @@ class FilterGUISSAMixin:
                         logger.debug("Falha ao atualizar botao limpar apos aplicar filtro de coluna %s: %s", c, exc)
                 return _inner
             apply_btn.clicked.connect(_mk_apply())
-            # Botao para ocultar a linha da exibicao (nao altera o valor do filtro)
-            clear_btn = QPushButton("Ocultar")
+            # Botao Limpar remove o valor do filtro, mas mantem a linha visivel.
+            clear_btn = QPushButton("Limpar")
             try:
                 clear_btn.setMinimumHeight(26)
             except Exception as exc:
-                logger.debug("Falha ao aplicar altura minima no botao Ocultar da coluna %s: %s", col, exc)
+                logger.debug("Falha ao aplicar altura minima no botao Limpar da coluna %s: %s", col, exc)
             try:
                 clear_btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
             except Exception as exc:
+                logger.debug("Falha ao aplicar size policy no botao Limpar da coluna %s: %s", col, exc)
+            try:
+                clear_btn.setFixedWidth(66)
+            except Exception as exc:
+                logger.debug("Falha ao aplicar largura fixa no botao Limpar da coluna %s: %s", col, exc)
+            try:
+                clear_btn.setToolTip("Limpa o valor desta coluna e reaplica os filtros.")
+            except Exception as exc:
+                logger.debug("Falha ao aplicar tooltip no botao Limpar da coluna %s: %s", col, exc)
+
+            def _mk_clear_value(c=col, tb=term_box):
+                def _inner():
+                    current_text = str(self._active_column_filters.get(c, "")).strip()
+                    typed_text = str(tb.text()).strip()
+                    if not current_text and not typed_text:
+                        return
+                    self._safe_store_last_filter_state("clear_column_filter_value")
+                    self._active_column_filters[c] = ""
+                    self._sync_or_group_values(c, "")
+                    try:
+                        tb.blockSignals(True)
+                        tb.setText("")
+                    finally:
+                        try:
+                            tb.blockSignals(False)
+                        except Exception as exc:
+                            logger.debug("Falha ao reativar sinais no input apos limpar coluna %s: %s", c, exc)
+                    self._mark_profile_as_custom()
+                    self._build_column_filters_panel()
+                    self._refresh_after_filter_change()
+                    try:
+                        if hasattr(self, "clear_filter_button"):
+                            self.clear_filter_button.setEnabled(self._has_any_active_filters())
+                    except Exception as exc:
+                        logger.debug("Falha ao atualizar botao limpar apos limpar valor da coluna %s: %s", c, exc)
+                return _inner
+            try:
+                clear_btn.clicked.connect(_mk_clear_value())
+            except Exception as exc:
+                logger.debug("Falha ao conectar botao limpar para filtro de coluna %s: %s", col, exc)
+
+            # Botao para ocultar a linha da exibicao (nao altera o valor do filtro)
+            hide_btn = QPushButton("Ocultar")
+            try:
+                hide_btn.setMinimumHeight(26)
+            except Exception as exc:
+                logger.debug("Falha ao aplicar altura minima no botao Ocultar da coluna %s: %s", col, exc)
+            try:
+                hide_btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+            except Exception as exc:
                 logger.debug("Falha ao aplicar size policy no botao Ocultar da coluna %s: %s", col, exc)
             try:
-                clear_btn.setFixedWidth(66)  # Padronizado com o botao Aplicar
+                hide_btn.setFixedWidth(66)
             except Exception as exc:
                 logger.debug("Falha ao aplicar largura fixa no botao Ocultar da coluna %s: %s", col, exc)
             try:
-                clear_btn.setToolTip("Oculta a linha. O filtro desta coluna continua ativo.")
+                hide_btn.setToolTip("Oculta a linha. O filtro desta coluna continua ativo.")
             except Exception as exc:
                 logger.debug("Falha ao aplicar tooltip no botao Ocultar da coluna %s: %s", col, exc)
-            
+
             def _mk_remove_line(c=col):
                 def _inner():
                     try:
                         self._hidden_column_filter_lines.add(c)
                     except Exception:
                         self._hidden_column_filter_lines = {c}
-                    # Não altera self._active_column_filters[c]
                     self._build_column_filters_panel()
-                    # Não refiltra; apenas exibição
                 return _inner
             try:
-                clear_btn.clicked.connect(_mk_remove_line())
+                hide_btn.clicked.connect(_mk_remove_line())
             except Exception as exc:
                 logger.debug("Falha ao conectar botao ocultar para filtro de coluna %s: %s", col, exc)
-            # Oculta o botão para colunas fixas que não devem ser removidas da exibição
+
             row.addWidget(name_lbl)
             row.addWidget(term_box, 1)
             row.addWidget(apply_btn)
             row.addWidget(clear_btn)
-            # Layout order: label, input, Aplicar, Ocultar (OU button removed - only commas needed)
+            row.addWidget(hide_btn)
+            # Layout order: label, input, Aplicar, Limpar, Ocultar
             row_w = QWidget()
             row_w.setLayout(row)
             target_layout.addWidget(row_w)

--- a/gui/mixins/filter_gui_ssa_mixin.py
+++ b/gui/mixins/filter_gui_ssa_mixin.py
@@ -64,6 +64,7 @@ from utils.robust_logging import get_robust_logger
 logger = get_robust_logger().get_logger(__name__, "gui")
 _NESTED_QUANTIFIER_RE = re.compile(r"\((?:[^()]*[+*][^()]*)\)\s*[+*{]")
 _HEAVY_QUANTIFIER_CHAIN_RE = re.compile(r"(?:[+*]|\{[^}]*\}){3,}")
+_REGEX_META_CHAR_RE = re.compile(r"[*+?{}|()[\]]")
 
 
 def _qt_parent(obj: Any) -> QWidget | None:
@@ -327,6 +328,14 @@ class FilterGUISSAMixin:
                 self.filter_thread = None
         if reason:
             logger.debug("Worker anterior cancelado (%s)", reason)
+
+    def _on_general_search_apply_clicked(self, tab_kind: str) -> None:
+        logger.debug("Acao aplicar busca geral acionada (tab_kind=%s)", tab_kind)
+        self.initiate_filtering()
+
+    def _on_general_search_clear_clicked(self, tab_kind: str) -> None:
+        logger.debug("Acao limpar busca geral acionada (tab_kind=%s)", tab_kind)
+        self.clear_filter()
 
     def initiate_filtering(self):
         if self.df_completo.empty:
@@ -2303,12 +2312,16 @@ class FilterGUISSAMixin:
                 return pd.Series([True] * len(s), index=s.index)
             has_lookaround = "(?=" in pattern_text or "(?!" in pattern_text or "(?<=" in pattern_text or "(?<!" in pattern_text
             has_backref = bool(re.search(r"\\[1-9]", pattern_text))
+            meta_char_count = len(_REGEX_META_CHAR_RE.findall(pattern_text))
+            has_alternation_with_quantifier = "|" in pattern_text and bool(re.search(r"[+*?{]", pattern_text))
             if (
                 len(pattern_text) > 120
                 or _NESTED_QUANTIFIER_RE.search(pattern_text)
                 or _HEAVY_QUANTIFIER_CHAIN_RE.search(pattern_text)
                 or has_lookaround
                 or has_backref
+                or meta_char_count > 16
+                or has_alternation_with_quantifier
             ):
                 logger.warning("Regex de filtro bloqueado por seguranca; usando busca literal.")
                 return s.str.contains(pattern_text, case=False, na=False, regex=False)

--- a/gui/mixins/filter_gui_ssa_mixin.py
+++ b/gui/mixins/filter_gui_ssa_mixin.py
@@ -224,6 +224,38 @@ class FilterGUISSAMixin:
             has_advanced = False
         return bool(has_search or has_column_filters or has_exclude_ste or has_advanced)
 
+    def _iter_clear_filter_buttons(self):
+        seen_ids = set()
+        direct_button = getattr(self, "clear_filter_button", None)
+        if direct_button is not None:
+            seen_ids.add(id(direct_button))
+            yield direct_button
+        tab_contexts = getattr(self, "_tab_contexts", None)
+        if not isinstance(tab_contexts, list):
+            return
+        for ctx in tab_contexts:
+            if not isinstance(ctx, dict):
+                continue
+            button = ctx.get("clear_filter_button")
+            if button is None:
+                continue
+            button_id = id(button)
+            if button_id in seen_ids:
+                continue
+            seen_ids.add(button_id)
+            yield button
+
+    def _set_clear_filter_buttons_enabled(self, enabled: bool) -> None:
+        target_state = bool(enabled)
+        for button in self._iter_clear_filter_buttons():
+            try:
+                button.setEnabled(target_state)
+            except Exception as exc:
+                logger.debug("Falha ao sincronizar estado de botao limpar em contexto de aba: %s", exc)
+
+    def _sync_clear_filter_button_state(self) -> None:
+        self._set_clear_filter_buttons_enabled(self._has_any_active_filters())
+
     def _set_filter_ui_idle(self) -> None:
         """Garante estado visual de ociosidade após abortar/limpar filtros."""
         try:
@@ -285,8 +317,7 @@ class FilterGUISSAMixin:
         # remove empty chunk lists
         chunk_terms_lists = [terms for terms in chunk_terms_lists if terms]
 
-        if hasattr(self, 'clear_filter_button'):
-            self.clear_filter_button.setEnabled(self._has_any_active_filters())
+        self._sync_clear_filter_button_state()
 
         if chunk_terms_lists:
             display_text = self._format_search_display(chunk_terms_lists)
@@ -443,8 +474,7 @@ class FilterGUISSAMixin:
             filtered_total=filtered_total_current,
             original_total=len(self.df_completo) if hasattr(self, "df_completo") and self.df_completo is not None else None,
         )
-        if hasattr(self, 'clear_filter_button'):
-            self.clear_filter_button.setEnabled(self._has_any_active_filters())
+        self._sync_clear_filter_button_state()
         self._apply_search_display()
         table_widget = getattr(self, "table_widget", None)
         table_widget_valid = _is_search_widget_valid(table_widget)
@@ -687,11 +717,7 @@ class FilterGUISSAMixin:
         self._df_last_search_filtered = self.df_completo.copy()
         self._refresh_after_filter_change()
         self._set_filtered_count_status("")
-        try:
-            if hasattr(self, 'clear_filter_button'):
-                self.clear_filter_button.setEnabled(self._has_any_active_filters())
-        except Exception as exc:
-            logger.debug("Falha ao atualizar estado do botao limpar filtro: %s", exc)
+        self._sync_clear_filter_button_state()
         # Atualizar resumo de filtros
         try:
             self._update_filters_summary()
@@ -1042,11 +1068,7 @@ class FilterGUISSAMixin:
                     self._mark_profile_as_custom()
                     self._build_column_filters_panel()
                     self._refresh_after_filter_change()
-                    try:
-                        if hasattr(self, "clear_filter_button"):
-                            self.clear_filter_button.setEnabled(self._has_any_active_filters())
-                    except Exception as exc:
-                        logger.debug("Falha ao atualizar botao limpar apos aplicar filtro de coluna %s: %s", c, exc)
+                    self._sync_clear_filter_button_state()
                 return _inner
             apply_btn.clicked.connect(_mk_apply())
             # Botao Limpar remove o valor do filtro, mas mantem a linha visivel.
@@ -1088,11 +1110,7 @@ class FilterGUISSAMixin:
                     self._mark_profile_as_custom()
                     self._build_column_filters_panel()
                     self._refresh_after_filter_change()
-                    try:
-                        if hasattr(self, "clear_filter_button"):
-                            self.clear_filter_button.setEnabled(self._has_any_active_filters())
-                    except Exception as exc:
-                        logger.debug("Falha ao atualizar botao limpar apos limpar valor da coluna %s: %s", c, exc)
+                    self._sync_clear_filter_button_state()
                 return _inner
             try:
                 clear_btn.clicked.connect(_mk_clear_value())
@@ -1248,11 +1266,7 @@ class FilterGUISSAMixin:
             self._mark_profile_as_custom()
             self._build_column_filters_panel()
             self._refresh_after_filter_change()
-            try:
-                if hasattr(self, "clear_filter_button"):
-                    self.clear_filter_button.setEnabled(self._has_any_active_filters())
-            except Exception as exc:
-                logger.debug("Falha ao atualizar botao limpar apos limpar filtro de coluna %s: %s", col_name, exc)
+            self._sync_clear_filter_button_state()
 
 
     def _clear_all_column_filters(self):
@@ -1278,11 +1292,7 @@ class FilterGUISSAMixin:
         self._mark_profile_as_custom()
         self._build_column_filters_panel()
         self._refresh_after_filter_change()
-        try:
-            if hasattr(self, "clear_filter_button"):
-                self.clear_filter_button.setEnabled(self._has_any_active_filters())
-        except Exception as exc:
-            logger.debug("Falha ao atualizar botao limpar apos limpar todos filtros de coluna: %s", exc)
+        self._sync_clear_filter_button_state()
 
 
     def _on_exclude_ste_sca_toggled(self, checked: bool):
@@ -1410,8 +1420,7 @@ class FilterGUISSAMixin:
 
         # Atualizar interface
         self._set_filtered_count_status("")
-        if hasattr(self, 'clear_filter_button'):
-            self.clear_filter_button.setEnabled(self._has_any_active_filters())
+        self._sync_clear_filter_button_state()
 
         # Atualizar resumo de filtros
         self._update_filters_summary()
@@ -1823,11 +1832,7 @@ class FilterGUISSAMixin:
             self._update_filters_summary()
         except Exception as exc:
             logger.debug("Falha ao atualizar resumo de filtros no refresh: %s", exc)
-        try:
-            if hasattr(self, "clear_filter_button"):
-                self.clear_filter_button.setEnabled(self._has_any_active_filters())
-        except Exception as exc:
-            logger.debug("Falha ao atualizar estado do botao limpar no refresh de filtros: %s", exc)
+        self._sync_clear_filter_button_state()
         try:
             self._set_filtered_count_status(str(getattr(self, "_pending_search_display", "") or ""))
         except Exception as exc:
@@ -1959,10 +1964,7 @@ class FilterGUISSAMixin:
                 self._update_filters_summary()
             except Exception as exc:
                 logger.debug("Falha ao atualizar resumo de filtros no restore: %s", exc)
-            try:
-                self.clear_filter_button.setEnabled(self._has_any_active_filters())
-            except Exception as exc:
-                logger.debug("Falha ao atualizar estado do botao limpar no restore: %s", exc)
+            self._sync_clear_filter_button_state()
             selector = getattr(self, 'profile_selector', None)
             if selector is not None:
                 idx = selector.findData(self.current_filter_profile) if self.current_filter_profile else selector.findData(None)

--- a/gui/mixins/filter_gui_ssa_mixin.py
+++ b/gui/mixins/filter_gui_ssa_mixin.py
@@ -680,6 +680,8 @@ class FilterGUISSAMixin:
                 except Exception as unblock_exc:
                     logger.debug("Falha ao reativar sinais do campo de busca apos clear_filter: %s", unblock_exc)
         self._pending_search_display = None
+        self._active_filter_search_display = ""
+        self._active_filter_search_request_id = None
         # Nao limpa filtros avancados nem filtros de coluna aqui.
         # Esse botao limpa apenas a busca geral; limpeza global usa "_clear_all_filters_global".
         self._df_last_search_filtered = self.df_completo.copy()
@@ -888,6 +890,7 @@ class FilterGUISSAMixin:
         if not col_name:
             return
         if col_name not in self._active_column_filters:
+            self._safe_store_last_filter_state("activate_column_filter")
             self._active_column_filters[col_name] = ""
             try:
                 self._mark_profile_as_custom()
@@ -902,6 +905,9 @@ class FilterGUISSAMixin:
         """Remove coluna do conjunto de filtros ativos e atualiza a interface."""
         if not col_name:
             return
+        if col_name not in self._active_column_filters and col_name not in self._column_to_or_group:
+            return
+        self._safe_store_last_filter_state("deactivate_column_filter")
         removed = False
         if col_name in self._column_to_or_group:
             group = self._column_to_or_group.get(col_name)

--- a/gui/mixins/filter_gui_ssa_mixin.py
+++ b/gui/mixins/filter_gui_ssa_mixin.py
@@ -1176,10 +1176,11 @@ class FilterGUISSAMixin:
 
             def _mk_remove_line(c=col):
                 def _inner():
-                    try:
-                        self._hidden_column_filter_lines.add(c)
-                    except Exception:
-                        self._hidden_column_filter_lines = {c}
+                    hidden_lines = getattr(self, "_hidden_column_filter_lines", None)
+                    if not isinstance(hidden_lines, set):
+                        hidden_lines = set()
+                        self._hidden_column_filter_lines = hidden_lines
+                    hidden_lines.add(c)
                     self._build_column_filters_panel()
                 return _inner
             try:
@@ -1409,6 +1410,7 @@ class FilterGUISSAMixin:
         self._active_column_filters = OrderedDict(
             (col, "") for col in self._column_filter_default_columns()
         )
+        self._reset_or_groups()
 
         # Limpar filtros auxiliares/avancados
         self._exclude_ste_sca = False

--- a/gui/mixins/filter_gui_ssa_mixin.py
+++ b/gui/mixins/filter_gui_ssa_mixin.py
@@ -256,6 +256,35 @@ class FilterGUISSAMixin:
     def _sync_clear_filter_button_state(self) -> None:
         self._set_clear_filter_buttons_enabled(self._has_any_active_filters())
 
+    def _iter_undo_filter_buttons(self):
+        seen_ids = set()
+        direct_button = getattr(self, "undo_filter_btn", None)
+        if direct_button is not None:
+            seen_ids.add(id(direct_button))
+            yield direct_button
+        tab_contexts = getattr(self, "_tab_contexts", None)
+        if not isinstance(tab_contexts, list):
+            return
+        for ctx in tab_contexts:
+            if not isinstance(ctx, dict):
+                continue
+            button = ctx.get("undo_filter_btn")
+            if button is None:
+                continue
+            button_id = id(button)
+            if button_id in seen_ids:
+                continue
+            seen_ids.add(button_id)
+            yield button
+
+    def _set_undo_filter_buttons_enabled(self, enabled: bool) -> None:
+        target_state = bool(enabled)
+        for button in self._iter_undo_filter_buttons():
+            try:
+                button.setEnabled(target_state)
+            except Exception as exc:
+                logger.debug("Falha ao sincronizar estado de botao undo em contexto de aba: %s", exc)
+
     def _set_filter_ui_idle(self) -> None:
         """Garante estado visual de ociosidade após abortar/limpar filtros."""
         try:
@@ -1980,13 +2009,7 @@ class FilterGUISSAMixin:
 
 
     def _update_undo_button_state(self) -> None:
-        btn = getattr(self, "undo_filter_btn", None)
-        if btn is None:
-            return
-        try:
-            btn.setEnabled(bool(getattr(self, "_last_filter_state", None)))
-        except Exception as exc:
-            logger.debug("Falha ao atualizar estado do botao de desfazer filtros: %s", exc)
+        self._set_undo_filter_buttons_enabled(bool(getattr(self, "_last_filter_state", None)))
 
 
     def _apply_search_display(self):

--- a/gui/mixins/tab_context_gui_ssa_mixin.py
+++ b/gui/mixins/tab_context_gui_ssa_mixin.py
@@ -60,7 +60,7 @@ class TabContextGUISSAMixin:
 
     def _sync_bind_search_state(self: _TabContextHostProtocol, ctx: dict) -> None:
         try:
-            self.clear_filter_button.setEnabled(self._has_any_active_filters())
+            self._sync_clear_filter_button_state()
         except Exception as exc:
             logger.debug("Falha ao sincronizar estado do botao limpar filtro no bind de aba: %s", exc)
         try:
@@ -76,7 +76,7 @@ class TabContextGUISSAMixin:
         except Exception as exc:
             logger.debug("Falha ao sincronizar busca durante bind da aba de filtros: %s", exc)
         try:
-            self.clear_filter_button.setEnabled(self._has_any_active_filters())
+            self._sync_clear_filter_button_state()
         except Exception as exc:
             logger.debug("Falha ao atualizar estado do botao limpar apos bind de aba: %s", exc)
 

--- a/gui/mixins/tab_context_gui_ssa_mixin.py
+++ b/gui/mixins/tab_context_gui_ssa_mixin.py
@@ -60,10 +60,6 @@ class TabContextGUISSAMixin:
 
     def _sync_bind_search_state(self: _TabContextHostProtocol, ctx: dict) -> None:
         try:
-            self._sync_clear_filter_button_state()
-        except Exception as exc:
-            logger.debug("Falha ao sincronizar estado do botao limpar filtro no bind de aba: %s", exc)
-        try:
             if ctx.get("tab_kind") == "filters":
                 try:
                     debounce_timer = self._debounce_timer

--- a/gui/widgets/filter_help_dialog.py
+++ b/gui/widgets/filter_help_dialog.py
@@ -55,7 +55,7 @@ class FilterHelpDialog(QDialog):
               <li><code>=NULL</code> — somente campos vazios/nulos</li>
             </ul>
             <h4>Filtro por coluna</h4>
-            <p>Abra o menu com <b>clique direito</b> no titulo da coluna. O painel a direita mostra os filtros por coluna com botoes <b>Aplicar</b> e <b>Limpar</b>. Regras identicas as do filtro geral.</p>
+            <p>Abra o menu com <b>clique direito</b> no titulo da coluna. O painel a direita mostra os filtros por coluna com botoes <b>Aplicar</b> e <b>Ocultar</b> (oculta a linha sem limpar o valor ativo). Regras identicas as do filtro geral.</p>
             <h4>Dicas</h4>
             <ul>
               <li>Nao diferencia maiusculas/minusculas</li>

--- a/gui/widgets/filter_help_dialog.py
+++ b/gui/widgets/filter_help_dialog.py
@@ -48,14 +48,14 @@ class FilterHelpDialog(QDialog):
             <p><i>Nota:</i> Nao e possivel marcar o mesmo valor em ambas as colunas simultaneamente.</p>
             <h4>Exemplos</h4>
             <ul>
-              <li><code>mel3</code> — procura por MEL3</li>
-              <li><code>pendente, programar</code> — termos combinados</li>
-              <li><code>executada, !mel4</code> — exclui MEL4</li>
-              <li><code>g076, amp</code> — combina setores</li>
-              <li><code>=NULL</code> — somente campos vazios/nulos</li>
+              <li><code>mel3</code> - procura por MEL3</li>
+              <li><code>pendente, programar</code> - termos combinados</li>
+              <li><code>executada, !mel4</code> - exclui MEL4</li>
+              <li><code>g076, amp</code> - combina setores</li>
+              <li><code>=NULL</code> - somente campos vazios/nulos</li>
             </ul>
             <h4>Filtro por coluna</h4>
-            <p>Abra o menu com <b>clique direito</b> no titulo da coluna. O painel a direita mostra os filtros por coluna com botoes <b>Aplicar</b> e <b>Ocultar</b> (oculta a linha sem limpar o valor ativo). Regras identicas as do filtro geral.</p>
+            <p>Abra o menu com <b>clique direito</b> no titulo da coluna. O painel a direita mostra os filtros por coluna com botoes <b>Aplicar</b>, <b>Limpar</b> e <b>Ocultar</b>. Regras identicas as do filtro geral.</p>
             <h4>Dicas</h4>
             <ul>
               <li>Nao diferencia maiusculas/minusculas</li>

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -521,6 +521,16 @@ class TestGUIFilterLogic:
         assert self.window.search_input.text() == ''
         assert self.window.clear_filter_button.isEnabled() is False
 
+    def test_clear_search_button_label_and_tooltip_are_explicit_on_both_tabs(self):
+        for ctx in self.window._tab_contexts:
+            button = ctx.get("clear_filter_button")
+            assert button is not None
+            assert button.text() == "Limpar Busca"
+            tooltip = str(button.toolTip() or "").casefold()
+            assert "apenas a busca geral" in tooltip
+            assert "coluna" in tooltip
+            assert "avancados" in tooltip
+
     def test_clear_filter_clears_only_general_search_and_keeps_advanced_filters(self):
         self.window._advanced_filters = {"situacao": ["STE"], "setor_executor": ["IEE3"]}
         self.window._advanced_filters_active = True

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -649,6 +649,32 @@ class TestGUIFilterLogic:
         assert self.window._active_column_filters['setor_executor'] == 'IEE3, MEL4'
         assert self.window._active_column_filters['setor_emissor'] == 'IEE3, MEL4'
 
+    def test_activate_column_filter_stores_undo_snapshot(self):
+        self.window._last_filter_state = None
+        self.window.search_input.setText("Marca")
+        QApplication.processEvents()
+
+        self.window._activate_column_filter("coluna_temporaria_teste")
+        QApplication.processEvents()
+
+        assert self.window._last_filter_state is not None
+        snapshot = self.window._last_filter_state
+        assert snapshot.get("search_text", "").strip() == "Marca"
+        assert "coluna_temporaria_teste" not in (snapshot.get("active_column_filters") or {})
+
+    def test_deactivate_column_filter_stores_undo_snapshot(self):
+        self.window._active_column_filters["descricao_ssa"] = "Teste A"
+        self.window._last_filter_state = None
+        QApplication.processEvents()
+
+        self.window._deactivate_column_filter("descricao_ssa")
+        QApplication.processEvents()
+
+        assert self.window._last_filter_state is not None
+        snapshot = self.window._last_filter_state
+        assert str((snapshot.get("active_column_filters") or {}).get("descricao_ssa", "")).strip() == "Teste A"
+        assert "descricao_ssa" not in self.window._active_column_filters
+
     @pytest.mark.skip(reason="exclude_ste_checkbox está oculto na UI atual; efeito funcional coberto por test_exclude_ste_sca_combined_with_or_group")
     def test_exclude_checkbox_and_clear_filter_button(self):
         self.window._apply_filter_profile('IEE3 + MEL3 + MEL4', refresh=True)
@@ -960,6 +986,9 @@ class TestGUIFilterLogic:
         assert Counter(self._extract_visible_ssa()) == Counter([1])
         for ctx in self.window._tab_contexts:
             assert ctx["search_input"].text().strip() == "Teste A, Teste D"
+
+    def test_general_search_debounce_uses_minimum_interval(self):
+        assert int(self.window._debounce_timer.interval()) >= 1400
 
     def test_clear_filter_on_filters_tab_clears_search_in_all_tabs(self):
         self.window.search_input.setText("Teste A")
@@ -1634,6 +1663,22 @@ class TestGUIFilterLogic:
 
         self.window.on_filter_finished(stale_df, request_id=20)
         assert self.window._df_last_search_filtered.equals(self.base_df)
+
+    def test_clear_filter_resets_async_search_display_state(self):
+        self.window._sync_filtering = False
+        self.window.search_input.setText("Teste A")
+        self.window.initiate_filtering()
+        QApplication.processEvents()
+
+        assert self.window._active_filter_search_request_id is not None
+        assert str(getattr(self.window, "_active_filter_search_display", "") or "").strip() == "Teste A"
+
+        self.window.clear_filter()
+        QApplication.processEvents()
+
+        assert self.window.search_input.text() == ""
+        assert self.window._active_filter_search_request_id is None
+        assert str(getattr(self.window, "_active_filter_search_display", "") or "").strip() == ""
 
     def test_clear_all_filters_global_invalidates_pending_async_result(self):
         self.window._filter_request_seq = 30

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -531,6 +531,24 @@ class TestGUIFilterLogic:
             assert "coluna" in tooltip
             assert "avancados" in tooltip
 
+    def test_search_buttons_route_to_tab_specific_handlers(self):
+        main_ctx = next(ctx for ctx in self.window._tab_contexts if ctx.get("tab_kind") == "main")
+        filters_ctx = next(ctx for ctx in self.window._tab_contexts if ctx.get("tab_kind") == "filters")
+        main_ctx["clear_filter_button"].setEnabled(True)
+        filters_ctx["clear_filter_button"].setEnabled(True)
+
+        with (
+            patch.object(self.window, "_on_general_search_apply_clicked") as apply_mock,
+            patch.object(self.window, "_on_general_search_clear_clicked") as clear_mock,
+        ):
+            cast(Any, QTest).mouseClick(main_ctx["search_button"], Qt.MouseButton.LeftButton)
+            cast(Any, QTest).mouseClick(filters_ctx["search_button"], Qt.MouseButton.LeftButton)
+            cast(Any, QTest).mouseClick(main_ctx["clear_filter_button"], Qt.MouseButton.LeftButton)
+            cast(Any, QTest).mouseClick(filters_ctx["clear_filter_button"], Qt.MouseButton.LeftButton)
+
+        assert [call.args[0] for call in apply_mock.call_args_list] == ["main", "filters"]
+        assert [call.args[0] for call in clear_mock.call_args_list] == ["main", "filters"]
+
     def test_clear_filter_clears_only_general_search_and_keeps_advanced_filters(self):
         self.window._advanced_filters = {"situacao": ["STE"], "setor_executor": ["IEE3"]}
         self.window._advanced_filters_active = True
@@ -734,6 +752,11 @@ class TestGUIFilterLogic:
         assert self.window._active_column_filters["descricao_ssa"] == ""
         controls_after = self._get_column_filter_controls()
         assert label in controls_after
+
+    def test_build_column_mask_blocks_heavy_regex_patterns(self):
+        series = pd.Series(["aaaaaaaaaaaa", "bbb"], dtype="string")
+        mask = self.window._build_column_mask(series, "~(a+)+$")
+        assert list(mask) == [False, False]
 
     def test_activate_column_filter_stores_undo_snapshot(self):
         self.window._last_filter_state = None

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -1369,6 +1369,19 @@ class TestGUIFilterLogic:
         assert Counter(self._extract_visible_ssa()) == Counter([1, 2, 3, 4, 5])
         assert self.window.clear_filter_button.isEnabled() is False
 
+    def test_clear_all_filters_global_restores_default_column_filter_keys(self):
+        self.window._active_column_filters = {
+            "situacao": "STE",
+            "numero_ssa": "2026",
+            "descricao_ssa": "Teste",
+        }
+        self.window._clear_all_filters_global()
+        QApplication.processEvents()
+
+        default_cols = self.window._column_filter_default_columns()
+        assert tuple(self.window._active_column_filters.keys()) == default_cols
+        assert not any(str(v).strip() for v in self.window._active_column_filters.values())
+
     def test_build_derivadas_tree_normalizes_and_ignores_invalid_values(self):
         df = pd.DataFrame(
             {

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -1215,6 +1215,59 @@ class TestGUIFilterLogic:
         assert self.window._saved_gui_column_widths.get("descricao_ssa") == 222
         assert self.window._gui_column_pixel_widths.get("descricao_ssa") == 222
 
+    def test_header_context_menu_apply_stores_undo_snapshot(self, monkeypatch):
+        class _FakeSignal:
+            def __init__(self):
+                self._callbacks = []
+
+            def connect(self, callback):
+                self._callbacks.append(callback)
+
+            def emit(self):
+                for callback in list(self._callbacks):
+                    callback()
+
+        class _FakeAction:
+            def __init__(self, text, _parent=None):
+                self.text = text
+                self.triggered = _FakeSignal()
+
+        class _FakeMenu:
+            def __init__(self, _parent=None):
+                self._actions = []
+
+            def addAction(self, action):
+                self._actions.append(action)
+                return action
+
+            def exec(self, _global_pos):
+                for action in self._actions:
+                    if str(getattr(action, "text", "")).startswith("Filtrar "):
+                        action.triggered.emit()
+                        return action
+                return None
+
+        self.window._last_filter_state = None
+        self.window._active_column_filters["situacao"] = ""
+        self.window.display_current_page(1)
+        QApplication.processEvents()
+
+        monkeypatch.setattr(gui_ssa, "QAction", _FakeAction)
+        monkeypatch.setattr(gui_ssa, "QMenu", _FakeMenu)
+
+        header = self.window.table_widget.horizontalHeader()
+        logical_index = 2  # "#"(0), numero_ssa(1), situacao(2)
+        pos = QPoint(header.sectionPosition(logical_index) + 2, 5)
+
+        with patch("PyQt6.QtWidgets.QInputDialog.getText", return_value=("STE", True)):
+            self.window.show_header_context_menu(pos)
+            QApplication.processEvents()
+
+        assert self.window._active_column_filters["situacao"] == "STE"
+        assert self.window._last_filter_state is not None
+        snapshot_filters = self.window._last_filter_state.get("active_column_filters") or {}
+        assert str(snapshot_filters.get("situacao", "")).strip() == ""
+
     def test_flush_column_width_preferences_persists_changed_values(self, monkeypatch):
         self.window._saved_gui_column_widths = {"descricao_ssa": 222}
         calls = {"persist": 0}

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -600,6 +600,24 @@ class TestGUIFilterLogic:
         QApplication.processEvents()
         assert self.window.clear_filter_button.isEnabled() is False
 
+    def test_clear_filter_button_state_syncs_across_tabs_without_switch(self):
+        buttons = []
+        for ctx in self.window._tab_contexts:
+            button = ctx.get("clear_filter_button")
+            if button is not None:
+                buttons.append(button)
+        assert len(buttons) == 2
+        assert all(button.isEnabled() is False for button in buttons)
+
+        self.window.search_input.setText("Teste A")
+        self.window.initiate_filtering()
+        QApplication.processEvents()
+        assert all(button.isEnabled() is True for button in buttons)
+
+        self.window.clear_filter()
+        QApplication.processEvents()
+        assert all(button.isEnabled() is False for button in buttons)
+
     def test_clear_advanced_filters_forces_refresh_when_pending_schedule(self):
         filter_tab_idx = next(
             idx for idx, ctx in enumerate(self.window._tab_contexts)

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -119,12 +119,13 @@ class TestGUIFilterLogic:
             if row_widget is None:
                 continue
             row_layout = row_widget.layout()
-            if row_layout is None or row_layout.count() < 4:
+            if row_layout is None or row_layout.count() < 5:
                 continue
             label_widget = row_layout.itemAt(0).widget()
             edit_widget = row_layout.itemAt(1).widget()
             apply_widget = row_layout.itemAt(2).widget()
             clear_widget = row_layout.itemAt(3).widget()
+            hide_widget = row_layout.itemAt(4).widget()
             if not isinstance(label_widget, QLabel):
                 continue
             if not isinstance(edit_widget, QLineEdit):
@@ -133,7 +134,9 @@ class TestGUIFilterLogic:
                 continue
             if not isinstance(clear_widget, QPushButton):
                 continue
-            controls[label_widget.text()] = (edit_widget, apply_widget, clear_widget)
+            if not isinstance(hide_widget, QPushButton):
+                continue
+            controls[label_widget.text()] = (edit_widget, apply_widget, clear_widget, hide_widget)
         return controls
 
     def test_profile_or_filters_executor_or_emissor(self):
@@ -294,7 +297,7 @@ class TestGUIFilterLogic:
         assert not any(str(v).strip() for v in self.window._active_column_filters.values())
         assert self.window._hidden_column_filter_lines == set()
 
-    def test_default_column_filter_rows_show_apply_and_hide_buttons(self):
+    def test_default_column_filter_rows_show_apply_clear_and_hide_buttons(self):
         self.window._active_column_filters = {
             col: '' for col in self.window._column_filter_default_columns()
         }
@@ -307,10 +310,12 @@ class TestGUIFilterLogic:
             else:
                 label = self.window._resolve_column_display_name(col)
             assert label in controls
-            _, apply_btn, hide_btn = controls[label]
+            _, apply_btn, clear_btn, hide_btn = controls[label]
             assert apply_btn.text() == "Aplicar"
+            assert clear_btn.text() == "Limpar"
             assert hide_btn.text() == "Ocultar"
             assert not apply_btn.isHidden()
+            assert not clear_btn.isHidden()
             assert not hide_btn.isHidden()
 
     def test_table_render_collapses_multiline_text_to_single_line(self):
@@ -619,10 +624,12 @@ class TestGUIFilterLogic:
             executor_label = self.window._resolve_column_display_name('setor_executor')
         assert emissor_label in controls
         assert executor_label in controls
-        emissor_edit, emissor_apply, emissor_clear = controls[emissor_label]
-        executor_edit, executor_apply, _ = controls[executor_label]
-        assert emissor_clear.text() == "Ocultar"
-        assert "continua ativo" in (emissor_clear.toolTip() or "").casefold()
+        emissor_edit, emissor_apply, emissor_clear, emissor_hide = controls[emissor_label]
+        executor_edit, executor_apply, _, _ = controls[executor_label]
+        assert emissor_clear.text() == "Limpar"
+        assert "limpa o valor" in (emissor_clear.toolTip() or "").casefold()
+        assert emissor_hide.text() == "Ocultar"
+        assert "continua ativo" in (emissor_hide.toolTip() or "").casefold()
 
         emissor_edit.setText('MEL3, MEL4')
         cast(Any, QTest).mouseClick(emissor_apply, Qt.MouseButton.LeftButton)
@@ -634,7 +641,7 @@ class TestGUIFilterLogic:
 
         # "Remover linha" agora apenas oculta a linha, não limpa o valor
         emissor_edit.setText('')
-        cast(Any, QTest).mouseClick(emissor_clear, Qt.MouseButton.LeftButton)
+        cast(Any, QTest).mouseClick(emissor_hide, Qt.MouseButton.LeftButton)
         QApplication.processEvents()
         # Verifica que a linha do Emissor foi removida da exibição
         controls_after = self._get_column_filter_controls()
@@ -648,6 +655,32 @@ class TestGUIFilterLogic:
         QApplication.processEvents()
         assert self.window._active_column_filters['setor_executor'] == 'IEE3, MEL4'
         assert self.window._active_column_filters['setor_emissor'] == 'IEE3, MEL4'
+
+    def test_column_filter_row_clear_button_clears_value_without_hiding_row(self):
+        self.window._active_column_filters = {col: '' for col in self.window._column_filter_default_columns()}
+        self.window._build_column_filters_panel()
+        QApplication.processEvents()
+
+        controls = self._get_column_filter_controls()
+        label = (
+            self.window._expand_column_alias_for_filter("descricao_ssa")
+            if hasattr(self.window, "_expand_column_alias_for_filter")
+            else self.window._resolve_column_display_name("descricao_ssa")
+        )
+        assert label in controls
+        edit_widget, apply_btn, clear_btn, _hide_btn = controls[label]
+
+        edit_widget.setText("Teste A")
+        cast(Any, QTest).mouseClick(apply_btn, Qt.MouseButton.LeftButton)
+        QApplication.processEvents()
+        assert self.window._active_column_filters["descricao_ssa"] == "Teste A"
+
+        cast(Any, QTest).mouseClick(clear_btn, Qt.MouseButton.LeftButton)
+        QApplication.processEvents()
+
+        assert self.window._active_column_filters["descricao_ssa"] == ""
+        controls_after = self._get_column_filter_controls()
+        assert label in controls_after
 
     def test_activate_column_filter_stores_undo_snapshot(self):
         self.window._last_filter_state = None

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -1491,6 +1491,20 @@ class TestGUIFilterLogic:
         assert tuple(self.window._active_column_filters.keys()) == default_cols
         assert not any(str(v).strip() for v in self.window._active_column_filters.values())
 
+    def test_clear_all_filters_global_resets_or_group_metadata(self):
+        self.window._apply_filter_profile("IEE3 + MEL3 + MEL4", refresh=True)
+        QApplication.processEvents()
+        assert len(self.window._column_or_groups) >= 1
+        assert len(self.window._column_to_or_group) >= 1
+
+        self.window._clear_all_filters_global()
+        QApplication.processEvents()
+
+        assert self.window._column_or_groups == []
+        assert self.window._column_to_or_group == {}
+        summary_text = str(self.window.filters_summary_label.text() or "").casefold()
+        assert "executor ou emissor (ou)" not in summary_text
+
     def test_build_derivadas_tree_normalizes_and_ignores_invalid_values(self):
         df = pd.DataFrame(
             {

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -640,6 +640,31 @@ class TestGUIFilterLogic:
         assert self.window._adv_options_dirty is False
         refresh_mock.assert_called_once()
 
+    def test_undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore(self):
+        undo_buttons = []
+        for ctx in self.window._tab_contexts:
+            button = ctx.get("undo_filter_btn")
+            if button is not None:
+                undo_buttons.append(button)
+        assert len(undo_buttons) == 2
+        assert all(button.isEnabled() is False for button in undo_buttons)
+
+        self.window._advanced_filters = {"situacao": ["STE"]}
+        self.window._advanced_filters_active = True
+        self.window._clear_advanced_filters()
+        QApplication.processEvents()
+
+        assert self.window._advanced_filters == {}
+        assert self.window._advanced_filters_active is False
+        assert all(button.isEnabled() is True for button in undo_buttons)
+
+        self.window._restore_last_filter_state()
+        QApplication.processEvents()
+
+        assert self.window._advanced_filters == {"situacao": ["STE"]}
+        assert self.window._advanced_filters_active is True
+        assert all(button.isEnabled() is False for button in undo_buttons)
+
     def test_column_filter_buttons_flow(self):
         self.window._apply_filter_profile('IEE3 + MEL3 + MEL4', refresh=True)
         QApplication.processEvents()


### PR DESCRIPTION
## Contexto
Este PR fecha um pacote de estabilidade para filtros da GUI, sem mudanca de layout/posicao.

## Escopo (slices)
1. Slice A (`50bf94f0`)
- sync do estado `Limpar Busca` entre abas (main/filters)
- teste: `test_clear_filter_button_state_syncs_across_tabs_without_switch`

2. Slice B (`32fca7c1`)
- sync do estado `Undo` entre abas
- cobertura de restore apos limpar filtros avancados
- teste: `test_undo_button_state_syncs_across_tabs_after_advanced_clear_and_restore`

3. Slice C (`fcc3715e`)
- handlers dedicados por aba para `Aplicar` e `Limpar Busca`
- hardening de guarda regex em filtro de coluna (fallback literal para padroes de risco)
- testes:
  - `test_search_buttons_route_to_tab_specific_handlers`
  - `test_build_column_mask_blocks_heavy_regex_patterns`

4. Doc sync (`fe27e4c0`)
- registro de evidencia nos arquivos de controle

## Arquivos principais
- `gui/gui_ssa.py`
- `gui/mixins/filter_gui_ssa_mixin.py`
- `gui/mixins/tab_context_gui_ssa_mixin.py`
- `tests/test_gui_filter_logic.py`
- `docs/RECOVERY_BACKLOG.md`
- `docs/NEXT_CHAT_MIGRATION.md`
- `docs/AGENTS_HANDOFF_NEXT_CYCLE.md`

## Validacao local
Executado por slice (arquivos tocados):
- `uv run --python 3.13 python -m py_compile ...`
- `uv run --python 3.13 ruff check ...`
- `uv run --python 3.13 ty check ...`
- `uv run --python 3.13 pytest -q tests/test_gui_filter_logic.py -k "..."`

Resultado final dos grupos focados deste pacote:
- `3 passed`
- `3 passed`
- `4 passed`

## Risco e nao-escopo
- sem alteracao de layout/posicionamento
- sem mudanca de startup/import policy
- sem alteracao fora do escopo de filtros

## Controle e rastreabilidade
Atualizado no mesmo ciclo:
- `docs/RECOVERY_BACKLOG.md`
- `docs/NEXT_CHAT_MIGRATION.md`
- `docs/AGENTS_HANDOFF_NEXT_CYCLE.md`

## Residuos locais fora do PR
- `config/gui_main_preferences.json` (nao commitado)
- `stash@{0}` mantido
