### PR TITLE
HOTFIX_BLOCKER: update GitPython security floor 2026-04-26T19:53:10-0300

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -574,14 +574,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.47"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Merge GitPython security hotfix from dev into main.

Source head: 499a4827b1c5ed54413e75cd33a6ab9382038e15
Fixes Dependabot alerts GHSA-rpm5-65cw-6hj4 and GHSA-x2qx-6953-8485 by updating GitPython to 3.1.47 in uv.lock.

Co-authored-by: Codex <noreply@openai.com>

## Summary by Sourcery

Atualizar a dependência GitPython no lockfile para tratar avisos de segurança e alinhar a branch main com a branch de desenvolvimento securizada.

Correções de bugs:
- Resolver os avisos de segurança GHSA-rpm5-65cw-6hj4 e GHSA-x2qx-6953-8485 atualizando a versão do GitPython.

Build:
- Atualizar o `uv.lock` para fixar o GitPython em uma versão não vulnerável.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update GitPython dependency in the lockfile to address security advisories and align main with the secured dev branch.

Bug Fixes:
- Resolve security advisories GHSA-rpm5-65cw-6hj4 and GHSA-x2qx-6953-8485 by updating the GitPython version.

Build:
- Refresh uv.lock to pin GitPython to a non-vulnerable version.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `GitPython` to 3.1.47 in `uv.lock` to fix security advisories GHSA-rpm5-65cw-6hj4 and GHSA-x2qx-6953-8485. Lockfile-only change with no runtime impact.

<sup>Written for commit 499a4827b1c5ed54413e75cd33a6ab9382038e15. Summary will update on new commits. <a href="https://cubic.dev/pr/mauriciomenon/SSA_Consulta_Rapida/pull/49">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

