### PR TITLE
STABILITY_PATCH: prepare v4.37 fixes for main

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sh text eol=lf
+*.bash text eol=lf
+.envrc text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -506,4 +506,3 @@ heatmap-last-year.png
 !dev_env/build/*.bat
 !dev_env/build/*.bzl
 docs_entrada/docs_entrada.zip
-docs_entrada/docs_entrada.zip

--- a/.gitignore
+++ b/.gitignore
@@ -505,3 +505,5 @@ heatmap-last-year.png
 !dev_env/build/*.sh
 !dev_env/build/*.bat
 !dev_env/build/*.bzl
+docs_entrada/docs_entrada.zip
+docs_entrada/docs_entrada.zip

--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -1,0 +1,12 @@
+# ROUND_STATUS
+
+## 2026-04-30T14:51:45-03:00 PR56 stability slice
+
+- Scope: PR #56 actionable review fixes and follow-up validation.
+- Kluster MCP: `kluster_code_review_auto` timed out after 120s on the modified files.
+- Kluster CLI deep: `kluster review file ... --mode deep` returned backend HTTP 500 after the first follow-up run.
+- Kluster CLI instant: first run completed and reported remaining search/filter/refactor items plus one script comment issue; the script comment issue was fixed.
+- Kluster CLI instant retry: one retry returned backend HTTP 500.
+- Kluster CLI instant successful run after status update: review `69f39d18295e5d0b624eac55`.
+- Kluster final remaining items: structural import orchestrator refactor, filter/search performance and parser documentation, duplicated emoji definitions, local lazy imports in rescan worker, and filter-search cache performance.
+- Status: classic validation passed; Kluster backend was unstable and final remaining items are deferred as non-blocking or performance-slice items.

--- a/armazenamento/database.py
+++ b/armazenamento/database.py
@@ -542,7 +542,7 @@ def insert_dataframe_to_db(*args, **kwargs) -> bool:  # noqa: C901, PLR0912
             if db_path is None:
                 raise ValueError("db_path ausente no caminho padrao de insercao")
 
-            with get_db_connection(cast(str, db_path)) as conn:
+            with get_db_connection(db_path) as conn:
                 active_conn = conn
                 cur = conn.cursor()
                 cur.execute("PRAGMA journal_mode")

--- a/armazenamento/database_upsert_logic.py
+++ b/armazenamento/database_upsert_logic.py
@@ -412,7 +412,7 @@ def _should_update_existing(
                     timestamp = pd.Timestamp(parsed)
                     if pd.isna(timestamp):
                         return None
-                    return timestamp
+                    return cast(pd.Timestamp, timestamp)
             raw = str(origin_name_value or "").strip()
             if not raw:
                 return None
@@ -422,7 +422,7 @@ def _should_update_existing(
             timestamp = pd.Timestamp(parsed)
             if pd.isna(timestamp):
                 return None
-            return timestamp
+            return cast(pd.Timestamp, timestamp)
 
         existing_situacao = _status_code(existing_row.get("situacao"))
         if existing_situacao in terminal_states:

--- a/armazenamento/derivadas_queries.py
+++ b/armazenamento/derivadas_queries.py
@@ -625,7 +625,7 @@ def _collect_family_subgraph(
     node_placeholders = ",".join("?" for _ in family_nodes)
     edge_rows = conn.execute(
         f"""
-        SELECT DISTINCT parent_ssa, child_ssa
+        SELECT DISTINCT parent_ssa, child_ssa, relation_type, relation_raw_label
         FROM ssa_derivada_matrix
         WHERE active = 1
           AND parent_ssa IN ({node_placeholders})
@@ -637,13 +637,18 @@ def _collect_family_subgraph(
     ).fetchall()
     family_truncated = family_truncated or len(edge_rows) > safe_max_nodes
     for row in edge_rows[:safe_max_nodes]:
-        family_descendants.append(
-            {
-                "ssa": row[1],
-                "parent": row[0],
-                "min_distance": int(distance_by_node.get(row[1], 1)),
-            }
-        )
+        entry: dict[str, Any] = {
+            "ssa": row[1],
+            "parent": row[0],
+            "min_distance": int(distance_by_node.get(row[1], 1)),
+        }
+        relation_type = int(row[2] or 0)
+        relation_raw_label = row[3]
+        if relation_type not in (0, 1):
+            entry["relation_type"] = relation_type
+        if relation_raw_label:
+            entry["relation_raw_label"] = relation_raw_label
+        family_descendants.append(entry)
     return family_roots, family_descendants, family_truncated
 
 

--- a/armazenamento/derivadas_queries.py
+++ b/armazenamento/derivadas_queries.py
@@ -464,6 +464,7 @@ def build_family_payload_from_edges(
         family_roots = list(dict.fromkeys(parents or [target_ssa]))
 
     family_descendants: list[dict[str, Any]] = []
+    replace_candidate_indexes: list[int] = []
     seen_edges: set[tuple[str, str]] = set()
     family_truncated = False
 
@@ -501,6 +502,8 @@ def build_family_payload_from_edges(
             family_descendants.append(
                 {"ssa": child, "parent": parent, "min_distance": node_distance}
             )
+            if child not in priority_nodes and parent != target_ssa:
+                replace_candidate_indexes.append(len(family_descendants) - 1)
             if child not in queued_nodes:
                 queued_nodes.add(child)
                 distance_by_node[child] = depth + 1
@@ -523,7 +526,8 @@ def build_family_payload_from_edges(
             family_truncated = True
             continue
         replace_index = None
-        for index in range(len(family_descendants) - 1, -1, -1):
+        while replace_candidate_indexes:
+            index = replace_candidate_indexes.pop()
             row = family_descendants[index]
             row_parent = str(row.get("parent", "") or "")
             row_child = str(row.get("ssa", "") or "")
@@ -642,7 +646,17 @@ def _collect_family_subgraph(
             "parent": row[0],
             "min_distance": int(distance_by_node.get(row[1], 1)),
         }
-        relation_type = int(row[2] or 0)
+        raw_relation_type = row[2]
+        try:
+            relation_type = int(raw_relation_type or 0)
+        except (TypeError, ValueError):
+            logger.warning(
+                "relation_type invalido em ssa_derivada_matrix: parent=%s child=%s value=%r",
+                row[0],
+                row[1],
+                raw_relation_type,
+            )
+            relation_type = 0
         relation_raw_label = row[3]
         if relation_type not in (0, 1):
             entry["relation_type"] = relation_type

--- a/codeql-custom-queries-python/codeql-pack.lock.yml
+++ b/codeql-custom-queries-python/codeql-pack.lock.yml
@@ -1,0 +1,30 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/concepts:
+    version: 0.0.22
+  codeql/controlflow:
+    version: 2.0.32
+  codeql/dataflow:
+    version: 2.1.4
+  codeql/mad:
+    version: 1.0.48
+  codeql/python-all:
+    version: 7.0.5
+  codeql/regex:
+    version: 1.0.48
+  codeql/ssa:
+    version: 2.0.24
+  codeql/threat-models:
+    version: 1.0.48
+  codeql/tutorial:
+    version: 1.0.48
+  codeql/typetracking:
+    version: 2.0.32
+  codeql/util:
+    version: 2.0.35
+  codeql/xml:
+    version: 1.0.48
+  codeql/yaml:
+    version: 1.0.48
+compiled: false

--- a/codeql-custom-queries-python/codeql-pack.yml
+++ b/codeql-custom-queries-python/codeql-pack.yml
@@ -1,0 +1,7 @@
+---
+library: false
+warnOnImplicitThis: false
+name: getting-started/codeql-extra-queries-python
+version: 1.0.0
+dependencies:
+  codeql/python-all: ^7.0.5

--- a/codeql-custom-queries-python/example.ql
+++ b/codeql-custom-queries-python/example.ql
@@ -1,0 +1,12 @@
+/**
+ * This is an automatically generated file
+ * @name Hello world
+ * @kind problem
+ * @problem.severity warning
+ * @id python/example/hello-world
+ */
+
+import python
+
+from File f
+select f, "Hello, world!"

--- a/config/gui_main_preferences.json.example
+++ b/config/gui_main_preferences.json.example
@@ -55,6 +55,7 @@
     "data_arquivo_origem": "Data do Arquivo de Origem",
     "total_de_reprogramacoes": "Tot. Reprog.",
     "execucao_parcial": "Exec. Parc.",
+    "situacao_da_parcial": "Situacao da Parcial",
     "semana_executada": "Sem. Exec."
   },
   "column_widths": {
@@ -197,6 +198,7 @@
     "data_arquivo_origem": "Data do Arquivo de Origem",
     "total_de_reprogramacoes": "Tot. Reprog.",
     "execucao_parcial": "Exec. Parc.",
+    "situacao_da_parcial": "Situacao da Parcial",
     "semana_executada": "Sem. Exec."
   },
   "required_display_columns": [

--- a/core/app_logic.py
+++ b/core/app_logic.py
@@ -1751,14 +1751,18 @@ def _run_optional_derivadas_sync(
             )
             if db_edges > 0 or merged_edges > 0:
                 sync_materialized = True
+            if len(synced_sheets) == 1:
+                progress_filename = os.path.basename(synced_sheets[0])
+            elif synced_sheets:
+                progress_filename = (
+                    f"SSAs Derivadas e Relacionadas ({len(synced_sheets)} arquivos)"
+                )
+            else:
+                progress_filename = "SSAs Derivadas e Relacionadas (banco atual)"
             emit_progress(
                 "file_success",
                 {
-                    "filename": (
-                        os.path.basename(synced_sheets[0])
-                        if len(synced_sheets) == 1
-                        else f"SSAs Derivadas e Relacionadas ({len(synced_sheets)} arquivos)"
-                    ),
+                    "filename": progress_filename,
                     "records": int(
                         (sync_report.get("merge_stats") or {}).get("merged_edges", 0)
                     ),

--- a/core/app_logic.py
+++ b/core/app_logic.py
@@ -85,7 +85,7 @@ class FilterSearchCacheManager:
         elif row_count <= 5000:
             hashed = pd.util.hash_pandas_object(search_df, index=True)
             data_digest = hashlib.blake2b(
-                hashed.to_numpy(copy=False).tobytes(),
+                hashed.to_numpy().tobytes(),
                 digest_size=16,
             ).hexdigest()
         else:
@@ -98,7 +98,7 @@ class FilterSearchCacheManager:
             sample_df = search_df.iloc[sorted(sample_positions)]
             hashed = pd.util.hash_pandas_object(sample_df, index=True)
             data_digest = hashlib.blake2b(
-                hashed.to_numpy(copy=False).tobytes(),
+                hashed.to_numpy().tobytes(),
                 digest_size=16,
             ).hexdigest()
         payload = (
@@ -2191,6 +2191,7 @@ def _initialize_import_run_context(
     docs_dir: str,
     data_dir: str,
     db_name: str,
+    extra_allowed_roots: Optional[Sequence[str | os.PathLike[str]]] = None,
 ) -> Dict[str, Any]:
     """Resolve caminhos e inicializa o estado mutavel da rodada de importacao."""
     try:
@@ -2207,6 +2208,7 @@ def _initialize_import_run_context(
             base=project_root_path,
             must_exist=False,
             expect_directory=True,
+            extra_allowed_roots=extra_allowed_roots,
         )
     except PathSafetyError as e:
         logger.error(f"Caminho bloqueado na importacao: {e}")
@@ -2219,6 +2221,7 @@ def _initialize_import_run_context(
             base=project_root_path,
             must_exist=False,
             expect_directory=False,
+            extra_allowed_roots=extra_allowed_roots,
         )
     except PathSafetyError as e:
         logger.error(f"Caminho de DB bloqueado: {e}")
@@ -2367,6 +2370,7 @@ def run_importer_logic(
     should_cancel: Optional[Callable[[], bool]] = None,
     progress_callback: Optional[Callable[[str, Dict[str, Any]], None]] = None,
     explicit_files: Optional[Sequence[str | os.PathLike[str]]] = None,
+    extra_allowed_roots: Optional[Sequence[str | os.PathLike[str]]] = None,
 ) -> bool:
     """
     Executa a logica principal de importacao de dados.
@@ -2382,6 +2386,7 @@ def run_importer_logic(
         progress_callback (Optional[Callable]): Callback para reportar progresso da importacao.
         explicit_files (Optional[Sequence[str | os.PathLike[str]]]): Se informado,
             processa apenas esses arquivos .xlsx ja presentes em docs_dir.
+        extra_allowed_roots: Bases adicionais explicitas para data_dir/db_path.
 
     Returns:
         bool: True se o banco de dados foi atualizado, False caso contrario.
@@ -2392,6 +2397,7 @@ def run_importer_logic(
         docs_dir=docs_dir,
         data_dir=data_dir,
         db_name=db_name,
+        extra_allowed_roots=extra_allowed_roots,
     )
     docs_dir_path = cast(Path, context["docs_dir_path"])
     db_path = str(context["db_path"])

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -163,6 +163,7 @@ DEFAULT_DISPLAY_MAPPINGS: Dict[str, str] = {
     "semana_executada": "Sem. Exec.",
     "num_reprogramacoes": "Nº Reprog.",
     "execucao_parcial": "Exec. Parcial",
+    "situacao_da_parcial": "Situacao da Parcial",
     "atividade_especial": "Atividade Especial",
     "equipamento_retirado": "Equipamento Retirado",
     "sn_retirado": "SN Retirado",

--- a/core/handler_base.py
+++ b/core/handler_base.py
@@ -195,7 +195,7 @@ class HandlerBase(ABC):
             json_text = data.to_json(orient="records", indent=2)
             return json_text or "[]"
         elif format_type == "csv":
-            return data.to_csv(index=False)
+            return data.to_csv(index=False, lineterminator="\n")
         elif data.empty:
             return "Nenhum resultado encontrado."
         else:  # table (default)

--- a/core/import_staging.py
+++ b/core/import_staging.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 from pathlib import Path
-from typing import Callable, Sequence
+from typing import Callable, Iterable, Sequence
 
 from utils.path_safety import ensure_path_is_allowed, reserve_unique_path
 
@@ -11,7 +11,19 @@ CancelCallback = Callable[[], bool]
 LineCallback = Callable[[str], None]
 
 
-def validate_external_source_path(raw_source: str | os.PathLike[str]) -> str:
+def _normalize_explicit_allowed_files(
+    extra_allowed_files: Iterable[str | os.PathLike[str]] | None,
+) -> set[Path]:
+    if not extra_allowed_files:
+        return set()
+    return {Path(raw).expanduser().resolve() for raw in extra_allowed_files if raw}
+
+
+def validate_external_source_path(
+    raw_source: str | os.PathLike[str],
+    *,
+    extra_allowed_files: Iterable[str | os.PathLike[str]] | None = None,
+) -> str:
     source = str(raw_source or "").strip()
     if not source:
         raise ValueError("Caminho vazio para staging externo.")
@@ -21,6 +33,7 @@ def validate_external_source_path(raw_source: str | os.PathLike[str]) -> str:
     if os.path.basename(normalized).startswith("-"):
         raise ValueError("Caminho externo inicia com '-' e nao e permitido.")
     source_path = Path(normalized)
+    explicit_allowed_files = _normalize_explicit_allowed_files(extra_allowed_files)
     try:
         safe_source_path = ensure_path_is_allowed(
             source_path,
@@ -31,7 +44,10 @@ def validate_external_source_path(raw_source: str | os.PathLike[str]) -> str:
     except ValueError as exc:
         if not source_path.exists():
             raise FileNotFoundError(f"Arquivo inexistente: {normalized}") from exc
-        raise
+        resolved_source = source_path.resolve()
+        if resolved_source not in explicit_allowed_files:
+            raise
+        safe_source_path = resolved_source
     source_path = safe_source_path
     if source_path.suffix.casefold() not in {".xlsx", ".xls"}:
         raise ValueError(f"Arquivo nao suportado pelo pipeline: {source_path.name}")
@@ -79,7 +95,10 @@ def stage_external_import_files(
                 f"[STAGE {index}/{total_sources}] Preparando: {os.path.basename(source) or source}"
             )
         try:
-            validated_source = validate_external_source_path(source)
+            validated_source = validate_external_source_path(
+                source,
+                extra_allowed_files=source_files,
+            )
         except FileNotFoundError:
             failed += 1
             if callable(error_callback):

--- a/core/import_staging.py
+++ b/core/import_staging.py
@@ -16,13 +16,22 @@ def _normalize_explicit_allowed_files(
 ) -> set[Path]:
     if not extra_allowed_files:
         return set()
-    return {Path(raw).expanduser().resolve() for raw in extra_allowed_files if raw}
+    allowed_files: set[Path] = set()
+    for raw in extra_allowed_files:
+        if not raw:
+            continue
+        candidate = Path(raw).expanduser()
+        resolved = candidate.resolve(strict=False)
+        if resolved.is_file():
+            allowed_files.add(resolved)
+    return allowed_files
 
 
 def validate_external_source_path(
     raw_source: str | os.PathLike[str],
     *,
     extra_allowed_files: Iterable[str | os.PathLike[str]] | None = None,
+    normalized_allowed_files: set[Path] | None = None,
 ) -> str:
     source = str(raw_source or "").strip()
     if not source:
@@ -33,18 +42,24 @@ def validate_external_source_path(
     if os.path.basename(normalized).startswith("-"):
         raise ValueError("Caminho externo inicia com '-' e nao e permitido.")
     source_path = Path(normalized)
-    explicit_allowed_files = _normalize_explicit_allowed_files(extra_allowed_files)
     try:
         safe_source_path = ensure_path_is_allowed(
             source_path,
-            purpose="external_import_source",
+            purpose="external_import_file",
             must_exist=True,
             expect_directory=False,
         )
     except ValueError as exc:
         if not source_path.exists():
             raise FileNotFoundError(f"Arquivo inexistente: {normalized}") from exc
-        resolved_source = source_path.resolve()
+        if not source_path.is_file():
+            raise
+        explicit_allowed_files = (
+            normalized_allowed_files
+            if normalized_allowed_files is not None
+            else _normalize_explicit_allowed_files(extra_allowed_files)
+        )
+        resolved_source = source_path.resolve(strict=False)
         if resolved_source not in explicit_allowed_files:
             raise
         safe_source_path = resolved_source
@@ -82,6 +97,7 @@ def stage_external_import_files(
     unsupported = 0
     staged_files: list[str] = []
     total_sources = len(source_files)
+    explicit_allowed_files = _normalize_explicit_allowed_files(source_files)
 
     for index, raw_source in enumerate(tuple(source_files), start=1):
         if callable(should_cancel) and should_cancel():
@@ -97,7 +113,7 @@ def stage_external_import_files(
         try:
             validated_source = validate_external_source_path(
                 source,
-                extra_allowed_files=source_files,
+                normalized_allowed_files=explicit_allowed_files,
             )
         except FileNotFoundError:
             failed += 1
@@ -156,7 +172,7 @@ def stage_external_import_files(
                     with open(destination, "xb") as destination_handle:
                         destination_created = True
                         shutil.copyfileobj(source_handle, destination_handle)
-                os.chmod(destination, source_stat.st_mode & 0o777)
+                os.chmod(destination, source_stat.st_mode & 0o600)
                 os.utime(
                     destination,
                     ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),

--- a/dev_env/build/build_nuitka_clean.bat
+++ b/dev_env/build/build_nuitka_clean.bat
@@ -31,10 +31,19 @@ for /f "tokens=1,2 delims=|" %%A in ('uv run --python 3.13 python -c "import jso
 if not defined APP_VERSION set "APP_VERSION=0.0"
 if not defined FILE_VERSION set "FILE_VERSION=0.0.0.0"
 
+set "BUILD_METADATA_DIR=%REPO_ROOT%\builds\metadata"
+if not exist "%BUILD_METADATA_DIR%" mkdir "%BUILD_METADATA_DIR%"
+set "BUILD_INFO_FILE=%BUILD_METADATA_DIR%\build_info_windows_amd64_nuitka.json"
+uv run --python 3.13 python -c "import datetime,json,os,pathlib,subprocess; root=pathlib.Path(os.environ['REPO_ROOT']); run=lambda args: subprocess.run(args,cwd=str(root),text=True,capture_output=True,check=False).stdout.strip(); commit=run(['git','rev-parse','HEAD']); payload={'app_version':os.environ.get('APP_VERSION',''),'build_datetime':datetime.datetime.now().astimezone().isoformat(timespec='seconds'),'build_system':'nuitka','git_commit':commit,'git_commit_datetime':run(['git','log','-1','--format=%%cI']),'git_commit_short':commit[:7] if commit else '','git_commit_title':run(['git','log','-1','--format=%%s']),'platform':'windows_amd64','uv_version':run(['uv','--version'])}; pathlib.Path(os.environ['BUILD_INFO_FILE']).write_text(json.dumps(payload,ensure_ascii=True,indent=2,sort_keys=True)+'\n',encoding='utf-8')"
+if errorlevel 1 (
+    echo Erro ao gerar build_info.json.
+    exit /b 1
+)
+
 if exist "%REPO_ROOT%\builds\nuitka\windows_amd64\SSA_GUI_v%APP_VERSION%_windows_amd64.dist" rmdir /s /q "%REPO_ROOT%\builds\nuitka\windows_amd64\SSA_GUI_v%APP_VERSION%_windows_amd64.dist"
 if exist "%REPO_ROOT%\builds\nuitka\windows_amd64\SSA_CLI_v%APP_VERSION%_windows_amd64.dist" rmdir /s /q "%REPO_ROOT%\builds\nuitka\windows_amd64\SSA_CLI_v%APP_VERSION%_windows_amd64.dist"
 
-set "BASE_CMD=uv run --python 3.13 -m nuitka --standalone --assume-yes-for-downloads --follow-imports --enable-plugin=pyqt6 --company-name=SSA --product-name=Consulta_Rapida_de_SSAs --file-version=%FILE_VERSION% --product-version=%FILE_VERSION% --include-data-dir=config=config --include-data-dir=resources=resources --output-dir=builds/nuitka/windows_amd64"
+set "BASE_CMD=uv run --python 3.13 -m nuitka --standalone --assume-yes-for-downloads --follow-imports --enable-plugin=pyqt6 --company-name=SSA --product-name=Consulta_Rapida_de_SSAs --file-version=%FILE_VERSION% --product-version=%FILE_VERSION% --include-data-dir=config=config --include-data-dir=resources=resources --include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md --include-data-file=%BUILD_INFO_FILE%=config/build_info.json --output-dir=builds/nuitka/windows_amd64"
 
 if "%SILENT%"=="1" (
     echo [build_nuitka] modo silencioso ativo. log: "%LOG_FILE%"

--- a/dev_env/build/build_nuitka_debian.sh
+++ b/dev_env/build/build_nuitka_debian.sh
@@ -18,6 +18,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 LOG_DIR="${REPO_ROOT}/launchers/logs"
 LOG_FILE="${LOG_DIR}/build_nuitka_debian_amd64.log"
+VENV_DIR="${REPO_ROOT}/launchers/platforms/debian_amd64/venv"
+PYTHON_EXE="${VENV_DIR}/bin/python"
+REQUIREMENTS_FILE="${REPO_ROOT}/launchers/platforms/debian_amd64/requirements.txt"
 
 mkdir -p "${LOG_DIR}"
 mkdir -p "${REPO_ROOT}/builds/nuitka/debian_amd64"
@@ -91,8 +94,16 @@ GUI_DIST="${REPO_ROOT}/builds/nuitka/debian_amd64/gui_entry.dist"
 CLI_DIST="${REPO_ROOT}/builds/nuitka/debian_amd64/cli_entry.dist"
 rm -rf "${GUI_DIST}" "${CLI_DIST}"
 
+if [[ ! -x "${PYTHON_EXE}" ]]; then
+  LAST_STEP="create_venv"
+  uv venv --python 3.13 "${VENV_DIR}"
+fi
+
+LAST_STEP="install_requirements"
+uv pip install --python "${PYTHON_EXE}" -r "${REQUIREMENTS_FILE}"
+
 GUI_CMD=(
-  uv run --python 3.13 -m nuitka
+  "${PYTHON_EXE}" -m nuitka
   --standalone
   --assume-yes-for-downloads
   --follow-imports
@@ -103,7 +114,7 @@ GUI_CMD=(
 )
 
 CLI_CMD=(
-  uv run --python 3.13 -m nuitka
+  "${PYTHON_EXE}" -m nuitka
   --standalone
   --assume-yes-for-downloads
   --follow-imports

--- a/dev_env/build/build_nuitka_debian.sh
+++ b/dev_env/build/build_nuitka_debian.sh
@@ -23,7 +23,18 @@ PYTHON_EXE="${VENV_DIR}/bin/python"
 REQUIREMENTS_FILE="${REPO_ROOT}/launchers/platforms/debian_amd64/requirements.txt"
 
 mkdir -p "${LOG_DIR}"
-mkdir -p "${REPO_ROOT}/builds/nuitka/debian_amd64"
+FINAL_BUILD_DIR="${REPO_ROOT}/builds/nuitka/debian_amd64"
+mkdir -p "${FINAL_BUILD_DIR}"
+BUILD_WORK_DIR=""
+
+cleanup_build_work_dir() {
+  if [[ -n "${BUILD_WORK_DIR}" && "${KEEP_NUITKA_WORK_DIR:-0}" != "1" ]]; then
+    rm -rf -- "${BUILD_WORK_DIR}"
+  fi
+}
+
+trap cleanup_build_work_dir EXIT
+cd "${REPO_ROOT}"
 
 export UV_PYTHON=3.13
 export UV_MANAGED_PYTHON=true
@@ -90,8 +101,43 @@ print(version)
 PY_VERSION
 )"
 
-GUI_DIST="${REPO_ROOT}/builds/nuitka/debian_amd64/gui_entry.dist"
-CLI_DIST="${REPO_ROOT}/builds/nuitka/debian_amd64/cli_entry.dist"
+BUILD_INFO_FILE="${REPO_ROOT}/builds/metadata/build_info_debian_amd64_nuitka.json"
+mkdir -p "$(dirname "${BUILD_INFO_FILE}")"
+LAST_STEP="write_build_info"
+uv run --python 3.13 python - "${REPO_ROOT}" "${BUILD_INFO_FILE}" "nuitka" "debian_amd64" "${APP_VERSION}" <<'PY_BUILD_INFO'
+import datetime
+import json
+import pathlib
+import subprocess
+import sys
+
+root = pathlib.Path(sys.argv[1])
+output = pathlib.Path(sys.argv[2])
+build_system = sys.argv[3]
+platform_name = sys.argv[4]
+app_version = sys.argv[5]
+
+def run(args):
+    result = subprocess.run(args, cwd=str(root), text=True, capture_output=True, check=False)
+    return (result.stdout or "").strip() if result.returncode == 0 else ""
+
+commit = run(["git", "rev-parse", "HEAD"])
+payload = {
+    "app_version": app_version,
+    "build_datetime": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
+    "build_system": build_system,
+    "git_commit": commit,
+    "git_commit_datetime": run(["git", "log", "-1", "--format=%cI"]),
+    "git_commit_short": commit[:7] if commit else "",
+    "git_commit_title": run(["git", "log", "-1", "--format=%s"]),
+    "platform": platform_name,
+    "uv_version": run(["uv", "--version"]),
+}
+output.write_text(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY_BUILD_INFO
+
+GUI_DIST="${FINAL_BUILD_DIR}/gui_entry.dist"
+CLI_DIST="${FINAL_BUILD_DIR}/cli_entry.dist"
 rm -rf "${GUI_DIST}" "${CLI_DIST}"
 
 if [[ ! -x "${PYTHON_EXE}" ]]; then
@@ -102,6 +148,15 @@ fi
 LAST_STEP="install_requirements"
 uv pip install --python "${PYTHON_EXE}" -r "${REQUIREMENTS_FILE}"
 
+WORK_PARENT="${SSA_NUITKA_WORK_ROOT:-${TMPDIR:-/tmp}/ssa_nuitka_build}"
+if [[ "${REPO_ROOT}" == /mnt/* ]]; then
+  mkdir -p "${WORK_PARENT}"
+  BUILD_WORK_DIR="$(mktemp -d "${WORK_PARENT}/debian_amd64.XXXXXX")"
+  NUITKA_OUTPUT_DIR="${BUILD_WORK_DIR}"
+else
+  NUITKA_OUTPUT_DIR="${FINAL_BUILD_DIR}"
+fi
+
 GUI_CMD=(
   "${PYTHON_EXE}" -m nuitka
   --standalone
@@ -110,7 +165,9 @@ GUI_CMD=(
   --enable-plugin=pyqt6
   --include-data-dir=config=config
   --include-data-dir=resources=resources
-  --output-dir=builds/nuitka/debian_amd64
+  --include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md
+  --include-data-file="${BUILD_INFO_FILE}=config/build_info.json"
+  --output-dir="${NUITKA_OUTPUT_DIR}"
 )
 
 CLI_CMD=(
@@ -119,7 +176,8 @@ CLI_CMD=(
   --assume-yes-for-downloads
   --follow-imports
   --include-data-dir=config=config
-  --output-dir=builds/nuitka/debian_amd64
+  --include-data-file="${BUILD_INFO_FILE}=config/build_info.json"
+  --output-dir="${NUITKA_OUTPUT_DIR}"
 )
 
 if [[ "${SILENT}" == "1" ]]; then
@@ -127,6 +185,11 @@ if [[ "${SILENT}" == "1" ]]; then
   "${GUI_CMD[@]}" --output-filename="SSA_GUI_v${APP_VERSION}_debian_amd64" --linux-icon=resources/app_icon.png launchers/gui_entry.py >"${LOG_FILE}" 2>&1
   LAST_STEP="nuitka_cli"
   "${CLI_CMD[@]}" --output-filename="SSA_CLI_v${APP_VERSION}_debian_amd64" launchers/cli_entry.py >>"${LOG_FILE}" 2>&1
+  if [[ "${NUITKA_OUTPUT_DIR}" != "${FINAL_BUILD_DIR}" ]]; then
+    LAST_STEP="copy_nuitka_dist"
+    cp -a "${NUITKA_OUTPUT_DIR}/gui_entry.dist" "${GUI_DIST}"
+    cp -a "${NUITKA_OUTPUT_DIR}/cli_entry.dist" "${CLI_DIST}"
+  fi
   if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
     LAST_STEP="copy_data_to_builds"
     uv run --python 3.13 "${REPO_ROOT}/scripts/copy_data_to_builds.py" --build-system nuitka --allow-local-data >>"${LOG_FILE}" 2>&1
@@ -139,6 +202,11 @@ else
   "${GUI_CMD[@]}" --output-filename="SSA_GUI_v${APP_VERSION}_debian_amd64" --linux-icon=resources/app_icon.png launchers/gui_entry.py
   LAST_STEP="nuitka_cli"
   "${CLI_CMD[@]}" --output-filename="SSA_CLI_v${APP_VERSION}_debian_amd64" launchers/cli_entry.py
+  if [[ "${NUITKA_OUTPUT_DIR}" != "${FINAL_BUILD_DIR}" ]]; then
+    LAST_STEP="copy_nuitka_dist"
+    cp -a "${NUITKA_OUTPUT_DIR}/gui_entry.dist" "${GUI_DIST}"
+    cp -a "${NUITKA_OUTPUT_DIR}/cli_entry.dist" "${CLI_DIST}"
+  fi
   if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
     LAST_STEP="copy_data_to_builds"
     uv run --python 3.13 "${REPO_ROOT}/scripts/copy_data_to_builds.py" --build-system nuitka --allow-local-data

--- a/dev_env/build/build_nuitka_debian.sh
+++ b/dev_env/build/build_nuitka_debian.sh
@@ -18,14 +18,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 LOG_DIR="${REPO_ROOT}/launchers/logs"
 LOG_FILE="${LOG_DIR}/build_nuitka_debian_amd64.log"
-VENV_DIR="${REPO_ROOT}/launchers/platforms/debian_amd64/venv"
-PYTHON_EXE="${VENV_DIR}/bin/python"
 REQUIREMENTS_FILE="${REPO_ROOT}/launchers/platforms/debian_amd64/requirements.txt"
 
 mkdir -p "${LOG_DIR}"
 FINAL_BUILD_DIR="${REPO_ROOT}/builds/nuitka/debian_amd64"
 mkdir -p "${FINAL_BUILD_DIR}"
 BUILD_WORK_DIR=""
+if [[ "${REPO_ROOT}" == /mnt/* ]]; then
+  NATIVE_CACHE_ROOT="${SSA_NUITKA_NATIVE_ROOT:-${XDG_CACHE_HOME:-${HOME}/.cache}/ssa_consulta_rapida/nuitka}"
+  VENV_DIR="${SSA_NUITKA_VENV_DIR:-${NATIVE_CACHE_ROOT}/debian_amd64/venv}"
+else
+  VENV_DIR="${REPO_ROOT}/launchers/platforms/debian_amd64/venv"
+fi
+PYTHON_EXE="${VENV_DIR}/bin/python"
 
 cleanup_build_work_dir() {
   if [[ -n "${BUILD_WORK_DIR}" && "${KEEP_NUITKA_WORK_DIR:-0}" != "1" ]]; then
@@ -58,8 +63,10 @@ trap on_error ERR
 
 if ! command -v patchelf >/dev/null 2>&1; then
   if sudo -n true >/dev/null 2>&1; then
-    mkdir -p "${TMPDIR:-/tmp}/ssa_build_locks"
-    APT_LOCK_FILE="${TMPDIR:-/tmp}/ssa_build_locks/patchelf_install.lock"
+    APT_LOCK_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/ssa_consulta_rapida/build_locks"
+    mkdir -p "${APT_LOCK_DIR}"
+    chmod 700 "${APT_LOCK_DIR}"
+    APT_LOCK_FILE="${APT_LOCK_DIR}/patchelf_install.lock"
     exec 9>"${APT_LOCK_FILE}"
     if command -v flock >/dev/null 2>&1; then
       flock 9
@@ -142,16 +149,24 @@ rm -rf "${GUI_DIST}" "${CLI_DIST}"
 
 if [[ ! -x "${PYTHON_EXE}" ]]; then
   LAST_STEP="create_venv"
+  mkdir -p "$(dirname "${VENV_DIR}")"
   uv venv --python 3.13 "${VENV_DIR}"
 fi
 
 LAST_STEP="install_requirements"
 uv pip install --python "${PYTHON_EXE}" -r "${REQUIREMENTS_FILE}"
-
-WORK_PARENT="${SSA_NUITKA_WORK_ROOT:-${TMPDIR:-/tmp}/ssa_nuitka_build}"
 if [[ "${REPO_ROOT}" == /mnt/* ]]; then
-  mkdir -p "${WORK_PARENT}"
-  BUILD_WORK_DIR="$(mktemp -d "${WORK_PARENT}/debian_amd64.XXXXXX")"
+  echo "[build_nuitka_debian] usando venv nativo WSL: ${VENV_DIR}" >>"${LOG_FILE}"
+fi
+
+if [[ "${REPO_ROOT}" == /mnt/* ]]; then
+  if [[ -n "${SSA_NUITKA_WORK_ROOT:-}" ]]; then
+    mkdir -p "${SSA_NUITKA_WORK_ROOT}"
+    chmod 700 "${SSA_NUITKA_WORK_ROOT}"
+    BUILD_WORK_DIR="$(mktemp -d "${SSA_NUITKA_WORK_ROOT}/debian_amd64.XXXXXX")"
+  else
+    BUILD_WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ssa_nuitka_debian_amd64.XXXXXX")"
+  fi
   NUITKA_OUTPUT_DIR="${BUILD_WORK_DIR}"
 else
   NUITKA_OUTPUT_DIR="${FINAL_BUILD_DIR}"
@@ -176,6 +191,7 @@ CLI_CMD=(
   --assume-yes-for-downloads
   --follow-imports
   --include-data-dir=config=config
+  --include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md
   --include-data-file="${BUILD_INFO_FILE}=config/build_info.json"
   --output-dir="${NUITKA_OUTPUT_DIR}"
 )
@@ -215,7 +231,7 @@ else
   fi
 fi
 
-echo "Build Nuitka Debian concluido com sucesso."
+echo "Build Nuitka Debian amd64 concluido com sucesso."
 echo "Artefatos em: ${REPO_ROOT}/builds/nuitka/debian_amd64"
 if [[ "${SILENT}" != "1" ]]; then
   read -r -p "Executar cleanup TEMP agora? [s/N]: " DO_CLEANUP

--- a/dev_env/build/build_nuitka_debian_arm64.sh
+++ b/dev_env/build/build_nuitka_debian_arm64.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SILENT=0
+WITH_LOCAL_DATA=0
+for arg in "$@"; do
+  case "${arg}" in
+    --silent)
+      SILENT=1
+      ;;
+    --with-local-data)
+      WITH_LOCAL_DATA=1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+LOG_DIR="${REPO_ROOT}/launchers/logs"
+LOG_FILE="${LOG_DIR}/build_nuitka_debian_arm64.log"
+VENV_DIR="${REPO_ROOT}/launchers/platforms/debian_arm64/venv"
+PYTHON_EXE="${VENV_DIR}/bin/python"
+REQUIREMENTS_FILE="${REPO_ROOT}/launchers/platforms/debian_arm64/requirements.txt"
+
+mkdir -p "${LOG_DIR}"
+mkdir -p "${REPO_ROOT}/builds/nuitka/debian_arm64"
+
+export UV_PYTHON=3.13
+export UV_MANAGED_PYTHON=true
+export UV_PROJECT_ENVIRONMENT=.venv-linux
+
+LAST_STEP=""
+
+on_error() {
+  local exit_code=$?
+  echo "Erro no build Nuitka Debian (step: ${LAST_STEP:-unknown}, exit: ${exit_code})."
+  echo "Log: ${LOG_FILE}"
+  if [[ "${SILENT}" == "1" ]] && [[ -f "${LOG_FILE}" ]]; then
+    echo "------ tail do log ------"
+    tail -n 80 "${LOG_FILE}" || true
+    echo "-------------------------"
+  fi
+  exit "${exit_code}"
+}
+
+trap on_error ERR
+
+if ! command -v patchelf >/dev/null 2>&1; then
+  if sudo -n true >/dev/null 2>&1; then
+    mkdir -p "${TMPDIR:-/tmp}/ssa_build_locks"
+    APT_LOCK_FILE="${TMPDIR:-/tmp}/ssa_build_locks/patchelf_install.lock"
+    exec 9>"${APT_LOCK_FILE}"
+    if command -v flock >/dev/null 2>&1; then
+      flock 9
+    fi
+    if ! command -v patchelf >/dev/null 2>&1; then
+      if [[ "${SILENT}" == "1" ]]; then
+        sudo -n apt-get update 2>&1 | tee -a "${LOG_FILE}" >/dev/null
+        sudo -n apt-get install -y patchelf 2>&1 | tee -a "${LOG_FILE}" >/dev/null
+      else
+        echo "Instalando patchelf..."
+        sudo -n apt-get update
+        sudo -n apt-get install -y patchelf
+      fi
+    fi
+  else
+    echo "Erro: patchelf ausente e sudo sem permissao nao interativa."
+    echo "Execute no WSL: sudo apt-get update && sudo apt-get install -y patchelf"
+    exit 1
+  fi
+fi
+
+VERSION_FILE="${REPO_ROOT}/config/version.json"
+if [[ ! -f "${VERSION_FILE}" ]]; then
+  echo "Erro: version.json nao encontrado: ${VERSION_FILE}"
+  exit 1
+fi
+APP_VERSION="$(
+  uv run --python 3.13 python - "${VERSION_FILE}" <<'PY_VERSION'
+import json
+import pathlib
+import sys
+
+version_file = pathlib.Path(sys.argv[1])
+payload = json.loads(version_file.read_text(encoding="utf-8"))
+version = str(payload.get("version_short") or "").strip()
+if not version:
+    raise SystemExit("version_short ausente em config/version.json")
+print(version)
+PY_VERSION
+)"
+
+GUI_DIST="${REPO_ROOT}/builds/nuitka/debian_arm64/gui_entry.dist"
+CLI_DIST="${REPO_ROOT}/builds/nuitka/debian_arm64/cli_entry.dist"
+rm -rf "${GUI_DIST}" "${CLI_DIST}"
+
+if [[ ! -x "${PYTHON_EXE}" ]]; then
+  LAST_STEP="create_venv"
+  uv venv --python 3.13 "${VENV_DIR}"
+fi
+
+LAST_STEP="install_requirements"
+uv pip install --python "${PYTHON_EXE}" -r "${REQUIREMENTS_FILE}"
+
+GUI_CMD=(
+  "${PYTHON_EXE}" -m nuitka
+  --standalone
+  --assume-yes-for-downloads
+  --follow-imports
+  --enable-plugin=pyqt6
+  --include-data-dir=config=config
+  --include-data-dir=resources=resources
+  --output-dir=builds/nuitka/debian_arm64
+)
+
+CLI_CMD=(
+  "${PYTHON_EXE}" -m nuitka
+  --standalone
+  --assume-yes-for-downloads
+  --follow-imports
+  --include-data-dir=config=config
+  --output-dir=builds/nuitka/debian_arm64
+)
+
+if [[ "${SILENT}" == "1" ]]; then
+  LAST_STEP="nuitka_gui"
+  "${GUI_CMD[@]}" --output-filename="SSA_GUI_v${APP_VERSION}_debian_arm64" --linux-icon=resources/app_icon.png launchers/gui_entry.py >"${LOG_FILE}" 2>&1
+  LAST_STEP="nuitka_cli"
+  "${CLI_CMD[@]}" --output-filename="SSA_CLI_v${APP_VERSION}_debian_arm64" launchers/cli_entry.py >>"${LOG_FILE}" 2>&1
+  if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
+    LAST_STEP="copy_data_to_builds"
+    uv run --python 3.13 "${REPO_ROOT}/scripts/copy_data_to_builds.py" --build-system nuitka --allow-local-data >>"${LOG_FILE}" 2>&1
+  else
+    echo "[build_nuitka_debian_arm64] pulando copia de dados locais. Use --with-local-data para habilitar." >>"${LOG_FILE}"
+  fi
+else
+  echo "Iniciando build Nuitka debian_arm64..."
+  LAST_STEP="nuitka_gui"
+  "${GUI_CMD[@]}" --output-filename="SSA_GUI_v${APP_VERSION}_debian_arm64" --linux-icon=resources/app_icon.png launchers/gui_entry.py
+  LAST_STEP="nuitka_cli"
+  "${CLI_CMD[@]}" --output-filename="SSA_CLI_v${APP_VERSION}_debian_arm64" launchers/cli_entry.py
+  if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
+    LAST_STEP="copy_data_to_builds"
+    uv run --python 3.13 "${REPO_ROOT}/scripts/copy_data_to_builds.py" --build-system nuitka --allow-local-data
+  else
+    echo "INFO Pulando copia de dados locais. Use --with-local-data para habilitar."
+  fi
+fi
+
+echo "Build Nuitka Debian concluido com sucesso."
+echo "Artefatos em: ${REPO_ROOT}/builds/nuitka/debian_arm64"
+if [[ "${SILENT}" != "1" ]]; then
+  read -r -p "Executar cleanup TEMP agora? [s/N]: " DO_CLEANUP
+  if [[ "${DO_CLEANUP,,}" == "s" ]]; then
+    uv run --python 3.13 "${REPO_ROOT}/scripts/cleanup_build_artifacts.py" --scope temp
+  fi
+fi

--- a/dev_env/build/build_nuitka_debian_arm64.sh
+++ b/dev_env/build/build_nuitka_debian_arm64.sh
@@ -18,14 +18,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 LOG_DIR="${REPO_ROOT}/launchers/logs"
 LOG_FILE="${LOG_DIR}/build_nuitka_debian_arm64.log"
-VENV_DIR="${REPO_ROOT}/launchers/platforms/debian_arm64/venv"
-PYTHON_EXE="${VENV_DIR}/bin/python"
 REQUIREMENTS_FILE="${REPO_ROOT}/launchers/platforms/debian_arm64/requirements.txt"
 
 mkdir -p "${LOG_DIR}"
 FINAL_BUILD_DIR="${REPO_ROOT}/builds/nuitka/debian_arm64"
 mkdir -p "${FINAL_BUILD_DIR}"
 BUILD_WORK_DIR=""
+if [[ "${REPO_ROOT}" == /mnt/* ]]; then
+  NATIVE_CACHE_ROOT="${SSA_NUITKA_NATIVE_ROOT:-${XDG_CACHE_HOME:-${HOME}/.cache}/ssa_consulta_rapida/nuitka}"
+  VENV_DIR="${SSA_NUITKA_VENV_DIR:-${NATIVE_CACHE_ROOT}/debian_arm64/venv}"
+else
+  VENV_DIR="${REPO_ROOT}/launchers/platforms/debian_arm64/venv"
+fi
+PYTHON_EXE="${VENV_DIR}/bin/python"
 
 cleanup_build_work_dir() {
   if [[ -n "${BUILD_WORK_DIR}" && "${KEEP_NUITKA_WORK_DIR:-0}" != "1" ]]; then
@@ -58,8 +63,10 @@ trap on_error ERR
 
 if ! command -v patchelf >/dev/null 2>&1; then
   if sudo -n true >/dev/null 2>&1; then
-    mkdir -p "${TMPDIR:-/tmp}/ssa_build_locks"
-    APT_LOCK_FILE="${TMPDIR:-/tmp}/ssa_build_locks/patchelf_install.lock"
+    APT_LOCK_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/ssa_consulta_rapida/build_locks"
+    mkdir -p "${APT_LOCK_DIR}"
+    chmod 700 "${APT_LOCK_DIR}"
+    APT_LOCK_FILE="${APT_LOCK_DIR}/patchelf_install.lock"
     exec 9>"${APT_LOCK_FILE}"
     if command -v flock >/dev/null 2>&1; then
       flock 9
@@ -142,16 +149,24 @@ rm -rf "${GUI_DIST}" "${CLI_DIST}"
 
 if [[ ! -x "${PYTHON_EXE}" ]]; then
   LAST_STEP="create_venv"
+  mkdir -p "$(dirname "${VENV_DIR}")"
   uv venv --python 3.13 "${VENV_DIR}"
 fi
 
 LAST_STEP="install_requirements"
 uv pip install --python "${PYTHON_EXE}" -r "${REQUIREMENTS_FILE}"
-
-WORK_PARENT="${SSA_NUITKA_WORK_ROOT:-${TMPDIR:-/tmp}/ssa_nuitka_build}"
 if [[ "${REPO_ROOT}" == /mnt/* ]]; then
-  mkdir -p "${WORK_PARENT}"
-  BUILD_WORK_DIR="$(mktemp -d "${WORK_PARENT}/debian_arm64.XXXXXX")"
+  echo "[build_nuitka_debian_arm64] usando venv nativo WSL: ${VENV_DIR}" >>"${LOG_FILE}"
+fi
+
+if [[ "${REPO_ROOT}" == /mnt/* ]]; then
+  if [[ -n "${SSA_NUITKA_WORK_ROOT:-}" ]]; then
+    mkdir -p "${SSA_NUITKA_WORK_ROOT}"
+    chmod 700 "${SSA_NUITKA_WORK_ROOT}"
+    BUILD_WORK_DIR="$(mktemp -d "${SSA_NUITKA_WORK_ROOT}/debian_arm64.XXXXXX")"
+  else
+    BUILD_WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ssa_nuitka_debian_arm64.XXXXXX")"
+  fi
   NUITKA_OUTPUT_DIR="${BUILD_WORK_DIR}"
 else
   NUITKA_OUTPUT_DIR="${FINAL_BUILD_DIR}"
@@ -176,6 +191,7 @@ CLI_CMD=(
   --assume-yes-for-downloads
   --follow-imports
   --include-data-dir=config=config
+  --include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md
   --include-data-file="${BUILD_INFO_FILE}=config/build_info.json"
   --output-dir="${NUITKA_OUTPUT_DIR}"
 )

--- a/dev_env/build/build_nuitka_debian_arm64.sh
+++ b/dev_env/build/build_nuitka_debian_arm64.sh
@@ -23,7 +23,18 @@ PYTHON_EXE="${VENV_DIR}/bin/python"
 REQUIREMENTS_FILE="${REPO_ROOT}/launchers/platforms/debian_arm64/requirements.txt"
 
 mkdir -p "${LOG_DIR}"
-mkdir -p "${REPO_ROOT}/builds/nuitka/debian_arm64"
+FINAL_BUILD_DIR="${REPO_ROOT}/builds/nuitka/debian_arm64"
+mkdir -p "${FINAL_BUILD_DIR}"
+BUILD_WORK_DIR=""
+
+cleanup_build_work_dir() {
+  if [[ -n "${BUILD_WORK_DIR}" && "${KEEP_NUITKA_WORK_DIR:-0}" != "1" ]]; then
+    rm -rf -- "${BUILD_WORK_DIR}"
+  fi
+}
+
+trap cleanup_build_work_dir EXIT
+cd "${REPO_ROOT}"
 
 export UV_PYTHON=3.13
 export UV_MANAGED_PYTHON=true
@@ -33,7 +44,7 @@ LAST_STEP=""
 
 on_error() {
   local exit_code=$?
-  echo "Erro no build Nuitka Debian (step: ${LAST_STEP:-unknown}, exit: ${exit_code})."
+  echo "Erro no build Nuitka Debian arm64 (step: ${LAST_STEP:-unknown}, exit: ${exit_code})."
   echo "Log: ${LOG_FILE}"
   if [[ "${SILENT}" == "1" ]] && [[ -f "${LOG_FILE}" ]]; then
     echo "------ tail do log ------"
@@ -90,8 +101,43 @@ print(version)
 PY_VERSION
 )"
 
-GUI_DIST="${REPO_ROOT}/builds/nuitka/debian_arm64/gui_entry.dist"
-CLI_DIST="${REPO_ROOT}/builds/nuitka/debian_arm64/cli_entry.dist"
+BUILD_INFO_FILE="${REPO_ROOT}/builds/metadata/build_info_debian_arm64_nuitka.json"
+mkdir -p "$(dirname "${BUILD_INFO_FILE}")"
+LAST_STEP="write_build_info"
+uv run --python 3.13 python - "${REPO_ROOT}" "${BUILD_INFO_FILE}" "nuitka" "debian_arm64" "${APP_VERSION}" <<'PY_BUILD_INFO'
+import datetime
+import json
+import pathlib
+import subprocess
+import sys
+
+root = pathlib.Path(sys.argv[1])
+output = pathlib.Path(sys.argv[2])
+build_system = sys.argv[3]
+platform_name = sys.argv[4]
+app_version = sys.argv[5]
+
+def run(args):
+    result = subprocess.run(args, cwd=str(root), text=True, capture_output=True, check=False)
+    return (result.stdout or "").strip() if result.returncode == 0 else ""
+
+commit = run(["git", "rev-parse", "HEAD"])
+payload = {
+    "app_version": app_version,
+    "build_datetime": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
+    "build_system": build_system,
+    "git_commit": commit,
+    "git_commit_datetime": run(["git", "log", "-1", "--format=%cI"]),
+    "git_commit_short": commit[:7] if commit else "",
+    "git_commit_title": run(["git", "log", "-1", "--format=%s"]),
+    "platform": platform_name,
+    "uv_version": run(["uv", "--version"]),
+}
+output.write_text(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY_BUILD_INFO
+
+GUI_DIST="${FINAL_BUILD_DIR}/gui_entry.dist"
+CLI_DIST="${FINAL_BUILD_DIR}/cli_entry.dist"
 rm -rf "${GUI_DIST}" "${CLI_DIST}"
 
 if [[ ! -x "${PYTHON_EXE}" ]]; then
@@ -102,6 +148,15 @@ fi
 LAST_STEP="install_requirements"
 uv pip install --python "${PYTHON_EXE}" -r "${REQUIREMENTS_FILE}"
 
+WORK_PARENT="${SSA_NUITKA_WORK_ROOT:-${TMPDIR:-/tmp}/ssa_nuitka_build}"
+if [[ "${REPO_ROOT}" == /mnt/* ]]; then
+  mkdir -p "${WORK_PARENT}"
+  BUILD_WORK_DIR="$(mktemp -d "${WORK_PARENT}/debian_arm64.XXXXXX")"
+  NUITKA_OUTPUT_DIR="${BUILD_WORK_DIR}"
+else
+  NUITKA_OUTPUT_DIR="${FINAL_BUILD_DIR}"
+fi
+
 GUI_CMD=(
   "${PYTHON_EXE}" -m nuitka
   --standalone
@@ -110,7 +165,9 @@ GUI_CMD=(
   --enable-plugin=pyqt6
   --include-data-dir=config=config
   --include-data-dir=resources=resources
-  --output-dir=builds/nuitka/debian_arm64
+  --include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md
+  --include-data-file="${BUILD_INFO_FILE}=config/build_info.json"
+  --output-dir="${NUITKA_OUTPUT_DIR}"
 )
 
 CLI_CMD=(
@@ -119,7 +176,8 @@ CLI_CMD=(
   --assume-yes-for-downloads
   --follow-imports
   --include-data-dir=config=config
-  --output-dir=builds/nuitka/debian_arm64
+  --include-data-file="${BUILD_INFO_FILE}=config/build_info.json"
+  --output-dir="${NUITKA_OUTPUT_DIR}"
 )
 
 if [[ "${SILENT}" == "1" ]]; then
@@ -127,6 +185,11 @@ if [[ "${SILENT}" == "1" ]]; then
   "${GUI_CMD[@]}" --output-filename="SSA_GUI_v${APP_VERSION}_debian_arm64" --linux-icon=resources/app_icon.png launchers/gui_entry.py >"${LOG_FILE}" 2>&1
   LAST_STEP="nuitka_cli"
   "${CLI_CMD[@]}" --output-filename="SSA_CLI_v${APP_VERSION}_debian_arm64" launchers/cli_entry.py >>"${LOG_FILE}" 2>&1
+  if [[ "${NUITKA_OUTPUT_DIR}" != "${FINAL_BUILD_DIR}" ]]; then
+    LAST_STEP="copy_nuitka_dist"
+    cp -a "${NUITKA_OUTPUT_DIR}/gui_entry.dist" "${GUI_DIST}"
+    cp -a "${NUITKA_OUTPUT_DIR}/cli_entry.dist" "${CLI_DIST}"
+  fi
   if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
     LAST_STEP="copy_data_to_builds"
     uv run --python 3.13 "${REPO_ROOT}/scripts/copy_data_to_builds.py" --build-system nuitka --allow-local-data >>"${LOG_FILE}" 2>&1
@@ -139,6 +202,11 @@ else
   "${GUI_CMD[@]}" --output-filename="SSA_GUI_v${APP_VERSION}_debian_arm64" --linux-icon=resources/app_icon.png launchers/gui_entry.py
   LAST_STEP="nuitka_cli"
   "${CLI_CMD[@]}" --output-filename="SSA_CLI_v${APP_VERSION}_debian_arm64" launchers/cli_entry.py
+  if [[ "${NUITKA_OUTPUT_DIR}" != "${FINAL_BUILD_DIR}" ]]; then
+    LAST_STEP="copy_nuitka_dist"
+    cp -a "${NUITKA_OUTPUT_DIR}/gui_entry.dist" "${GUI_DIST}"
+    cp -a "${NUITKA_OUTPUT_DIR}/cli_entry.dist" "${CLI_DIST}"
+  fi
   if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
     LAST_STEP="copy_data_to_builds"
     uv run --python 3.13 "${REPO_ROOT}/scripts/copy_data_to_builds.py" --build-system nuitka --allow-local-data
@@ -147,7 +215,7 @@ else
   fi
 fi
 
-echo "Build Nuitka Debian concluido com sucesso."
+echo "Build Nuitka Debian arm64 concluido com sucesso."
 echo "Artefatos em: ${REPO_ROOT}/builds/nuitka/debian_arm64"
 if [[ "${SILENT}" != "1" ]]; then
   read -r -p "Executar cleanup TEMP agora? [s/N]: " DO_CLEANUP

--- a/dev_env/build/build_pyinstaller_debian_arm64.sh
+++ b/dev_env/build/build_pyinstaller_debian_arm64.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SILENT=0
+WITH_LOCAL_DATA=0
+for arg in "$@"; do
+  case "${arg}" in
+    --silent)
+      SILENT=1
+      ;;
+    --with-local-data)
+      WITH_LOCAL_DATA=1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+LOG_DIR="${REPO_ROOT}/launchers/logs"
+LOG_FILE="${LOG_DIR}/build_pyinstaller_debian_arm64.log"
+
+mkdir -p "${LOG_DIR}"
+
+export UV_PYTHON=3.13
+export UV_MANAGED_PYTHON=true
+export UV_PROJECT_ENVIRONMENT=.venv-linux
+
+COPY_DATA_ARGS=(--build-system pyinstaller)
+if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
+  COPY_DATA_ARGS+=(--allow-local-data)
+fi
+
+if [[ "${SILENT}" == "1" ]]; then
+  uv run --python 3.13 "${REPO_ROOT}/launchers/build_multiplatform.py" --platform debian_arm64 --clean >/dev/null 2>&1
+  uv run --python 3.13 "${REPO_ROOT}/launchers/build_multiplatform.py" --platform debian_arm64 --apps cli gui >"${LOG_FILE}" 2>&1
+  uv run --python 3.13 "${REPO_ROOT}/scripts/sync_pyinstaller_outputs.py" --platform debian_arm64 --quiet >>"${LOG_FILE}" 2>&1
+  if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
+    uv run --python 3.13 "${REPO_ROOT}/scripts/copy_data_to_builds.py" "${COPY_DATA_ARGS[@]}" >>"${LOG_FILE}" 2>&1
+  else
+    echo "[build_pyinstaller_debian_arm64] pulando copia de dados locais. Use --with-local-data para habilitar." >>"${LOG_FILE}"
+  fi
+else
+  echo "Limpando artefatos PyInstaller Debian anteriores..."
+  uv run --python 3.13 "${REPO_ROOT}/launchers/build_multiplatform.py" --platform debian_arm64 --clean
+  echo "Iniciando build PyInstaller debian_arm64..."
+  uv run --python 3.13 "${REPO_ROOT}/launchers/build_multiplatform.py" --platform debian_arm64 --apps cli gui
+  uv run --python 3.13 "${REPO_ROOT}/scripts/sync_pyinstaller_outputs.py" --platform debian_arm64
+  if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
+    uv run --python 3.13 "${REPO_ROOT}/scripts/copy_data_to_builds.py" "${COPY_DATA_ARGS[@]}"
+  else
+    echo "INFO Pulando copia de dados locais. Use --with-local-data para habilitar."
+  fi
+fi
+
+echo "Build PyInstaller Debian concluido com sucesso."
+echo "Artefatos em: ${REPO_ROOT}/launchers/dist/debian_arm64 e ${REPO_ROOT}/builds/pyinstaller/debian_arm64"
+if [[ "${SILENT}" != "1" ]]; then
+  read -r -p "Executar cleanup TEMP agora? [s/N]: " DO_CLEANUP
+  if [[ "${DO_CLEANUP,,}" == "s" ]]; then
+    uv run --python 3.13 "${REPO_ROOT}/scripts/cleanup_build_artifacts.py" --scope temp
+  fi
+fi

--- a/dev_env/build/build_pyoxidizer.bat
+++ b/dev_env/build/build_pyoxidizer.bat
@@ -26,10 +26,12 @@ set "PYOX_RUNTIME_PYTHON=3.10"
 set "UV_MANAGED_PYTHON=true"
 set "UV_PROJECT_ENVIRONMENT=.venv-win"
 
-for /f "tokens=1" %%A in ('uv run --python 3.13 python -c "import json,pathlib; print(json.loads(pathlib.Path('config/version.json').read_text(encoding='utf-8')).get('version_short','0.0'))"') do (
+for /f "tokens=1,2 delims=|" %%A in ('uv run --python 3.13 python -c "import json,pathlib,re; v=str(json.loads(pathlib.Path('config/version.json').read_text(encoding='utf-8')).get('version_short','0.0')); parts=[int(p) for p in re.findall(r'\d+', v)[:4]]; parts=(parts+[0,0,0,0])[:4]; print(v+'|'+'.'.join(str(p) for p in parts))"') do (
     set "APP_VERSION=%%A"
+    set "APP_VERSION_PE=%%B"
 )
 if not defined APP_VERSION set "APP_VERSION=0.0"
+if not defined APP_VERSION_PE set "APP_VERSION_PE=0.0.0.0"
 
 set "MSVC_LINK="
 set "VCVARS="
@@ -246,6 +248,19 @@ if not exist "%APP_ICON%" (
 "%RCEDIT_EXE%" "%TARGET_BUILD_DIR%\SSA_Consulta_Rapida.exe" --set-icon "%APP_ICON%"
 if errorlevel 1 (
     echo Build PyOxidizer concluiu, mas aplicacao do icone falhou.
+    exit /b 1
+)
+"%RCEDIT_EXE%" "%TARGET_BUILD_DIR%\SSA_Consulta_Rapida.exe" ^
+    --set-file-version "%APP_VERSION_PE%" ^
+    --set-product-version "%APP_VERSION_PE%" ^
+    --set-version-string "CompanyName" "SSA Consulta Rapida" ^
+    --set-version-string "FileDescription" "SSA_Consulta_Rapida.exe" ^
+    --set-version-string "InternalName" "SSA_Consulta_Rapida" ^
+    --set-version-string "OriginalFilename" "SSA_Consulta_Rapida.exe" ^
+    --set-version-string "ProductName" "SSA Consulta Rapida" ^
+    --set-version-string "ProductVersion" "%APP_VERSION_PE%"
+if errorlevel 1 (
+    echo Build PyOxidizer concluiu, mas aplicacao de metadata falhou.
     exit /b 1
 )
 

--- a/dev_env/build/build_pyoxidizer.bat
+++ b/dev_env/build/build_pyoxidizer.bat
@@ -21,6 +21,8 @@ if not exist "%LOG_DIR%" mkdir "%LOG_DIR%"
 if not exist "%REPO_ROOT%\builds\pyoxidizer" mkdir "%REPO_ROOT%\builds\pyoxidizer"
 
 set "UV_PYTHON=3.13"
+REM PyOxidizer embeds CPython 3.10 on this target; native runtime libs must match it.
+set "PYOX_RUNTIME_PYTHON=3.10"
 set "UV_MANAGED_PYTHON=true"
 set "UV_PROJECT_ENVIRONMENT=.venv-win"
 
@@ -221,13 +223,39 @@ if /I "%COPY_TOOL%"=="xcopy" (
     )
 )
 
+if not exist "%TARGET_BUILD_DIR%\config" mkdir "%TARGET_BUILD_DIR%\config"
+copy /Y "%REPO_ROOT%\config\version.json" "%TARGET_BUILD_DIR%\config\version.json" >nul
+if errorlevel 1 (
+    echo Build PyOxidizer concluiu, mas copia de config/version.json falhou.
+    exit /b 1
+)
+
+set "RCEDIT_EXE="
+for /f "delims=" %%R in ('where rcedit.exe 2^>nul') do (
+    if not defined RCEDIT_EXE set "RCEDIT_EXE=%%R"
+)
+if not defined RCEDIT_EXE (
+    echo Erro: rcedit.exe nao encontrado. Instale com: scoop install rcedit
+    exit /b 1
+)
+set "APP_ICON=%REPO_ROOT%\resources\app_icon.ico"
+if not exist "%APP_ICON%" (
+    echo Erro: icone do aplicativo nao encontrado: "%APP_ICON%"
+    exit /b 1
+)
+"%RCEDIT_EXE%" "%TARGET_BUILD_DIR%\SSA_Consulta_Rapida.exe" --set-icon "%APP_ICON%"
+if errorlevel 1 (
+    echo Build PyOxidizer concluiu, mas aplicacao do icone falhou.
+    exit /b 1
+)
+
 if "%SILENT%"=="1" (
     set "UV_PROJECT_ENVIRONMENT=.venv-pyoxidizer-runtime-win"
-    uv run --python %UV_PYTHON% --with numpy --with pandas --with tabulate --with openpyxl --with pyqt6 python "%REPO_ROOT%\scripts\sync_pyoxidizer_runtime_libs.py" --target "%TARGET_BUILD_DIR%\lib" >> "%LOG_FILE%" 2>&1
+    uv run --python %PYOX_RUNTIME_PYTHON% --with numpy --with pandas --with tabulate --with openpyxl --with pyqt6 python "%REPO_ROOT%\scripts\sync_pyoxidizer_runtime_libs.py" --target "%TARGET_BUILD_DIR%\lib" >> "%LOG_FILE%" 2>&1
     set "UV_PROJECT_ENVIRONMENT=.venv-win"
 ) else (
     set "UV_PROJECT_ENVIRONMENT=.venv-pyoxidizer-runtime-win"
-    uv run --python %UV_PYTHON% --with numpy --with pandas --with tabulate --with openpyxl --with pyqt6 python "%REPO_ROOT%\scripts\sync_pyoxidizer_runtime_libs.py" --target "%TARGET_BUILD_DIR%\lib"
+    uv run --python %PYOX_RUNTIME_PYTHON% --with numpy --with pandas --with tabulate --with openpyxl --with pyqt6 python "%REPO_ROOT%\scripts\sync_pyoxidizer_runtime_libs.py" --target "%TARGET_BUILD_DIR%\lib"
     set "UV_PROJECT_ENVIRONMENT=.venv-win"
 )
 
@@ -255,6 +283,22 @@ if "%WITH_LOCAL_DATA%"=="1" (
     ) else (
         echo INFO Pulando copia de dados locais. Use --with-local-data para habilitar.
     )
+)
+
+set "SSA_PYOXIDIZER_SMOKE_LOG=%TEMP%\ssa_pyoxidizer_windows_amd64_smoke.log"
+set "PYOXIDIZER_EXE=%TARGET_BUILD_DIR%\SSA_Consulta_Rapida.exe"
+pushd "%TARGET_BUILD_DIR%" >nul
+echo q | "%PYOXIDIZER_EXE%" > "%SSA_PYOXIDIZER_SMOKE_LOG%" 2>&1
+set "PYOX_SMOKE_RC=!ERRORLEVEL!"
+popd >nul
+if not "%PYOX_SMOKE_RC%"=="0" (
+    echo Smoke PyOxidizer falhou. Veja: "%SSA_PYOXIDIZER_SMOKE_LOG%"
+    exit /b 1
+)
+findstr /C:"Falha critica nas importacoes" /C:"Error importing numpy" /C:"modo limitado" "%SSA_PYOXIDIZER_SMOKE_LOG%" >nul 2>&1
+if not errorlevel 1 (
+    echo Smoke PyOxidizer detectou runtime quebrado. Veja: "%SSA_PYOXIDIZER_SMOKE_LOG%"
+    exit /b 1
 )
 
 echo Build PyOxidizer concluido com sucesso.

--- a/dev_env/build/build_pyoxidizer.bat
+++ b/dev_env/build/build_pyoxidizer.bat
@@ -24,6 +24,12 @@ set "UV_PYTHON=3.13"
 set "UV_MANAGED_PYTHON=true"
 set "UV_PROJECT_ENVIRONMENT=.venv-win"
 
+for /f "tokens=1" %%A in ('uv run --python 3.13 python -c "import json,pathlib; print(json.loads(pathlib.Path('config/version.json').read_text(encoding='utf-8')).get('version_short','0.0'))"') do (
+    set "APP_VERSION=%%A"
+)
+if not defined APP_VERSION set "APP_VERSION=0.0"
+
+set "MSVC_LINK="
 set "VCVARS="
 set "VSWHERE=C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
 
@@ -67,6 +73,17 @@ if defined VCToolsInstallDir (
         set "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=%MSVC_LINK%"
         if "%SILENT%"=="0" echo Linker MSVC forcado: "%MSVC_LINK%"
     )
+)
+
+if not defined MSVC_LINK (
+    for /f "delims=" %%L in ('where link.exe 2^>nul') do (
+        if not defined MSVC_LINK set "MSVC_LINK=%%L"
+    )
+)
+
+if not defined MSVC_LINK (
+    echo Erro: linker MSVC nao localizado. link.exe atual no PATH pode nao ser do Visual Studio.
+    exit /b 1
 )
 
 if not exist "%MSVC_LINK%" (
@@ -137,6 +154,19 @@ for %%D in (core gui armazenamento extracao utils interface exportacao shared co
             )
         )
     )
+)
+if not exist "%STAGE_DIR%\docs" mkdir "%STAGE_DIR%\docs"
+copy /Y "%REPO_ROOT%\docs\GUIA_MIGRACAO_NOVA_INSTALACAO.md" "%STAGE_DIR%\docs\GUIA_MIGRACAO_NOVA_INSTALACAO.md" >nul
+if errorlevel 1 (
+    echo Erro ao copiar guia de instalacao para staging.
+    exit /b 1
+)
+if not exist "%STAGE_DIR%\config" mkdir "%STAGE_DIR%\config"
+set "BUILD_INFO_FILE=%STAGE_DIR%\config\build_info.json"
+uv run --python 3.13 python -c "import datetime,json,os,pathlib,subprocess; root=pathlib.Path(os.environ['REPO_ROOT']); run=lambda args: subprocess.run(args,cwd=str(root),text=True,capture_output=True,check=False).stdout.strip(); commit=run(['git','rev-parse','HEAD']); payload={'app_version':os.environ.get('APP_VERSION',''),'build_datetime':datetime.datetime.now().astimezone().isoformat(timespec='seconds'),'build_system':'pyoxidizer','git_commit':commit,'git_commit_datetime':run(['git','log','-1','--format=%%cI']),'git_commit_short':commit[:7] if commit else '','git_commit_title':run(['git','log','-1','--format=%%s']),'platform':'windows_amd64','uv_version':run(['uv','--version'])}; pathlib.Path(os.environ['BUILD_INFO_FILE']).write_text(json.dumps(payload,ensure_ascii=True,indent=2,sort_keys=True)+'\n',encoding='utf-8')"
+if errorlevel 1 (
+    echo Erro ao gerar build_info.json para staging.
+    exit /b 1
 )
 set "STAGE_DIR_POSIX=%STAGE_DIR:\=/%"
 

--- a/dev_env/build/build_pyoxidizer_debian.sh
+++ b/dev_env/build/build_pyoxidizer_debian.sh
@@ -33,6 +33,65 @@ export UV_PYTHON=3.13
 export UV_MANAGED_PYTHON=true
 export UV_PROJECT_ENVIRONMENT=.venv-linux
 
+VERSION_FILE="${REPO_ROOT}/config/version.json"
+if [[ ! -f "${VERSION_FILE}" ]]; then
+  echo "Erro: version.json nao encontrado: ${VERSION_FILE}"
+  exit 1
+fi
+
+BUILD_INFO_FILE="${REPO_ROOT}/config/build_info.json"
+BUILD_INFO_BACKUP=""
+if [[ -f "${BUILD_INFO_FILE}" ]]; then
+  BUILD_INFO_BACKUP="${BUILD_INFO_FILE}.$$.bak"
+  cp -p "${BUILD_INFO_FILE}" "${BUILD_INFO_BACKUP}"
+fi
+
+cleanup_build_info() {
+  if [[ -n "${BUILD_INFO_BACKUP}" && -f "${BUILD_INFO_BACKUP}" ]]; then
+    mv -f "${BUILD_INFO_BACKUP}" "${BUILD_INFO_FILE}"
+  else
+    rm -f "${BUILD_INFO_FILE}"
+  fi
+}
+trap cleanup_build_info EXIT
+
+uv run --python 3.13 python - "${REPO_ROOT}" "${VERSION_FILE}" "${BUILD_INFO_FILE}" "pyoxidizer" "debian_amd64" <<'PY_BUILD_INFO'
+import datetime
+import json
+import pathlib
+import subprocess
+import sys
+
+root = pathlib.Path(sys.argv[1])
+version_file = pathlib.Path(sys.argv[2])
+output = pathlib.Path(sys.argv[3])
+build_system = sys.argv[4]
+platform_name = sys.argv[5]
+
+version_payload = json.loads(version_file.read_text(encoding="utf-8"))
+app_version = str(version_payload.get("version_short") or "").strip()
+if not app_version:
+    raise SystemExit("version_short ausente em config/version.json")
+
+def run(args):
+    result = subprocess.run(args, cwd=str(root), text=True, capture_output=True, check=False)
+    return (result.stdout or "").strip() if result.returncode == 0 else ""
+
+commit = run(["git", "rev-parse", "HEAD"])
+payload = {
+    "app_version": app_version,
+    "build_datetime": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
+    "build_system": build_system,
+    "git_commit": commit,
+    "git_commit_datetime": run(["git", "log", "-1", "--format=%cI"]),
+    "git_commit_short": commit[:7] if commit else "",
+    "git_commit_title": run(["git", "log", "-1", "--format=%s"]),
+    "platform": platform_name,
+    "uv_version": run(["uv", "--version"]),
+}
+output.write_text(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY_BUILD_INFO
+
 PYOX_CMD=(
   uv tool run --python 3.13 --from pyoxidizer pyoxidizer build
   --release
@@ -55,9 +114,10 @@ else
   "${PYOX_CMD[@]}"
 fi
 
-SOURCE_INSTALL="${REPO_ROOT}/build/x86_64-unknown-linux-gnu/release/install"
-if [[ ! -d "${SOURCE_INSTALL}" ]]; then
-  SOURCE_INSTALL="$(find "${REPO_ROOT}/build" -maxdepth 6 -type d -path "*/x86_64-unknown-linux-gnu/*/install" | head -n 1 || true)"
+SOURCE_INSTALL_ROOT="${REPO_ROOT}/build/x86_64-unknown-linux-gnu"
+SOURCE_INSTALL="${SOURCE_INSTALL_ROOT}/release/install"
+if [[ ! -d "${SOURCE_INSTALL}" && -d "${SOURCE_INSTALL_ROOT}" ]]; then
+  SOURCE_INSTALL="$(find "${SOURCE_INSTALL_ROOT}" -maxdepth 4 -type d -path "*/install" | head -n 1 || true)"
 fi
 if [[ -z "${SOURCE_INSTALL}" || ! -d "${SOURCE_INSTALL}" ]]; then
   echo "Build PyOxidizer concluiu, mas pasta install Linux nao foi encontrada em build/."

--- a/dev_env/build/build_pyoxidizer_debian_arm64.sh
+++ b/dev_env/build/build_pyoxidizer_debian_arm64.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SILENT=0
+WITH_LOCAL_DATA=0
+for arg in "$@"; do
+  case "${arg}" in
+    --silent)
+      SILENT=1
+      ;;
+    --with-local-data)
+      WITH_LOCAL_DATA=1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+LOG_DIR="${REPO_ROOT}/launchers/logs"
+LOG_FILE="${LOG_DIR}/build_pyoxidizer_debian_arm64.log"
+TARGET_BUILD_DIR="${REPO_ROOT}/builds/pyoxidizer/debian_arm64"
+PYOX_CONFIG="${REPO_ROOT}/pyoxidizer.bzl"
+
+mkdir -p "${LOG_DIR}"
+mkdir -p "${REPO_ROOT}/builds/pyoxidizer"
+
+if [[ ! -f "${PYOX_CONFIG}" ]]; then
+  echo "Erro: pyoxidizer.bzl nao encontrado na raiz do repositorio: ${PYOX_CONFIG}"
+  exit 1
+fi
+
+export UV_PYTHON=3.13
+export UV_MANAGED_PYTHON=true
+export UV_PROJECT_ENVIRONMENT=.venv-linux
+
+PYOX_CMD=(
+  uv tool run --python 3.13 --from pyoxidizer pyoxidizer build
+  --release
+  --var SSA_PROJECT_ROOT "${REPO_ROOT}"
+  --path "${REPO_ROOT}"
+)
+
+COPY_DATA_ARGS=(--build-system pyoxidizer)
+if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
+  COPY_DATA_ARGS+=(--allow-local-data)
+fi
+
+if [[ "${SILENT}" == "1" ]]; then
+  echo "[build_pyoxidizer_debian_arm64] modo silencioso ativo. log: ${LOG_FILE}"
+  echo "[build_pyoxidizer_debian_arm64] usando pyoxidizer.bzl da raiz: ${PYOX_CONFIG}" >>"${LOG_FILE}"
+  "${PYOX_CMD[@]}" >"${LOG_FILE}" 2>&1
+else
+  echo "Iniciando build PyOxidizer debian_arm64..."
+  echo "Usando pyoxidizer.bzl da raiz: ${PYOX_CONFIG}"
+  "${PYOX_CMD[@]}"
+fi
+
+SOURCE_INSTALL="${REPO_ROOT}/build/aarch64-unknown-linux-gnu/release/install"
+if [[ ! -d "${SOURCE_INSTALL}" ]]; then
+  SOURCE_INSTALL="$(find "${REPO_ROOT}/build" -maxdepth 6 -type d -path "*/aarch64-unknown-linux-gnu/*/install" | head -n 1 || true)"
+fi
+if [[ -z "${SOURCE_INSTALL}" || ! -d "${SOURCE_INSTALL}" ]]; then
+  echo "Build PyOxidizer concluiu, mas pasta install Linux nao foi encontrada em build/."
+  echo "Veja o log: ${LOG_FILE}"
+  exit 1
+fi
+
+rm -rf "${TARGET_BUILD_DIR}"
+mkdir -p "${TARGET_BUILD_DIR}"
+cp -a "${SOURCE_INSTALL}/." "${TARGET_BUILD_DIR}/"
+
+if [[ -d "${TARGET_BUILD_DIR}/lib" && ! -e "${TARGET_BUILD_DIR}/lib/python3.10" ]]; then
+  ln -s . "${TARGET_BUILD_DIR}/lib/python3.10"
+fi
+
+if [[ "${SILENT}" == "1" ]]; then
+  UV_PROJECT_ENVIRONMENT=.venv-pyoxidizer-runtime-linux \
+  uv run --python 3.10 --with numpy --with pandas --with tabulate --with openpyxl --with pyqt6 \
+    python "${REPO_ROOT}/scripts/sync_pyoxidizer_runtime_libs.py" --target "${TARGET_BUILD_DIR}/lib" >>"${LOG_FILE}" 2>&1
+else
+  UV_PROJECT_ENVIRONMENT=.venv-pyoxidizer-runtime-linux \
+  uv run --python 3.10 --with numpy --with pandas --with tabulate --with openpyxl --with pyqt6 \
+    python "${REPO_ROOT}/scripts/sync_pyoxidizer_runtime_libs.py" --target "${TARGET_BUILD_DIR}/lib"
+fi
+
+if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
+  if [[ "${SILENT}" == "1" ]]; then
+    uv run --python 3.13 "${REPO_ROOT}/scripts/copy_data_to_builds.py" "${COPY_DATA_ARGS[@]}" >>"${LOG_FILE}" 2>&1
+  else
+    uv run --python 3.13 "${REPO_ROOT}/scripts/copy_data_to_builds.py" "${COPY_DATA_ARGS[@]}"
+  fi
+elif [[ "${SILENT}" == "1" ]]; then
+  echo "[build_pyoxidizer_debian_arm64] pulando copia de dados locais. Use --with-local-data para habilitar." >>"${LOG_FILE}"
+else
+  echo "INFO Pulando copia de dados locais. Use --with-local-data para habilitar."
+fi
+
+echo "Build PyOxidizer Debian concluido com sucesso."
+echo "Artefatos em: ${TARGET_BUILD_DIR}"
+if [[ "${SILENT}" != "1" ]]; then
+  read -r -p "Executar cleanup TEMP agora? [s/N]: " DO_CLEANUP
+  if [[ "${DO_CLEANUP,,}" == "s" ]]; then
+    uv run --python 3.13 "${REPO_ROOT}/scripts/cleanup_build_artifacts.py" --scope temp
+  fi
+fi

--- a/dev_env/build/build_pyoxidizer_debian_arm64.sh
+++ b/dev_env/build/build_pyoxidizer_debian_arm64.sh
@@ -33,6 +33,65 @@ export UV_PYTHON=3.13
 export UV_MANAGED_PYTHON=true
 export UV_PROJECT_ENVIRONMENT=.venv-linux
 
+VERSION_FILE="${REPO_ROOT}/config/version.json"
+if [[ ! -f "${VERSION_FILE}" ]]; then
+  echo "Erro: version.json nao encontrado: ${VERSION_FILE}"
+  exit 1
+fi
+
+BUILD_INFO_FILE="${REPO_ROOT}/config/build_info.json"
+BUILD_INFO_BACKUP=""
+if [[ -f "${BUILD_INFO_FILE}" ]]; then
+  BUILD_INFO_BACKUP="${BUILD_INFO_FILE}.$$.bak"
+  cp -p "${BUILD_INFO_FILE}" "${BUILD_INFO_BACKUP}"
+fi
+
+cleanup_build_info() {
+  if [[ -n "${BUILD_INFO_BACKUP}" && -f "${BUILD_INFO_BACKUP}" ]]; then
+    mv -f "${BUILD_INFO_BACKUP}" "${BUILD_INFO_FILE}"
+  else
+    rm -f "${BUILD_INFO_FILE}"
+  fi
+}
+trap cleanup_build_info EXIT
+
+uv run --python 3.13 python - "${REPO_ROOT}" "${VERSION_FILE}" "${BUILD_INFO_FILE}" "pyoxidizer" "debian_arm64" <<'PY_BUILD_INFO'
+import datetime
+import json
+import pathlib
+import subprocess
+import sys
+
+root = pathlib.Path(sys.argv[1])
+version_file = pathlib.Path(sys.argv[2])
+output = pathlib.Path(sys.argv[3])
+build_system = sys.argv[4]
+platform_name = sys.argv[5]
+
+version_payload = json.loads(version_file.read_text(encoding="utf-8"))
+app_version = str(version_payload.get("version_short") or "").strip()
+if not app_version:
+    raise SystemExit("version_short ausente em config/version.json")
+
+def run(args):
+    result = subprocess.run(args, cwd=str(root), text=True, capture_output=True, check=False)
+    return (result.stdout or "").strip() if result.returncode == 0 else ""
+
+commit = run(["git", "rev-parse", "HEAD"])
+payload = {
+    "app_version": app_version,
+    "build_datetime": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
+    "build_system": build_system,
+    "git_commit": commit,
+    "git_commit_datetime": run(["git", "log", "-1", "--format=%cI"]),
+    "git_commit_short": commit[:7] if commit else "",
+    "git_commit_title": run(["git", "log", "-1", "--format=%s"]),
+    "platform": platform_name,
+    "uv_version": run(["uv", "--version"]),
+}
+output.write_text(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY_BUILD_INFO
+
 PYOX_CMD=(
   uv tool run --python 3.13 --from pyoxidizer pyoxidizer build
   --release
@@ -55,9 +114,10 @@ else
   "${PYOX_CMD[@]}"
 fi
 
-SOURCE_INSTALL="${REPO_ROOT}/build/aarch64-unknown-linux-gnu/release/install"
-if [[ ! -d "${SOURCE_INSTALL}" ]]; then
-  SOURCE_INSTALL="$(find "${REPO_ROOT}/build" -maxdepth 6 -type d -path "*/aarch64-unknown-linux-gnu/*/install" | head -n 1 || true)"
+SOURCE_INSTALL_ROOT="${REPO_ROOT}/build/aarch64-unknown-linux-gnu"
+SOURCE_INSTALL="${SOURCE_INSTALL_ROOT}/release/install"
+if [[ ! -d "${SOURCE_INSTALL}" && -d "${SOURCE_INSTALL_ROOT}" ]]; then
+  SOURCE_INSTALL="$(find "${SOURCE_INSTALL_ROOT}" -maxdepth 4 -type d -path "*/install" | head -n 1 || true)"
 fi
 if [[ -z "${SOURCE_INSTALL}" || ! -d "${SOURCE_INSTALL}" ]]; then
   echo "Build PyOxidizer concluiu, mas pasta install Linux nao foi encontrada em build/."

--- a/dev_env/build/package_debian_amd64_appimage.sh
+++ b/dev_env/build/package_debian_amd64_appimage.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+export DEBIAN_PLATFORM="debian_amd64"
+export DEBIAN_PACKAGE_ARCH="amd64"
+export DEBIAN_MACHINE_REGEX='^(x86_64|amd64)$'
+export DEBIAN_APPIMAGE_ARCH="x86_64"
+export DEBIAN_ARCH_LABEL="amd64/x86_64"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+exec "${SCRIPT_DIR}/package_debian_appimage.sh" "$@"

--- a/dev_env/build/package_debian_amd64_deb.sh
+++ b/dev_env/build/package_debian_amd64_deb.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+export DEBIAN_PLATFORM="debian_amd64"
+export DEBIAN_PACKAGE_ARCH="amd64"
+export DEBIAN_MACHINE_REGEX='^(x86_64|amd64)$'
+export DEBIAN_APPIMAGE_ARCH="x86_64"
+export DEBIAN_ARCH_LABEL="amd64/x86_64"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+exec "${SCRIPT_DIR}/package_debian_deb.sh" "$@"

--- a/dev_env/build/package_debian_appimage.sh
+++ b/dev_env/build/package_debian_appimage.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BUILD_SYSTEM="pyinstaller"
+OUTPUT_DIR=""
+STAGING_DIR=""
+APPIMAGETOOL_BIN="${APPIMAGETOOL:-}"
+KEEP_STAGING=0
+PREPARE_ONLY=0
+
+usage() {
+  cat <<USAGE
+Uso: $(basename "$0") [opcoes]
+
+Gera AppImage Debian ${DEBIAN_ARCH_LABEL} a partir do artefato GUI Linux.
+
+Opcoes:
+  --build-system NAME   pyinstaller ou nuitka (default: pyinstaller)
+  --output-dir DIR      diretorio final (default: builds/packages/${DEBIAN_PLATFORM})
+  --staging-dir DIR     diretorio temporario (default: build/package_${DEBIAN_PLATFORM}_appimage)
+  --appimagetool PATH   caminho do appimagetool ${DEBIAN_APPIMAGE_ARCH}
+  --prepare-only        prepara AppDir sem chamar appimagetool
+  --keep-staging        nao remove AppDir ao terminar
+  -h, --help            mostra esta ajuda
+
+Pre-requisitos:
+  - rodar no Debian ${DEBIAN_ARCH_LABEL}
+  - appimagetool ${DEBIAN_APPIMAGE_ARCH} no PATH ou informado por --appimagetool
+  - artefato GUI em launchers/dist/${DEBIAN_PLATFORM} ou builds/nuitka/${DEBIAN_PLATFORM}
+USAGE
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd -P)"
+# shellcheck source=dev_env/build/package_debian_common.sh
+source "${SCRIPT_DIR}/package_debian_common.sh"
+require_debian_package_context
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build-system)
+      BUILD_SYSTEM="${2:?valor ausente para --build-system}"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="${2:?valor ausente para --output-dir}"
+      shift 2
+      ;;
+    --staging-dir)
+      STAGING_DIR="${2:?valor ausente para --staging-dir}"
+      shift 2
+      ;;
+    --appimagetool)
+      APPIMAGETOOL_BIN="${2:?valor ausente para --appimagetool}"
+      shift 2
+      ;;
+    --prepare-only)
+      PREPARE_ONLY=1
+      shift
+      ;;
+    --keep-staging)
+      KEEP_STAGING=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Erro: opcao desconhecida: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}/builds/packages/${DEBIAN_PLATFORM}}"
+STAGING_DIR="${STAGING_DIR:-${REPO_ROOT}/build/package_${DEBIAN_PLATFORM}_appimage}"
+APPDIR="${STAGING_DIR}/SSA_Consulta_Rapida.AppDir"
+APP_ID="ssa-consulta-rapida"
+APP_DISPLAY_NAME="SSA Consulta Rapida"
+APP_EXEC=""
+
+case "${BUILD_SYSTEM}" in
+  pyinstaller | nuitka) ;;
+  *)
+    echo "Erro: --build-system deve ser pyinstaller ou nuitka para AppImage GUI." >&2
+    exit 2
+    ;;
+esac
+
+assert_debian_machine
+
+VERSION_FILE="${REPO_ROOT}/config/version.json"
+APP_VERSION="$(read_app_version "${VERSION_FILE}")"
+
+safe_reset_dir "${STAGING_DIR}"
+mkdir -p -- "${APPDIR}/opt/${APP_ID}" "${APPDIR}/usr/share/applications" "${APPDIR}/usr/share/icons/hicolor/256x256/apps" "${OUTPUT_DIR}"
+
+case "${BUILD_SYSTEM}" in
+  pyinstaller)
+    SOURCE_ROOT="${REPO_ROOT}/launchers/dist/${DEBIAN_PLATFORM}"
+    [[ -d "${SOURCE_ROOT}" ]] || SOURCE_ROOT="${REPO_ROOT}/builds/pyinstaller/${DEBIAN_PLATFORM}"
+    copy_dir_checked "${SOURCE_ROOT}/SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}" "${APPDIR}/opt/${APP_ID}/runtime"
+    APP_EXEC="$(
+      first_existing_executable \
+        "${APPDIR}/opt/${APP_ID}/runtime/SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}"
+    )"
+    ;;
+  nuitka)
+    copy_dir_checked "${REPO_ROOT}/builds/nuitka/${DEBIAN_PLATFORM}/gui_entry.dist" "${APPDIR}/opt/${APP_ID}/runtime"
+    APP_EXEC="$(
+      first_existing_executable \
+        "${APPDIR}/opt/${APP_ID}/runtime/SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}" \
+        "${APPDIR}/opt/${APP_ID}/runtime/gui_entry"
+    )"
+    ;;
+esac
+
+require_executable "${APP_EXEC}"
+APP_REL_EXEC="${APP_EXEC/${APPDIR}/}"
+
+clean_release_tree "${APPDIR}"
+
+if [[ -f "${REPO_ROOT}/resources/app_icon.png" ]]; then
+  cp -a -- "${REPO_ROOT}/resources/app_icon.png" "${APPDIR}/${APP_ID}.png"
+  cp -a -- "${REPO_ROOT}/resources/app_icon.png" "${APPDIR}/usr/share/icons/hicolor/256x256/apps/${APP_ID}.png"
+fi
+
+cat >"${APPDIR}/${APP_ID}.desktop" <<DESKTOP
+[Desktop Entry]
+Type=Application
+Name=${APP_DISPLAY_NAME}
+Exec=AppRun
+Icon=${APP_ID}
+Categories=Utility;
+Terminal=false
+DESKTOP
+cp -a -- "${APPDIR}/${APP_ID}.desktop" "${APPDIR}/usr/share/applications/${APP_ID}.desktop"
+
+cat >"${APPDIR}/AppRun" <<APPRUN
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="\$(cd -- "\$(dirname -- "\${BASH_SOURCE[0]}")" && pwd -P)"
+exec "\${HERE}${APP_REL_EXEC}" "\$@"
+APPRUN
+chmod 0755 "${APPDIR}/AppRun"
+
+if [[ "${PREPARE_ONLY}" == "1" ]]; then
+  echo "AppDir preparado: ${APPDIR}"
+  exit 0
+fi
+
+if [[ -z "${APPIMAGETOOL_BIN}" ]]; then
+  APPIMAGETOOL_BIN="$(command -v appimagetool || true)"
+fi
+if [[ -z "${APPIMAGETOOL_BIN}" || ! -x "${APPIMAGETOOL_BIN}" ]]; then
+  echo "Erro: appimagetool ${DEBIAN_APPIMAGE_ARCH} nao encontrado." >&2
+  echo "Informe com --appimagetool /caminho/appimagetool-${DEBIAN_APPIMAGE_ARCH}.AppImage ou APPIMAGETOOL=/caminho." >&2
+  exit 1
+fi
+
+OUTPUT_FILE="${OUTPUT_DIR}/SSA_Consulta_Rapida_v${APP_VERSION}_${DEBIAN_PLATFORM}_${BUILD_SYSTEM}.AppImage"
+ARCH="${DEBIAN_APPIMAGE_ARCH}" "${APPIMAGETOOL_BIN}" "${APPDIR}" "${OUTPUT_FILE}"
+chmod 0755 "${OUTPUT_FILE}"
+
+if [[ "${KEEP_STAGING}" != "1" ]]; then
+  rm -rf -- "${STAGING_DIR}"
+fi
+
+echo "AppImage gerado: ${OUTPUT_FILE}"

--- a/dev_env/build/package_debian_appimage.sh
+++ b/dev_env/build/package_debian_appimage.sh
@@ -75,7 +75,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}/builds/packages/${DEBIAN_PLATFORM}}"
-STAGING_DIR="${STAGING_DIR:-${REPO_ROOT}/build/package_${DEBIAN_PLATFORM}_appimage}"
+if [[ -z "${STAGING_DIR}" ]]; then
+  STAGING_DIR="$(default_package_staging_dir appimage)"
+fi
 APPDIR="${STAGING_DIR}/SSA_Consulta_Rapida.AppDir"
 APP_ID="ssa-consulta-rapida"
 APP_DISPLAY_NAME="SSA Consulta Rapida"
@@ -109,16 +111,20 @@ case "${BUILD_SYSTEM}" in
     ;;
   nuitka)
     copy_dir_checked "${REPO_ROOT}/builds/nuitka/${DEBIAN_PLATFORM}/gui_entry.dist" "${APPDIR}/opt/${APP_ID}/runtime"
+    APP_FALLBACK_EXEC="$(
+      find "${APPDIR}/opt/${APP_ID}/runtime" -maxdepth 1 -type f -executable -print -quit
+    )"
     APP_EXEC="$(
       first_existing_executable \
         "${APPDIR}/opt/${APP_ID}/runtime/SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}" \
-        "${APPDIR}/opt/${APP_ID}/runtime/gui_entry"
+        "${APPDIR}/opt/${APP_ID}/runtime/gui_entry" \
+        "${APP_FALLBACK_EXEC}"
     )"
     ;;
 esac
 
 require_executable "${APP_EXEC}"
-APP_REL_EXEC="${APP_EXEC/${APPDIR}/}"
+APP_REL_EXEC="${APP_EXEC#"${APPDIR}"}"
 
 clean_release_tree "${APPDIR}"
 

--- a/dev_env/build/package_debian_arm64_appimage.sh
+++ b/dev_env/build/package_debian_arm64_appimage.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+export DEBIAN_PLATFORM="debian_arm64"
+export DEBIAN_PACKAGE_ARCH="arm64"
+export DEBIAN_MACHINE_REGEX='^(aarch64|arm64)$'
+export DEBIAN_APPIMAGE_ARCH="aarch64"
+export DEBIAN_ARCH_LABEL="arm64/aarch64"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+exec "${SCRIPT_DIR}/package_debian_appimage.sh" "$@"

--- a/dev_env/build/package_debian_arm64_deb.sh
+++ b/dev_env/build/package_debian_arm64_deb.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+export DEBIAN_PLATFORM="debian_arm64"
+export DEBIAN_PACKAGE_ARCH="arm64"
+export DEBIAN_MACHINE_REGEX='^(aarch64|arm64)$'
+export DEBIAN_APPIMAGE_ARCH="aarch64"
+export DEBIAN_ARCH_LABEL="arm64/aarch64"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+exec "${SCRIPT_DIR}/package_debian_deb.sh" "$@"

--- a/dev_env/build/package_debian_common.sh
+++ b/dev_env/build/package_debian_common.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+require_debian_package_context() {
+  : "${DEBIAN_PLATFORM:?DEBIAN_PLATFORM nao definido}"
+  : "${DEBIAN_PACKAGE_ARCH:?DEBIAN_PACKAGE_ARCH nao definido}"
+  : "${DEBIAN_MACHINE_REGEX:?DEBIAN_MACHINE_REGEX nao definido}"
+  : "${DEBIAN_APPIMAGE_ARCH:?DEBIAN_APPIMAGE_ARCH nao definido}"
+  : "${DEBIAN_ARCH_LABEL:?DEBIAN_ARCH_LABEL nao definido}"
+}
+
+read_app_version() {
+  local version_file="$1"
+  local version=""
+  if command -v jq >/dev/null 2>&1; then
+    if version="$(jq -er '.version_short // empty' "${version_file}")" && [[ -n "${version}" ]]; then
+      printf '%s\n' "${version}"
+      return 0
+    fi
+  fi
+  uv run --python 3.13 python - "${version_file}" <<'PY_VERSION'
+import json
+import pathlib
+import sys
+
+version_file = pathlib.Path(sys.argv[1])
+payload = json.loads(version_file.read_text(encoding="utf-8"))
+version = str(payload.get("version_short") or "").strip()
+if not version:
+    raise SystemExit(f"version_short ausente em {sys.argv[1]}")
+print(version)
+PY_VERSION
+}
+
+safe_reset_dir() {
+  local dir="$1"
+  local resolved_dir
+  local allowed_build
+  local allowed_packages
+  resolved_dir="$(realpath -m -- "${dir}")"
+  allowed_build="$(realpath -m -- "${REPO_ROOT}/build")"
+  allowed_packages="$(realpath -m -- "${REPO_ROOT}/builds/packages")"
+  if [[ -z "${dir}" || "${resolved_dir}" == "/" || "${resolved_dir}" == "${REPO_ROOT}" ]]; then
+    echo "Erro: recusa limpar diretorio inseguro: ${dir}" >&2
+    exit 1
+  fi
+  case "${resolved_dir}/" in
+    "${allowed_build}/"* | "${allowed_packages}/"*) ;;
+    *)
+      echo "Erro: staging fora dos diretorios permitidos: ${resolved_dir}" >&2
+      exit 1
+      ;;
+  esac
+  rm -rf -- "${resolved_dir}"
+  mkdir -p -- "${resolved_dir}"
+}
+
+clean_release_tree() {
+  local root="$1"
+  find "${root}" \
+    \( -type d \( -name venv -o -name .venv -o -name __pycache__ \) -prune -exec rm -rf -- {} + \) -o \
+    \( -type f \( \
+      -name '*.bak' -o -name '*.bak-*' -o -name '*.bak.*' -o -name '*.example.bak_*' -o \
+      -name '*.db' -o -name '*.sqlite' -o -name '*.sqlite3' -o \
+      -name '*.xlsx' -o -name '*.xls' -o -name '*.xlsm' -o \
+      -name '.env' -o -name '.env.*' \
+    \) -exec rm -f -- {} + \)
+}
+
+copy_dir_checked() {
+  local src="$1"
+  local dst="$2"
+  if [[ ! -d "${src}" ]]; then
+    echo "Erro: artefato esperado nao encontrado: ${src}" >&2
+    exit 1
+  fi
+  mkdir -p -- "$(dirname -- "${dst}")"
+  cp -a -- "${src}" "${dst}"
+}
+
+require_executable() {
+  local executable_path="$1"
+  if [[ ! -x "${executable_path}" ]]; then
+    echo "Erro: executavel esperado nao encontrado ou sem permissao: ${executable_path}" >&2
+    exit 1
+  fi
+}
+
+first_existing_executable() {
+  local candidate
+  for candidate in "$@"; do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  echo "Erro: nenhum executavel esperado foi encontrado." >&2
+  printf 'Candidatos:\n' >&2
+  for candidate in "$@"; do
+    printf '  %s\n' "${candidate}" >&2
+  done
+  exit 1
+}
+
+write_wrapper() {
+  local wrapper_path="$1"
+  local target_path="$2"
+  local args_text=""
+  local arg
+  local quoted_arg
+  shift 2
+  for arg in "$@"; do
+    printf -v quoted_arg '%q' "${arg}"
+    args_text+=" ${quoted_arg}"
+  done
+  cat >"${wrapper_path}" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+exec "${target_path}"${args_text} "\$@"
+WRAPPER
+  chmod 0755 "${wrapper_path}"
+}
+
+assert_debian_machine() {
+  local machine
+  machine="$(uname -m)"
+  if [[ ! "${machine}" =~ ${DEBIAN_MACHINE_REGEX} ]]; then
+    echo "Erro: este script deve rodar em Debian ${DEBIAN_ARCH_LABEL}." >&2
+    echo "Arquitetura atual: ${machine}" >&2
+    exit 1
+  fi
+}

--- a/dev_env/build/package_debian_common.sh
+++ b/dev_env/build/package_debian_common.sh
@@ -8,6 +8,15 @@ require_debian_package_context() {
   : "${DEBIAN_ARCH_LABEL:?DEBIAN_ARCH_LABEL nao definido}"
 }
 
+default_package_staging_dir() {
+  local package_kind="$1"
+  if [[ "${REPO_ROOT}" == /mnt/* ]]; then
+    printf '%s\n' "${TMPDIR:-/tmp}/ssa_consulta_rapida_package/package_${DEBIAN_PLATFORM}_${package_kind}"
+  else
+    printf '%s\n' "${REPO_ROOT}/build/package_${DEBIAN_PLATFORM}_${package_kind}"
+  fi
+}
+
 read_app_version() {
   local version_file="$1"
   local version=""
@@ -36,15 +45,17 @@ safe_reset_dir() {
   local resolved_dir
   local allowed_build
   local allowed_packages
+  local allowed_tmp_package
   resolved_dir="$(realpath -m -- "${dir}")"
   allowed_build="$(realpath -m -- "${REPO_ROOT}/build")"
   allowed_packages="$(realpath -m -- "${REPO_ROOT}/builds/packages")"
+  allowed_tmp_package="$(realpath -m -- "${TMPDIR:-/tmp}/ssa_consulta_rapida_package")"
   if [[ -z "${dir}" || "${resolved_dir}" == "/" || "${resolved_dir}" == "${REPO_ROOT}" ]]; then
     echo "Erro: recusa limpar diretorio inseguro: ${dir}" >&2
     exit 1
   fi
   case "${resolved_dir}/" in
-    "${allowed_build}/"* | "${allowed_packages}/"*) ;;
+    "${allowed_build}/"* | "${allowed_packages}/"* | "${allowed_tmp_package}/"*) ;;
     *)
       echo "Erro: staging fora dos diretorios permitidos: ${resolved_dir}" >&2
       exit 1
@@ -52,12 +63,13 @@ safe_reset_dir() {
   esac
   rm -rf -- "${resolved_dir}"
   mkdir -p -- "${resolved_dir}"
+  chmod 700 "${resolved_dir}"
 }
 
 clean_release_tree() {
   local root="$1"
   find "${root}" \
-    \( -type d \( -name venv -o -name .venv -o -name __pycache__ \) -prune -exec rm -rf -- {} + \) -o \
+    \( -type d \( -name venv -o -name .venv -o -name __pycache__ -o -name .git -o -name .hg -o -name .svn -o -name .ssh \) -prune -exec rm -rf -- {} + \) -o \
     \( -type f \( \
       -name '*.bak' -o -name '*.bak-*' -o -name '*.bak.*' -o -name '*.example.bak_*' -o \
       -name '*.db' -o -name '*.sqlite' -o -name '*.sqlite3' -o \

--- a/dev_env/build/package_debian_deb.sh
+++ b/dev_env/build/package_debian_deb.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BUILD_SYSTEM="pyinstaller"
+OUTPUT_DIR=""
+STAGING_DIR=""
+KEEP_STAGING=0
+
+usage() {
+  cat <<USAGE
+Uso: $(basename "$0") [opcoes]
+
+Gera pacote .deb Debian ${DEBIAN_ARCH_LABEL} a partir dos artefatos Linux ja criados.
+
+Opcoes:
+  --build-system NAME   pyinstaller, nuitka ou pyoxidizer (default: pyinstaller)
+  --output-dir DIR      diretorio final dos pacotes (default: builds/packages/${DEBIAN_PLATFORM})
+  --staging-dir DIR     diretorio temporario (default: build/package_${DEBIAN_PLATFORM}_deb)
+  --keep-staging        nao remove staging ao terminar
+  -h, --help            mostra esta ajuda
+
+Pre-requisitos:
+  - rodar no Debian ${DEBIAN_ARCH_LABEL}
+  - dpkg-deb instalado
+  - artefatos em launchers/dist/${DEBIAN_PLATFORM} ou builds/<sistema>/${DEBIAN_PLATFORM}
+USAGE
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd -P)"
+# shellcheck source=dev_env/build/package_debian_common.sh
+source "${SCRIPT_DIR}/package_debian_common.sh"
+require_debian_package_context
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build-system)
+      BUILD_SYSTEM="${2:?valor ausente para --build-system}"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="${2:?valor ausente para --output-dir}"
+      shift 2
+      ;;
+    --staging-dir)
+      STAGING_DIR="${2:?valor ausente para --staging-dir}"
+      shift 2
+      ;;
+    --keep-staging)
+      KEEP_STAGING=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Erro: opcao desconhecida: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}/builds/packages/${DEBIAN_PLATFORM}}"
+STAGING_DIR="${STAGING_DIR:-${REPO_ROOT}/build/package_${DEBIAN_PLATFORM}_deb}"
+APP_ID="ssa-consulta-rapida"
+APP_DISPLAY_NAME="SSA Consulta Rapida"
+APP_MAINTAINER="SSA Consulta Rapida <noreply@example.invalid>"
+CLI_TARGET=""
+GUI_TARGET=""
+
+case "${BUILD_SYSTEM}" in
+  pyinstaller | nuitka | pyoxidizer) ;;
+  *)
+    echo "Erro: --build-system deve ser pyinstaller, nuitka ou pyoxidizer." >&2
+    exit 2
+    ;;
+esac
+
+assert_debian_machine
+
+if ! command -v dpkg-deb >/dev/null 2>&1; then
+  echo "Erro: dpkg-deb nao encontrado. Instale com: sudo apt-get install -y dpkg-dev" >&2
+  exit 1
+fi
+
+VERSION_FILE="${REPO_ROOT}/config/version.json"
+APP_VERSION="$(read_app_version "${VERSION_FILE}")"
+
+PACKAGE_NAME="${APP_ID}-${BUILD_SYSTEM}-${DEBIAN_PACKAGE_ARCH}"
+PACKAGE_ROOT="${STAGING_DIR}/${PACKAGE_NAME}"
+INSTALL_ROOT="${PACKAGE_ROOT}/usr/lib/${APP_ID}/${BUILD_SYSTEM}"
+BIN_DIR="${PACKAGE_ROOT}/usr/bin"
+DEBIAN_DIR="${PACKAGE_ROOT}/DEBIAN"
+PACKAGE_FILE="${OUTPUT_DIR}/${PACKAGE_NAME}_${APP_VERSION}_${DEBIAN_PACKAGE_ARCH}.deb"
+
+safe_reset_dir "${STAGING_DIR}"
+mkdir -p -- "${OUTPUT_DIR}" "${INSTALL_ROOT}" "${BIN_DIR}" "${DEBIAN_DIR}"
+
+case "${BUILD_SYSTEM}" in
+  pyinstaller)
+    SOURCE_ROOT="${REPO_ROOT}/launchers/dist/${DEBIAN_PLATFORM}"
+    [[ -d "${SOURCE_ROOT}" ]] || SOURCE_ROOT="${REPO_ROOT}/builds/pyinstaller/${DEBIAN_PLATFORM}"
+    copy_dir_checked "${SOURCE_ROOT}/SSA_CLI_v${APP_VERSION}_${DEBIAN_PLATFORM}" "${INSTALL_ROOT}/cli"
+    copy_dir_checked "${SOURCE_ROOT}/SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}" "${INSTALL_ROOT}/gui"
+    CLI_TARGET="$(first_existing_executable "${INSTALL_ROOT}/cli/SSA_CLI_v${APP_VERSION}_${DEBIAN_PLATFORM}")"
+    GUI_TARGET="$(first_existing_executable "${INSTALL_ROOT}/gui/SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}")"
+    write_wrapper "${BIN_DIR}/${APP_ID}-cli" "${CLI_TARGET/${PACKAGE_ROOT}/}"
+    write_wrapper "${BIN_DIR}/${APP_ID}-gui" "${GUI_TARGET/${PACKAGE_ROOT}/}"
+    ;;
+  nuitka)
+    copy_dir_checked "${REPO_ROOT}/builds/nuitka/${DEBIAN_PLATFORM}/cli_entry.dist" "${INSTALL_ROOT}/cli"
+    copy_dir_checked "${REPO_ROOT}/builds/nuitka/${DEBIAN_PLATFORM}/gui_entry.dist" "${INSTALL_ROOT}/gui"
+    CLI_TARGET="$(
+      first_existing_executable \
+        "${INSTALL_ROOT}/cli/SSA_CLI_v${APP_VERSION}_${DEBIAN_PLATFORM}" \
+        "${INSTALL_ROOT}/cli/cli_entry"
+    )"
+    GUI_TARGET="$(
+      first_existing_executable \
+        "${INSTALL_ROOT}/gui/SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}" \
+        "${INSTALL_ROOT}/gui/gui_entry"
+    )"
+    write_wrapper "${BIN_DIR}/${APP_ID}-cli" "${CLI_TARGET/${PACKAGE_ROOT}/}"
+    write_wrapper "${BIN_DIR}/${APP_ID}-gui" "${GUI_TARGET/${PACKAGE_ROOT}/}"
+    ;;
+  pyoxidizer)
+    copy_dir_checked "${REPO_ROOT}/builds/pyoxidizer/${DEBIAN_PLATFORM}" "${INSTALL_ROOT}/runtime"
+    CLI_TARGET="$(first_existing_executable "${INSTALL_ROOT}/runtime/SSA_Consulta_Rapida")"
+    write_wrapper "${BIN_DIR}/${APP_ID}-cli" "${CLI_TARGET/${PACKAGE_ROOT}/}"
+    write_wrapper "${BIN_DIR}/${APP_ID}-gui" "${CLI_TARGET/${PACKAGE_ROOT}/}" "--gui"
+    ;;
+esac
+
+clean_release_tree "${PACKAGE_ROOT}"
+
+cat >"${DEBIAN_DIR}/control" <<CONTROL
+Package: ${PACKAGE_NAME}
+Version: ${APP_VERSION}
+Section: utils
+Priority: optional
+Architecture: ${DEBIAN_PACKAGE_ARCH}
+Maintainer: ${APP_MAINTAINER}
+Depends: libc6, libstdc++6, zlib1g
+Description: ${APP_DISPLAY_NAME} (${BUILD_SYSTEM}, Debian ${DEBIAN_ARCH_LABEL})
+ Pacote local gerado a partir dos artefatos Debian ${DEBIAN_ARCH_LABEL} do projeto.
+CONTROL
+
+chmod -R go-w "${PACKAGE_ROOT}"
+dpkg-deb --build --root-owner-group "${PACKAGE_ROOT}" "${PACKAGE_FILE}"
+
+if [[ "${KEEP_STAGING}" != "1" ]]; then
+  rm -rf -- "${STAGING_DIR}"
+fi
+
+echo "Pacote .deb gerado: ${PACKAGE_FILE}"

--- a/dev_env/build/package_debian_deb.sh
+++ b/dev_env/build/package_debian_deb.sh
@@ -63,7 +63,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}/builds/packages/${DEBIAN_PLATFORM}}"
-STAGING_DIR="${STAGING_DIR:-${REPO_ROOT}/build/package_${DEBIAN_PLATFORM}_deb}"
+if [[ -z "${STAGING_DIR}" ]]; then
+  STAGING_DIR="$(default_package_staging_dir deb)"
+fi
 APP_ID="ssa-consulta-rapida"
 APP_DISPLAY_NAME="SSA Consulta Rapida"
 APP_MAINTAINER="SSA Consulta Rapida <noreply@example.invalid>"
@@ -106,8 +108,8 @@ case "${BUILD_SYSTEM}" in
     copy_dir_checked "${SOURCE_ROOT}/SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}" "${INSTALL_ROOT}/gui"
     CLI_TARGET="$(first_existing_executable "${INSTALL_ROOT}/cli/SSA_CLI_v${APP_VERSION}_${DEBIAN_PLATFORM}")"
     GUI_TARGET="$(first_existing_executable "${INSTALL_ROOT}/gui/SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}")"
-    write_wrapper "${BIN_DIR}/${APP_ID}-cli" "${CLI_TARGET/${PACKAGE_ROOT}/}"
-    write_wrapper "${BIN_DIR}/${APP_ID}-gui" "${GUI_TARGET/${PACKAGE_ROOT}/}"
+    write_wrapper "${BIN_DIR}/${APP_ID}-cli" "${CLI_TARGET#"${PACKAGE_ROOT}"}"
+    write_wrapper "${BIN_DIR}/${APP_ID}-gui" "${GUI_TARGET#"${PACKAGE_ROOT}"}"
     ;;
   nuitka)
     copy_dir_checked "${REPO_ROOT}/builds/nuitka/${DEBIAN_PLATFORM}/cli_entry.dist" "${INSTALL_ROOT}/cli"
@@ -122,14 +124,15 @@ case "${BUILD_SYSTEM}" in
         "${INSTALL_ROOT}/gui/SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}" \
         "${INSTALL_ROOT}/gui/gui_entry"
     )"
-    write_wrapper "${BIN_DIR}/${APP_ID}-cli" "${CLI_TARGET/${PACKAGE_ROOT}/}"
-    write_wrapper "${BIN_DIR}/${APP_ID}-gui" "${GUI_TARGET/${PACKAGE_ROOT}/}"
+    write_wrapper "${BIN_DIR}/${APP_ID}-cli" "${CLI_TARGET#"${PACKAGE_ROOT}"}"
+    write_wrapper "${BIN_DIR}/${APP_ID}-gui" "${GUI_TARGET#"${PACKAGE_ROOT}"}"
     ;;
   pyoxidizer)
     copy_dir_checked "${REPO_ROOT}/builds/pyoxidizer/${DEBIAN_PLATFORM}" "${INSTALL_ROOT}/runtime"
     CLI_TARGET="$(first_existing_executable "${INSTALL_ROOT}/runtime/SSA_Consulta_Rapida")"
-    write_wrapper "${BIN_DIR}/${APP_ID}-cli" "${CLI_TARGET/${PACKAGE_ROOT}/}"
-    write_wrapper "${BIN_DIR}/${APP_ID}-gui" "${CLI_TARGET/${PACKAGE_ROOT}/}" "--gui"
+    GUI_TARGET="${CLI_TARGET}"
+    write_wrapper "${BIN_DIR}/${APP_ID}-cli" "${CLI_TARGET#"${PACKAGE_ROOT}"}"
+    write_wrapper "${BIN_DIR}/${APP_ID}-gui" "${GUI_TARGET#"${PACKAGE_ROOT}"}" "--gui"
     ;;
 esac
 

--- a/dev_env/build/pyoxidizer.bzl
+++ b/dev_env/build/pyoxidizer.bzl
@@ -81,8 +81,17 @@ def make_install(exe):
                 "launchers/*.py",
                 "launchers/**/*.py",
                 "config/**",
+                "config/build_info.json",
+                "docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md",
                 "themes/**",
                 "resources/**",
+            ],
+            exclude=[
+                "launchers/**/__pycache__/**",
+                "launchers/dist/**",
+                "launchers/logs/**",
+                "launchers/platforms/**/temp/**",
+                "launchers/platforms/**/venv/**",
             ],
             strip_prefix=PROJECT_PREFIX,
         )

--- a/dev_env/build/release_debian.sh
+++ b/dev_env/build/release_debian.sh
@@ -58,10 +58,20 @@ split_csv() {
   local csv="${1%,}"
   local -n output="$2"
   local item
-  IFS=',' read -r -a output <<<"${csv}"
-  for item in "${output[@]}"; do
+  local raw_items=()
+  IFS=',' read -r -a raw_items <<<"${csv}"
+  output=()
+  for item in "${raw_items[@]}"; do
+    item="${item#"${item%%[![:space:]]*}"}"
+    item="${item%"${item##*[![:space:]]}"}"
     [[ -n "${item}" ]] || die "lista contem item vazio: ${csv}"
+    output+=("${item}")
   done
+}
+
+join_csv() {
+  local IFS=,
+  printf '%s\n' "$*"
 }
 
 normalize_backends() {
@@ -82,7 +92,7 @@ normalize_backends() {
       *) die "--backend invalido: ${backend}" ;;
     esac
   done
-  printf '%s\n' "${csv}"
+  join_csv "${items[@]}"
 }
 
 normalize_packages() {
@@ -100,7 +110,7 @@ normalize_packages() {
       *) die "--package invalido: ${package_kind}" ;;
     esac
   done
-  printf '%s\n' "${csv}"
+  join_csv "${items[@]}"
 }
 
 select_backend_interactively() {
@@ -228,35 +238,46 @@ validate_build_payload() {
   local app_version="$3"
   local git_commit="$4"
   local build_root=""
-  local build_info=""
-  local guide=""
+  local bundle_root=""
+  local bundle_roots=()
 
   case "${backend}" in
     pyinstaller)
       build_root="${root}/launchers/dist/debian_amd64"
       [[ -d "${build_root}" ]] || build_root="${root}/builds/pyinstaller/debian_amd64"
+      bundle_roots=(
+        "${build_root}/SSA_CLI_v${app_version}_debian_amd64"
+        "${build_root}/SSA_GUI_v${app_version}_debian_amd64"
+      )
       ;;
     nuitka)
       build_root="${root}/builds/nuitka/debian_amd64"
+      bundle_roots=(
+        "${build_root}/cli_entry.dist"
+        "${build_root}/gui_entry.dist"
+      )
       ;;
     pyoxidizer)
       build_root="${root}/builds/pyoxidizer/debian_amd64"
+      bundle_roots=("${build_root}")
       ;;
   esac
 
   [[ -d "${build_root}" ]] || die "artefato ${backend} nao encontrado: ${build_root}"
-  build_info="$(find "${build_root}" -path '*/config/build_info.json' -type f -print -quit)"
-  guide="$(find "${build_root}" -path '*/docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md' -type f -print -quit)"
-  [[ -n "${build_info}" ]] || die "build_info.json ausente em ${backend}"
-  [[ -n "${guide}" ]] || die "GUIA_MIGRACAO_NOVA_INSTALACAO.md ausente em ${backend}"
 
-  uv run --python 3.13 python "${root}/dev_env/build/release_debian_report.py" \
-    validate-build-info \
-    --build-info "${build_info}" \
-    --backend "${backend}" \
-    --platform "debian_amd64" \
-    --app-version "${app_version}" \
-    --git-commit "${git_commit}"
+  for bundle_root in "${bundle_roots[@]}"; do
+    [[ -d "${bundle_root}" ]] || die "bundle ${backend} ausente: ${bundle_root}"
+    [[ -f "${bundle_root}/config/build_info.json" ]] || die "build_info.json ausente em ${bundle_root}"
+    [[ -f "${bundle_root}/docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md" ]] || die "GUIA_MIGRACAO_NOVA_INSTALACAO.md ausente em ${bundle_root}"
+
+    uv run --python 3.13 python "${root}/dev_env/build/release_debian_report.py" \
+      validate-build-info \
+      --build-info "${bundle_root}/config/build_info.json" \
+      --backend "${backend}" \
+      --platform "debian_amd64" \
+      --app-version "${app_version}" \
+      --git-commit "${git_commit}"
+  done
 }
 
 run_build_backend() {

--- a/dev_env/build/release_debian.sh
+++ b/dev_env/build/release_debian.sh
@@ -21,10 +21,10 @@ Opcoes:
   --backend LIST      pyinstaller,nuitka,pyoxidizer ou all
   --package LIST      deb,appimage ou all (default: deb)
   --ssh-host HOST     executa remotamente via ssh (ex: user@host)
-  --ssh-repo DIR      caminho do repositorio no host remoto
+  --ssh-repo DIR      caminho absoluto do repositorio no host remoto
   --with-local-data   copia dados locais para os artefatos
   --skip-build        nao recompila, apenas valida/empacota artefatos existentes
-  --skip-package      nao empacota, apenas build/valida artefatos de build
+  --skip-package      nao gera .deb/AppImage; ainda valida artefatos de build
   --dry-run           valida ambiente e mostra plano sem executar build/pacote
   -y, --yes           nao perguntar interativamente
   -h, --help          mostra esta ajuda
@@ -43,11 +43,6 @@ die() {
   exit 1
 }
 
-shell_quote() {
-  local value="$1"
-  printf "'%s'" "$(printf '%s' "${value}" | sed "s/'/'\\\\''/g")"
-}
-
 repo_root() {
   local script_dir
   script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
@@ -59,6 +54,9 @@ split_csv() {
   local -n output="$2"
   local item
   local raw_items=()
+  while [[ "${csv}" == *, ]]; do
+    csv="${csv%,}"
+  done
   IFS=',' read -r -a raw_items <<<"${csv}"
   output=()
   for item in "${raw_items[@]}"; do
@@ -158,8 +156,8 @@ assert_ssh_host() {
 
 assert_ssh_repo() {
   local repo="$1"
-  if [[ ! "${repo}" =~ ^(/|~/)[A-Za-z0-9._/@%+=:,~-]+$ ]]; then
-    die "--ssh-repo invalido. Use caminho absoluto ou ~/... sem espacos/metacaracteres."
+  if [[ ! "${repo}" =~ ^/[A-Za-z0-9._/@%+=:,~-]+$ ]]; then
+    die "--ssh-repo invalido. Use caminho absoluto sem espacos/metacaracteres."
   fi
 }
 
@@ -210,26 +208,26 @@ run_remote_release() {
   if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
     die "--with-local-data nao e suportado via SSH; execute localmente no host Debian com os dados ja presentes."
   fi
-  local remote_cmd
-  local quoted_backends
-  local quoted_packages
-  local quoted_repo
-  quoted_backends="$(shell_quote "${BACKENDS_CSV}")"
-  quoted_packages="$(shell_quote "${PACKAGES_CSV}")"
-  quoted_repo="$(shell_quote "${SSH_REPO}")"
-  remote_cmd="cd ${quoted_repo} && bash dev_env/build/release_debian.sh --backend ${quoted_backends} --package ${quoted_packages} -y"
+  local remote_flags=()
   if [[ "${SKIP_BUILD}" == "1" ]]; then
-    remote_cmd+=" --skip-build"
+    remote_flags+=(--skip-build)
   fi
   if [[ "${SKIP_PACKAGE}" == "1" ]]; then
-    remote_cmd+=" --skip-package"
+    remote_flags+=(--skip-package)
   fi
   if [[ "${DRY_RUN}" == "1" ]]; then
-    remote_cmd+=" --dry-run"
+    remote_flags+=(--dry-run)
   fi
   log "executando remoto via ssh: ${SSH_HOST}"
-  # shellcheck disable=SC2029
-  ssh "${SSH_HOST}" "${remote_cmd}"
+  ssh "${SSH_HOST}" bash -s -- "${SSH_REPO}" "${BACKENDS_CSV}" "${PACKAGES_CSV}" "${remote_flags[@]}" <<'REMOTE_RELEASE'
+set -euo pipefail
+repo="$1"
+backends="$2"
+packages="$3"
+shift 3
+cd -- "${repo}"
+bash dev_env/build/release_debian.sh --backend "${backends}" --package "${packages}" -y "$@"
+REMOTE_RELEASE
 }
 
 validate_build_payload() {

--- a/dev_env/build/release_debian.sh
+++ b/dev_env/build/release_debian.sh
@@ -1,0 +1,506 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKENDS_CSV=""
+PACKAGES_CSV="deb"
+SSH_HOST=""
+SSH_REPO=""
+DRY_RUN=0
+SKIP_BUILD=0
+SKIP_PACKAGE=0
+WITH_LOCAL_DATA=0
+ASSUME_YES=0
+
+usage() {
+  cat <<'USAGE'
+Uso: release_debian.sh [opcoes]
+
+Orquestra build e pacote Debian amd64 de forma deterministica.
+
+Opcoes:
+  --backend LIST      pyinstaller,nuitka,pyoxidizer ou all
+  --package LIST      deb,appimage ou all (default: deb)
+  --ssh-host HOST     executa remotamente via ssh (ex: user@host)
+  --ssh-repo DIR      caminho do repositorio no host remoto
+  --with-local-data   copia dados locais para os artefatos
+  --skip-build        nao recompila, apenas valida/empacota artefatos existentes
+  --skip-package      nao empacota, apenas build/valida artefatos de build
+  --dry-run           valida ambiente e mostra plano sem executar build/pacote
+  -y, --yes           nao perguntar interativamente
+  -h, --help          mostra esta ajuda
+
+Sem --backend, o script pergunta quais backends usar.
+Com -y/--yes e sem --backend, usa todos os backends.
+USAGE
+}
+
+log() {
+  printf '[release_debian] %s\n' "$*"
+}
+
+die() {
+  printf 'Erro: %s\n' "$*" >&2
+  exit 1
+}
+
+shell_quote() {
+  local value="$1"
+  printf "'%s'" "$(printf '%s' "${value}" | sed "s/'/'\\\\''/g")"
+}
+
+repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+  cd -- "${script_dir}/../.." && pwd -P
+}
+
+split_csv() {
+  local csv="${1%,}"
+  local -n output="$2"
+  local item
+  IFS=',' read -r -a output <<<"${csv}"
+  for item in "${output[@]}"; do
+    [[ -n "${item}" ]] || die "lista contem item vazio: ${csv}"
+  done
+}
+
+normalize_backends() {
+  local csv="$1"
+  local backend
+  if [[ -z "${csv}" ]]; then
+    die "backend vazio"
+  fi
+  if [[ "${csv}" == "all" ]]; then
+    printf '%s\n' "pyinstaller,nuitka,pyoxidizer"
+    return 0
+  fi
+  local items=()
+  split_csv "${csv}" items
+  for backend in "${items[@]}"; do
+    case "${backend}" in
+      pyinstaller | nuitka | pyoxidizer) ;;
+      *) die "--backend invalido: ${backend}" ;;
+    esac
+  done
+  printf '%s\n' "${csv}"
+}
+
+normalize_packages() {
+  local csv="$1"
+  local package_kind
+  if [[ -z "${csv}" || "${csv}" == "all" ]]; then
+    printf '%s\n' "deb,appimage"
+    return 0
+  fi
+  local items=()
+  split_csv "${csv}" items
+  for package_kind in "${items[@]}"; do
+    case "${package_kind}" in
+      deb | appimage) ;;
+      *) die "--package invalido: ${package_kind}" ;;
+    esac
+  done
+  printf '%s\n' "${csv}"
+}
+
+select_backend_interactively() {
+  local answer
+  cat <<'CHOICES'
+Backends disponiveis:
+  1) pyinstaller
+  2) nuitka
+  3) pyoxidizer
+  4) all
+
+Nota resumida:
+  pyinstaller: seguranca media, codigo Python mais exposto, boa compatibilidade.
+  nuitka: seguranca maior, codigo menos exposto, build mais pesado.
+  pyoxidizer: seguranca media/alta, runtime mais fechado, maior risco operacional.
+CHOICES
+  read -r -p "Escolha backend(s) [all]: " answer
+  case "${answer:-all}" in
+    1 | pyinstaller) printf '%s\n' "pyinstaller" ;;
+    2 | nuitka) printf '%s\n' "nuitka" ;;
+    3 | pyoxidizer) printf '%s\n' "pyoxidizer" ;;
+    4 | all) printf '%s\n' "pyinstaller,nuitka,pyoxidizer" ;;
+    *) printf '%s\n' "${answer}" ;;
+  esac
+}
+
+get_backend_scorecard() {
+  local backend="$1"
+  uv run --python 3.13 python "$(repo_root)/dev_env/build/release_debian_report.py" \
+    scorecard \
+    --backend "${backend}"
+}
+
+assert_tool() {
+  local tool="$1"
+  command -v "${tool}" >/dev/null 2>&1 || die "comando ausente: ${tool}"
+}
+
+assert_ssh_host() {
+  local host="$1"
+  if [[ ! "${host}" =~ ^([A-Za-z0-9._-]+@)?[A-Za-z0-9._-]+$ ]]; then
+    die "--ssh-host invalido. Use apenas user@host ou host sem opcoes ssh."
+  fi
+}
+
+assert_ssh_repo() {
+  local repo="$1"
+  if [[ ! "${repo}" =~ ^(/|~/)[A-Za-z0-9._/@%+=:,~-]+$ ]]; then
+    die "--ssh-repo invalido. Use caminho absoluto ou ~/... sem espacos/metacaracteres."
+  fi
+}
+
+assert_debian_host() {
+  local os_name
+  [[ "$(uname -s)" == "Linux" ]] || die "este script local deve rodar em Linux (Debian ou Ubuntu)"
+  if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    os_name="$(. /etc/os-release && printf '%s' "${ID:-}")"
+    [[ "${os_name}" == "debian" || "${os_name}" == "ubuntu" ]] || die "host Linux nao Debian/Ubuntu: ${os_name}"
+  fi
+}
+
+assert_debian_amd64() {
+  local machine
+  machine="$(uname -m)"
+  case "${machine}" in
+    x86_64 | amd64) ;;
+    *) die "este orquestrador e para debian_amd64; arquitetura atual: ${machine}" ;;
+  esac
+}
+
+assert_clean_release_workspace() {
+  local root="$1"
+  local dirty
+  dirty="$(git -C "${root}" status --porcelain)"
+  if [[ -n "${dirty}" ]]; then
+    printf '%s\n' "${dirty}" >&2
+    die "workspace sujo. Release deterministico exige git limpo."
+  fi
+}
+
+git_head() {
+  local root="$1"
+  git -C "${root}" rev-parse HEAD
+}
+
+read_app_version() {
+  local root="$1"
+  uv run --python 3.13 python "${root}/dev_env/build/release_debian_report.py" \
+    app-version \
+    --version-file "${root}/config/version.json"
+}
+
+run_remote_release() {
+  [[ -n "${SSH_REPO}" ]] || die "--ssh-repo e obrigatorio com --ssh-host"
+  assert_ssh_repo "${SSH_REPO}"
+  if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
+    die "--with-local-data nao e suportado via SSH; execute localmente no host Debian com os dados ja presentes."
+  fi
+  local remote_cmd
+  local quoted_backends
+  local quoted_packages
+  local quoted_repo
+  quoted_backends="$(shell_quote "${BACKENDS_CSV}")"
+  quoted_packages="$(shell_quote "${PACKAGES_CSV}")"
+  quoted_repo="$(shell_quote "${SSH_REPO}")"
+  remote_cmd="cd ${quoted_repo} && bash dev_env/build/release_debian.sh --backend ${quoted_backends} --package ${quoted_packages} -y"
+  if [[ "${SKIP_BUILD}" == "1" ]]; then
+    remote_cmd+=" --skip-build"
+  fi
+  if [[ "${SKIP_PACKAGE}" == "1" ]]; then
+    remote_cmd+=" --skip-package"
+  fi
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    remote_cmd+=" --dry-run"
+  fi
+  log "executando remoto via ssh: ${SSH_HOST}"
+  # shellcheck disable=SC2029
+  ssh "${SSH_HOST}" "${remote_cmd}"
+}
+
+validate_build_payload() {
+  local root="$1"
+  local backend="$2"
+  local app_version="$3"
+  local git_commit="$4"
+  local build_root=""
+  local build_info=""
+  local guide=""
+
+  case "${backend}" in
+    pyinstaller)
+      build_root="${root}/launchers/dist/debian_amd64"
+      [[ -d "${build_root}" ]] || build_root="${root}/builds/pyinstaller/debian_amd64"
+      ;;
+    nuitka)
+      build_root="${root}/builds/nuitka/debian_amd64"
+      ;;
+    pyoxidizer)
+      build_root="${root}/builds/pyoxidizer/debian_amd64"
+      ;;
+  esac
+
+  [[ -d "${build_root}" ]] || die "artefato ${backend} nao encontrado: ${build_root}"
+  build_info="$(find "${build_root}" -path '*/config/build_info.json' -type f -print -quit)"
+  guide="$(find "${build_root}" -path '*/docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md' -type f -print -quit)"
+  [[ -n "${build_info}" ]] || die "build_info.json ausente em ${backend}"
+  [[ -n "${guide}" ]] || die "GUIA_MIGRACAO_NOVA_INSTALACAO.md ausente em ${backend}"
+
+  uv run --python 3.13 python "${root}/dev_env/build/release_debian_report.py" \
+    validate-build-info \
+    --build-info "${build_info}" \
+    --backend "${backend}" \
+    --platform "debian_amd64" \
+    --app-version "${app_version}" \
+    --git-commit "${git_commit}"
+}
+
+run_build_backend() {
+  local root="$1"
+  local backend="$2"
+  local args=(--silent)
+  if [[ "${WITH_LOCAL_DATA}" == "1" ]]; then
+    args+=(--with-local-data)
+  fi
+  case "${backend}" in
+    pyinstaller) bash "${root}/dev_env/build/build_pyinstaller_debian.sh" "${args[@]}" ;;
+    nuitka) bash "${root}/dev_env/build/build_nuitka_debian.sh" "${args[@]}" ;;
+    pyoxidizer) bash "${root}/dev_env/build/build_pyoxidizer_debian.sh" "${args[@]}" ;;
+    *) die "backend desconhecido: ${backend}" ;;
+  esac
+}
+
+run_package_backend() {
+  local root="$1"
+  local backend="$2"
+  local package_kind="$3"
+  case "${package_kind}:${backend}" in
+    deb:*)
+      bash "${root}/dev_env/build/package_debian_amd64_deb.sh" --build-system "${backend}"
+      ;;
+    appimage:pyinstaller | appimage:nuitka)
+      bash "${root}/dev_env/build/package_debian_amd64_appimage.sh" --build-system "${backend}"
+      ;;
+    appimage:pyoxidizer)
+      die "AppImage pyoxidizer nao suportado pelos scripts atuais. Use --package deb para pyoxidizer."
+      ;;
+    *)
+      die "pacote invalido: ${package_kind}:${backend}"
+      ;;
+  esac
+}
+
+validate_package_payload() {
+  local root="$1"
+  local backend="$2"
+  local package_kind="$3"
+  local app_version="$4"
+  local package_dir="${root}/builds/packages/debian_amd64"
+  local package_contents=""
+  local package_file=""
+  case "${package_kind}:${backend}" in
+    deb:*)
+      package_file="${package_dir}/ssa-consulta-rapida-${backend}-amd64_${app_version}_amd64.deb"
+      [[ -f "${package_file}" ]] || die "pacote .deb ausente: ${package_file}"
+      package_contents="$(dpkg-deb -c "${package_file}")"
+      grep -F "GUIA_MIGRACAO_NOVA_INSTALACAO.md" <<<"${package_contents}" >/dev/null || die "guia ausente no .deb ${backend}"
+      grep -F "build_info.json" <<<"${package_contents}" >/dev/null || die "build_info ausente no .deb ${backend}"
+      ;;
+    appimage:pyinstaller | appimage:nuitka)
+      package_file="${package_dir}/SSA_Consulta_Rapida_v${app_version#v}_debian_amd64_${backend}.AppImage"
+      [[ -x "${package_file}" ]] || die "AppImage ausente ou sem execucao: ${package_file}"
+      ;;
+    appimage:pyoxidizer)
+      die "AppImage pyoxidizer nao suportado pelos scripts atuais. Use --package deb para pyoxidizer."
+      ;;
+  esac
+}
+
+write_release_report() {
+  local root="$1"
+  local report_file="$2"
+  local backend_csv="$3"
+  local package_csv="$4"
+  local app_version="$5"
+  local git_commit="$6"
+  uv run --python 3.13 python "${root}/dev_env/build/release_debian_report.py" \
+    write-report \
+    --repo-root "${root}" \
+    --report-file "${report_file}" \
+    --backends "${backend_csv}" \
+    --packages "${package_csv}" \
+    --app-version "${app_version}" \
+    --git-commit "${git_commit}"
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --backend)
+        BACKENDS_CSV="${2:?valor ausente para --backend}"
+        shift 2
+        ;;
+      --package)
+        PACKAGES_CSV="${2:?valor ausente para --package}"
+        shift 2
+        ;;
+      --ssh-host)
+        SSH_HOST="${2:?valor ausente para --ssh-host}"
+        shift 2
+        ;;
+      --ssh-repo)
+        SSH_REPO="${2:?valor ausente para --ssh-repo}"
+        shift 2
+        ;;
+      --with-local-data)
+        WITH_LOCAL_DATA=1
+        shift
+        ;;
+      --skip-build)
+        SKIP_BUILD=1
+        shift
+        ;;
+      --skip-package)
+        SKIP_PACKAGE=1
+        shift
+        ;;
+      --dry-run)
+        DRY_RUN=1
+        shift
+        ;;
+      -y | --yes)
+        ASSUME_YES=1
+        shift
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *)
+        die "opcao desconhecida: $1"
+        ;;
+    esac
+  done
+}
+
+resolve_release_options() {
+  if [[ -z "${BACKENDS_CSV}" ]]; then
+    if [[ "${ASSUME_YES}" == "1" ]]; then
+      BACKENDS_CSV="pyinstaller,nuitka,pyoxidizer"
+    elif [[ ! -t 0 ]]; then
+      die "--backend e obrigatorio em ambiente nao interativo. Use --backend LIST ou -y."
+    else
+      BACKENDS_CSV="$(select_backend_interactively)"
+    fi
+  fi
+  BACKENDS_CSV="$(normalize_backends "${BACKENDS_CSV}")"
+  PACKAGES_CSV="$(normalize_packages "${PACKAGES_CSV}")"
+}
+
+assert_local_environment() {
+  assert_debian_host
+  assert_debian_amd64
+  assert_tool git
+  assert_tool uv
+  assert_tool bash
+  if [[ "${PACKAGES_CSV}" == *deb* ]]; then
+    assert_tool dpkg-deb
+  fi
+  if [[ "${PACKAGES_CSV}" == *appimage* && "${SKIP_PACKAGE}" != "1" ]]; then
+    assert_tool appimagetool
+  fi
+  assert_clean_release_workspace "${REPO_ROOT}"
+}
+
+load_release_metadata() {
+  GIT_COMMIT="$(git_head "${REPO_ROOT}")"
+  APP_VERSION="$(read_app_version "${REPO_ROOT}")"
+  log "repo=${REPO_ROOT}"
+  log "git=${GIT_COMMIT}"
+  log "versao=${APP_VERSION}"
+  log "backends=${BACKENDS_CSV}"
+  log "packages=${PACKAGES_CSV}"
+}
+
+prepare_release_arrays() {
+  split_csv "${BACKENDS_CSV}" BACKENDS
+  split_csv "${PACKAGES_CSV}" PACKAGES
+}
+
+log_backend_scorecards() {
+  local backend
+  for backend in "${BACKENDS[@]}"; do
+    log "scorecard ${backend}: $(get_backend_scorecard "${backend}")"
+  done
+}
+
+run_build_phase() {
+  local backend
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    log "dry-run concluido sem build/pacote"
+    return 0
+  fi
+
+  for backend in "${BACKENDS[@]}"; do
+    if [[ "${SKIP_BUILD}" != "1" ]]; then
+      log "build ${backend}"
+      run_build_backend "${REPO_ROOT}" "${backend}"
+    fi
+    validate_build_payload "${REPO_ROOT}" "${backend}" "${APP_VERSION}" "${GIT_COMMIT}"
+  done
+}
+
+run_package_phase() {
+  local backend
+  local package_kind
+  if [[ "${SKIP_PACKAGE}" != "1" ]]; then
+    for backend in "${BACKENDS[@]}"; do
+      for package_kind in "${PACKAGES[@]}"; do
+        log "pacote ${package_kind} ${backend}"
+        run_package_backend "${REPO_ROOT}" "${backend}" "${package_kind}"
+        validate_package_payload "${REPO_ROOT}" "${backend}" "${package_kind}" "${APP_VERSION}"
+      done
+    done
+  fi
+}
+
+run_local_release() {
+  REPO_ROOT="$(repo_root)"
+  REPORT_FILE="${REPO_ROOT}/builds/reports/release_report_debian_amd64.json"
+
+  assert_local_environment
+  load_release_metadata
+  prepare_release_arrays
+  log_backend_scorecards
+  run_build_phase
+
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    return 0
+  fi
+
+  run_package_phase
+
+  write_release_report "${REPO_ROOT}" "${REPORT_FILE}" "${BACKENDS_CSV}" "${PACKAGES_CSV}" "${APP_VERSION}" "${GIT_COMMIT}"
+  log "report=${REPORT_FILE}"
+  log "release Debian amd64 concluido"
+}
+
+main() {
+  parse_args "$@"
+  resolve_release_options
+
+  if [[ -n "${SSH_HOST}" ]]; then
+    assert_tool ssh
+    assert_ssh_host "${SSH_HOST}"
+    run_remote_release
+    exit 0
+  fi
+
+  run_local_release
+}
+
+main "$@"

--- a/dev_env/build/release_debian_report.py
+++ b/dev_env/build/release_debian_report.py
@@ -36,7 +36,14 @@ SCORECARDS = {
 
 
 def _read_json(path: pathlib.Path) -> dict[str, object]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ReleaseReportError(f"arquivo JSON ausente: {path}") from exc
+    except OSError as exc:
+        raise ReleaseReportError(f"falha lendo JSON {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ReleaseReportError(f"JSON invalido em {path}: {exc}") from exc
 
 
 def _sha256(path: pathlib.Path) -> str:
@@ -48,11 +55,14 @@ def _sha256(path: pathlib.Path) -> str:
 
 
 def _asset_payload(path: pathlib.Path) -> dict[str, object]:
-    return {
-        "name": path.name,
-        "size": path.stat().st_size,
-        "sha256": _sha256(path),
-    }
+    try:
+        return {
+            "name": path.name,
+            "size": path.stat().st_size,
+            "sha256": _sha256(path),
+        }
+    except OSError as exc:
+        raise ReleaseReportError(f"falha lendo asset {path}: {exc}") from exc
 
 
 def cmd_print_app_version(args: argparse.Namespace) -> int:

--- a/dev_env/build/release_debian_report.py
+++ b/dev_env/build/release_debian_report.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import pathlib
+import platform
+import sys
+
+
+class ReleaseReportError(RuntimeError):
+    pass
+
+
+SCORECARDS = {
+    "pyinstaller": {
+        "security_score": 3,
+        "python_source_exposure_score": 2,
+        "easy_user_dirs_score": 5,
+        "package_size_score": 4,
+    },
+    "nuitka": {
+        "security_score": 4,
+        "python_source_exposure_score": 4,
+        "easy_user_dirs_score": 4,
+        "package_size_score": 3,
+    },
+    "pyoxidizer": {
+        "security_score": 4,
+        "python_source_exposure_score": 3,
+        "easy_user_dirs_score": 3,
+        "package_size_score": 4,
+    },
+}
+
+
+def _read_json(path: pathlib.Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _asset_payload(path: pathlib.Path) -> dict[str, object]:
+    return {
+        "name": path.name,
+        "size": path.stat().st_size,
+        "sha256": _sha256(path),
+    }
+
+
+def cmd_print_app_version(args: argparse.Namespace) -> int:
+    payload = _read_json(args.version_file)
+    version = str(payload.get("version_short") or "").strip()
+    if not version:
+        raise ReleaseReportError("version_short ausente em config/version.json")
+    print(version)
+    return 0
+
+
+def validate_build_info(args: argparse.Namespace) -> int:
+    payload = _read_json(args.build_info)
+    errors = []
+    expected = {
+        "build_system": args.backend,
+        "platform": args.platform,
+        "app_version": args.app_version,
+        "git_commit": args.git_commit,
+    }
+    for key, value in expected.items():
+        if str(payload.get(key)) != value:
+            errors.append(f"{key}={payload.get(key)!r}")
+    if errors:
+        joined = ", ".join(errors)
+        raise ReleaseReportError(f"build_info invalido em {args.build_info}: {joined}")
+    return 0
+
+
+def print_scorecard(args: argparse.Namespace) -> int:
+    try:
+        scorecard = SCORECARDS[args.backend]
+    except KeyError as exc:
+        raise ReleaseReportError(f"backend desconhecido: {args.backend}") from exc
+    print(json.dumps(scorecard, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+def write_report(args: argparse.Namespace) -> int:
+    package_dir = args.repo_root / "builds" / "packages" / "debian_amd64"
+    assets = []
+    if package_dir.is_dir():
+        asset_paths = [
+            path
+            for path in sorted(package_dir.iterdir())
+            if path.is_file() and path.suffix in {".deb", ".AppImage"}
+        ]
+        if asset_paths:
+            workers = min(4, len(asset_paths))
+            with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+                assets = list(executor.map(_asset_payload, asset_paths))
+
+    backends = [item for item in args.backends.split(",") if item]
+    packages = [item for item in args.packages.split(",") if item]
+    unknown_backends = [backend for backend in backends if backend not in SCORECARDS]
+    if unknown_backends:
+        joined = ", ".join(unknown_backends)
+        raise ReleaseReportError(f"backend desconhecido no report: {joined}")
+    payload = {
+        "platform": "debian_amd64",
+        "host_os": platform.platform(),
+        "machine": platform.machine(),
+        "app_version": args.app_version,
+        "git_commit": args.git_commit,
+        "backends": backends,
+        "packages": packages,
+        "scorecards": {backend: SCORECARDS[backend] for backend in backends},
+        "assets": assets,
+    }
+    args.report_file.parent.mkdir(parents=True, exist_ok=True)
+    args.report_file.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    app_version = subparsers.add_parser("app-version")
+    app_version.add_argument("--version-file", type=pathlib.Path, required=True)
+    app_version.set_defaults(func=cmd_print_app_version)
+
+    validate = subparsers.add_parser("validate-build-info")
+    validate.add_argument("--build-info", type=pathlib.Path, required=True)
+    validate.add_argument("--backend", required=True)
+    validate.add_argument("--platform", required=True)
+    validate.add_argument("--app-version", required=True)
+    validate.add_argument("--git-commit", required=True)
+    validate.set_defaults(func=validate_build_info)
+
+    scorecard = subparsers.add_parser("scorecard")
+    scorecard.add_argument("--backend", required=True)
+    scorecard.set_defaults(func=print_scorecard)
+
+    report = subparsers.add_parser("write-report")
+    report.add_argument("--repo-root", type=pathlib.Path, required=True)
+    report.add_argument("--report-file", type=pathlib.Path, required=True)
+    report.add_argument("--backends", required=True)
+    report.add_argument("--packages", required=True)
+    report.add_argument("--app-version", required=True)
+    report.add_argument("--git-commit", required=True)
+    report.set_defaults(func=write_report)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return int(args.func(args))
+    except ReleaseReportError as exc:
+        print(f"Erro: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -329,13 +329,13 @@ function Invoke-Smoke {
             throw "Smoke PyOxidizer --version falhou."
         }
         $versionText = ($versionOutput | Out-String).Trim()
-        $verificationType = "version_check_stdout"
-        $commandText = "--version"
+        $verificationType = "gui_version_check_stdout"
+        $commandText = "GUI --version"
         if ([string]::IsNullOrWhiteSpace($versionText)) {
             $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo((Resolve-Path $Config.gui_exe).Path)
             $versionText = [string] $versionInfo.ProductVersion
-            $verificationType = "version_check_metadata"
-            $commandText = "--version + FileVersionInfo"
+            $verificationType = "gui_version_check_metadata"
+            $commandText = "GUI --version + FileVersionInfo"
         }
         if ([string]::IsNullOrWhiteSpace($versionText)) {
             throw "Smoke PyOxidizer nao conseguiu confirmar versao por stdout nem FileVersionInfo."
@@ -460,13 +460,15 @@ Assert-WindowsHost
 Assert-PowerShellHost
 Assert-Tool "git" "instale Git para Windows"
 Assert-Tool "uv" "instale uv"
-Assert-Tool "rcedit.exe" "scoop install rcedit"
 if (-not $SkipInstaller) {
     Assert-Tool "iscc" "instale Inno Setup ou use -SkipInstaller"
 }
 
 $repoRoot = Resolve-RepoRoot
 $selectedBackends = Get-SelectedBackends $Backend
+if ((-not $SkipBuild) -and ($selectedBackends -contains "pyoxidizer")) {
+    Assert-Tool "rcedit.exe" "scoop install rcedit"
+}
 $version = Get-AppVersion $repoRoot
 $windowsVersion = Get-WindowsVersionText $version
 $gitHead = Get-GitHead $repoRoot

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -113,6 +113,7 @@ function Get-WindowsVersionText {
 function Get-SelectedBackends {
     param([string[]] $RequestedBackends)
 
+    $valid = @("pyinstaller", "nuitka", "pyoxidizer")
     if (-not $RequestedBackends -or $RequestedBackends.Count -eq 0) {
         Write-Host "Backends disponiveis: pyinstaller, nuitka, pyoxidizer, all"
         $raw = Read-Host "Informe um ou mais backends separados por virgula"
@@ -120,10 +121,9 @@ function Get-SelectedBackends {
     }
 
     if ($RequestedBackends -contains "all") {
-        return @("pyinstaller", "nuitka", "pyoxidizer")
+        return $valid
     }
 
-    $valid = @("pyinstaller", "nuitka", "pyoxidizer")
     foreach ($item in $RequestedBackends) {
         if ($valid -notcontains $item) {
             throw "Backend invalido: $item"
@@ -325,12 +325,20 @@ function Invoke-Smoke {
             throw "Smoke PyOxidizer --version falhou."
         }
         $versionText = ($versionOutput | Out-String).Trim()
+        $verificationType = "version_check_stdout"
+        $commandText = "--version"
         if ([string]::IsNullOrWhiteSpace($versionText)) {
-            throw "Smoke PyOxidizer --version nao retornou texto."
+            $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo((Resolve-Path $Config.gui_exe).Path)
+            $versionText = [string] $versionInfo.ProductVersion
+            $verificationType = "version_check_metadata"
+            $commandText = "--version + FileVersionInfo"
+        }
+        if ([string]::IsNullOrWhiteSpace($versionText)) {
+            throw "Smoke PyOxidizer nao conseguiu confirmar versao por stdout nem FileVersionInfo."
         }
         return [ordered]@{
-            verification_type = "version_check"
-            command = "--version"
+            verification_type = $verificationType
+            command = $commandText
             exit_code = 0
             output = $versionText
         }
@@ -354,9 +362,9 @@ function Write-BackendReleaseZips {
         [Parameter(Mandatory = $true)] [array] $ReleaseZips
     )
 
-    $outDir = Split-Path -Parent $ReleaseZips[0].zip
-    New-Item -ItemType Directory -Force $outDir | Out-Null
     foreach ($item in $ReleaseZips) {
+        $outDir = Split-Path -Parent $item.zip
+        New-Item -ItemType Directory -Force $outDir | Out-Null
         Assert-ExistingDirectory $item.source
         Compress-Archive -Force -Path $item.source -DestinationPath $item.zip
     }

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -436,11 +436,11 @@ function Invoke-DistributionPackage {
         [Parameter(Mandatory = $true)] [bool] $SkipInstallerFlag
     )
 
-    $args = @("run", "--python", "3.13", $DistributionScript, "--build-system", $BackendName)
+    $distributionArgs = @("run", "--python", "3.13", $DistributionScript, "--build-system", $BackendName)
     if ($SkipInstallerFlag) {
-        $args += "--skip-installer"
+        $distributionArgs += "--skip-installer"
     }
-    Invoke-CheckedProcess $RepoRoot "uv" $args
+    Invoke-CheckedProcess $RepoRoot "uv" $distributionArgs
 }
 
 function Write-ReleaseReport {

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -33,6 +33,10 @@ function Invoke-RepoCommand {
         [string[]] $Arguments = @()
     )
 
+    if ($Command -notin @("git", "uv")) {
+        throw "Comando de repo nao permitido: $Command"
+    }
+
     Push-Location $RepoRoot
     try {
         $output = & $Command @Arguments
@@ -454,19 +458,19 @@ function Write-ReleaseReport {
 
 Assert-WindowsHost
 Assert-PowerShellHost
-$repoRoot = Resolve-RepoRoot
-$selectedBackends = Get-SelectedBackends $Backend
-$version = Get-AppVersion $repoRoot
-$windowsVersion = Get-WindowsVersionText $version
-$gitHead = Get-GitHead $repoRoot
-$dirtyEntries = Assert-CleanReleaseWorkspace $repoRoot
-
 Assert-Tool "git" "instale Git para Windows"
 Assert-Tool "uv" "instale uv"
 Assert-Tool "rcedit.exe" "scoop install rcedit"
 if (-not $SkipInstaller) {
     Assert-Tool "iscc" "instale Inno Setup ou use -SkipInstaller"
 }
+
+$repoRoot = Resolve-RepoRoot
+$selectedBackends = Get-SelectedBackends $Backend
+$version = Get-AppVersion $repoRoot
+$windowsVersion = Get-WindowsVersionText $version
+$gitHead = Get-GitHead $repoRoot
+$dirtyEntries = Assert-CleanReleaseWorkspace $repoRoot
 
 if (-not $Yes) {
     Write-Host "Repo: $repoRoot"

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -170,57 +170,57 @@ function Get-BackendConfig {
 
     return @{
         pyinstaller = [ordered]@{
-            build_script = Join-Path $RepoRoot "dev_env\build\build_pyinstaller.bat"
+            build_script = (Join-Path $RepoRoot "dev_env\build\build_pyinstaller.bat")
             package_system = "pyinstaller"
-            cli_exe = Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_CLI_v$($Version)_windows_amd64\SSA_CLI_v$($Version)_windows_amd64.exe"
-            gui_exe = Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_GUI_v$($Version)_windows_amd64\SSA_GUI_v$($Version)_windows_amd64.exe"
+            cli_exe = (Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_CLI_v$($Version)_windows_amd64\SSA_CLI_v$($Version)_windows_amd64.exe")
+            gui_exe = (Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_GUI_v$($Version)_windows_amd64\SSA_GUI_v$($Version)_windows_amd64.exe")
             build_info = @(
-                Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_CLI_v$($Version)_windows_amd64\_internal\config\build_info.json",
-                Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_GUI_v$($Version)_windows_amd64\_internal\config\build_info.json"
+                (Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_CLI_v$($Version)_windows_amd64\_internal\config\build_info.json"),
+                (Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_GUI_v$($Version)_windows_amd64\_internal\config\build_info.json")
             )
             release_zips = @(
                 [ordered]@{
-                    source = Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_CLI_v$($Version)_windows_amd64"
-                    zip = Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_pyinstaller_cli.zip"
+                    source = (Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_CLI_v$($Version)_windows_amd64")
+                    zip = (Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_pyinstaller_cli.zip")
                 },
                 [ordered]@{
-                    source = Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_GUI_v$($Version)_windows_amd64"
-                    zip = Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_pyinstaller_gui.zip"
+                    source = (Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_GUI_v$($Version)_windows_amd64")
+                    zip = (Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_pyinstaller_gui.zip")
                 }
             )
         }
         nuitka = [ordered]@{
-            build_script = Join-Path $RepoRoot "dev_env\build\build_nuitka.bat"
+            build_script = (Join-Path $RepoRoot "dev_env\build\build_nuitka.bat")
             package_system = "nuitka"
-            cli_exe = Join-Path $RepoRoot "builds\nuitka\windows_amd64\cli_entry.dist\SSA_CLI_v$($Version)_windows_amd64.exe"
-            gui_exe = Join-Path $RepoRoot "builds\nuitka\windows_amd64\gui_entry.dist\SSA_GUI_v$($Version)_windows_amd64.exe"
+            cli_exe = (Join-Path $RepoRoot "builds\nuitka\windows_amd64\cli_entry.dist\SSA_CLI_v$($Version)_windows_amd64.exe")
+            gui_exe = (Join-Path $RepoRoot "builds\nuitka\windows_amd64\gui_entry.dist\SSA_GUI_v$($Version)_windows_amd64.exe")
             build_info = @(
-                Join-Path $RepoRoot "builds\nuitka\windows_amd64\cli_entry.dist\config\build_info.json",
-                Join-Path $RepoRoot "builds\nuitka\windows_amd64\gui_entry.dist\config\build_info.json"
+                (Join-Path $RepoRoot "builds\nuitka\windows_amd64\cli_entry.dist\config\build_info.json"),
+                (Join-Path $RepoRoot "builds\nuitka\windows_amd64\gui_entry.dist\config\build_info.json")
             )
             release_zips = @(
                 [ordered]@{
-                    source = Join-Path $RepoRoot "builds\nuitka\windows_amd64\cli_entry.dist"
-                    zip = Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_nuitka_cli.zip"
+                    source = (Join-Path $RepoRoot "builds\nuitka\windows_amd64\cli_entry.dist")
+                    zip = (Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_nuitka_cli.zip")
                 },
                 [ordered]@{
-                    source = Join-Path $RepoRoot "builds\nuitka\windows_amd64\gui_entry.dist"
-                    zip = Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_nuitka_gui.zip"
+                    source = (Join-Path $RepoRoot "builds\nuitka\windows_amd64\gui_entry.dist")
+                    zip = (Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_nuitka_gui.zip")
                 }
             )
         }
         pyoxidizer = [ordered]@{
-            build_script = Join-Path $RepoRoot "dev_env\build\build_pyoxidizer.bat"
+            build_script = (Join-Path $RepoRoot "dev_env\build\build_pyoxidizer.bat")
             package_system = "pyoxidizer"
             cli_exe = $null
-            gui_exe = Join-Path $RepoRoot "builds\pyoxidizer\windows_amd64\SSA_Consulta_Rapida.exe"
+            gui_exe = (Join-Path $RepoRoot "builds\pyoxidizer\windows_amd64\SSA_Consulta_Rapida.exe")
             build_info = @(
-                Join-Path $RepoRoot "builds\pyoxidizer\windows_amd64\config\build_info.json"
+                (Join-Path $RepoRoot "builds\pyoxidizer\windows_amd64\config\build_info.json")
             )
             release_zips = @(
                 [ordered]@{
-                    source = Join-Path $RepoRoot "builds\pyoxidizer\windows_amd64"
-                    zip = Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_pyoxidizer.zip"
+                    source = (Join-Path $RepoRoot "builds\pyoxidizer\windows_amd64")
+                    zip = (Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_pyoxidizer.zip")
                 }
             )
         }

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -1,0 +1,525 @@
+param(
+    [ValidateSet("pyinstaller", "nuitka", "pyoxidizer", "all")]
+    [string[]] $Backend,
+    [switch] $Yes,
+    [switch] $SkipBuild,
+    [switch] $SkipPackage,
+    [switch] $SkipInstaller
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = "Stop"
+
+$Platform = "windows_amd64"
+$DistributionScript = "scripts\create_distribution.py"
+$MandatoryGuideName = "GUIA_MIGRACAO_NOVA_INSTALACAO.md"
+
+function Assert-WindowsHost {
+    if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
+        throw "release_windows.ps1 deve rodar somente em Windows PowerShell."
+    }
+}
+
+function Assert-PowerShellHost {
+    if ($PSVersionTable.PSVersion.Major -lt 5) {
+        throw "PowerShell 5 ou superior e requerido."
+    }
+}
+
+function Invoke-RepoCommand {
+    param(
+        [Parameter(Mandatory = $true)] [string] $RepoRoot,
+        [Parameter(Mandatory = $true)] [string] $Command,
+        [string[]] $Arguments = @()
+    )
+
+    Push-Location $RepoRoot
+    try {
+        $output = & $Command @Arguments
+        if ($LASTEXITCODE -ne 0) {
+            throw "Comando falhou: $Command $($Arguments -join ' ')"
+        }
+        return $output
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Resolve-RepoRoot {
+    $root = (git rev-parse --show-toplevel).Trim()
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($root)) {
+        throw "Nao foi possivel localizar a raiz git."
+    }
+    return (Resolve-Path $root).Path
+}
+
+function Assert-Tool {
+    param(
+        [Parameter(Mandatory = $true)] [string] $Name,
+        [Parameter(Mandatory = $true)] [string] $InstallHint
+    )
+
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Ferramenta obrigatoria ausente: $Name. Instale/verifique: $InstallHint"
+    }
+}
+
+function Get-GitHead {
+    param([Parameter(Mandatory = $true)] [string] $RepoRoot)
+
+    $commit = (Invoke-RepoCommand $RepoRoot "git" @("rev-parse", "HEAD")).Trim()
+    $commitDate = (Invoke-RepoCommand $RepoRoot "git" @("log", "-1", "--format=%cI")).Trim()
+    $title = (Invoke-RepoCommand $RepoRoot "git" @("log", "-1", "--format=%s")).Trim()
+    return [ordered]@{
+        commit = $commit
+        short = $commit.Substring(0, 7)
+        commit_datetime = $commitDate
+        title = $title
+    }
+}
+
+function Assert-CleanReleaseWorkspace {
+    param(
+        [Parameter(Mandatory = $true)] [string] $RepoRoot
+    )
+
+    $status = @(Invoke-RepoCommand $RepoRoot "git" @("status", "--porcelain=v1"))
+    if ($status.Count -gt 0) {
+        throw "Workspace sujo. Release Windows requer fonte versionada e limpa.`n$($status -join [Environment]::NewLine)"
+    }
+    return $status
+}
+
+function Get-AppVersion {
+    param([Parameter(Mandatory = $true)] [string] $RepoRoot)
+
+    $versionFile = Join-Path $RepoRoot "config\version.json"
+    $versionJson = Get-Content $versionFile -Raw -Encoding UTF8 | ConvertFrom-Json
+    return [string] $versionJson.version_short
+}
+
+function Get-WindowsVersionText {
+    param([Parameter(Mandatory = $true)] [string] $Version)
+
+    $parts = [regex]::Matches($Version, "\d+") | ForEach-Object { [int] $_.Value } | Select-Object -First 4
+    $list = @($parts)
+    while ($list.Count -lt 4) {
+        $list += 0
+    }
+    return ($list[0..3] -join ".")
+}
+
+function Get-SelectedBackends {
+    param([string[]] $RequestedBackends)
+
+    if (-not $RequestedBackends -or $RequestedBackends.Count -eq 0) {
+        Write-Host "Backends disponiveis: pyinstaller, nuitka, pyoxidizer, all"
+        $raw = Read-Host "Informe um ou mais backends separados por virgula"
+        $RequestedBackends = $raw -split "," | ForEach-Object { $_.Trim().ToLowerInvariant() } | Where-Object { $_ }
+    }
+
+    if ($RequestedBackends -contains "all") {
+        return @("pyinstaller", "nuitka", "pyoxidizer")
+    }
+
+    $valid = @("pyinstaller", "nuitka", "pyoxidizer")
+    foreach ($item in $RequestedBackends) {
+        if ($valid -notcontains $item) {
+            throw "Backend invalido: $item"
+        }
+    }
+    return @($RequestedBackends | Select-Object -Unique)
+}
+
+function Get-BackendScorecard {
+    return [ordered]@{
+        pyinstaller = [ordered]@{
+            security_score = 2
+            python_source_exposure_score = 2
+            easy_user_dirs_score = 5
+            package_size_score = 4
+            note = "Alta compatibilidade; menor protecao contra inspecao do Python empacotado."
+        }
+        nuitka = [ordered]@{
+            security_score = 4
+            python_source_exposure_score = 4
+            easy_user_dirs_score = 4
+            package_size_score = 3
+            note = "Melhor protecao do codigo Python; build mais lento e dependente de toolchain."
+        }
+        pyoxidizer = [ordered]@{
+            security_score = 3
+            python_source_exposure_score = 3
+            easy_user_dirs_score = 3
+            package_size_score = 2
+            note = "Empacotamento forte, mas o layout atual ainda expoe varias pastas Python no output."
+        }
+    }
+}
+
+function Get-BackendConfig {
+    param(
+        [Parameter(Mandatory = $true)] [string] $RepoRoot,
+        [Parameter(Mandatory = $true)] [string] $Version
+    )
+
+    return @{
+        pyinstaller = [ordered]@{
+            build_script = Join-Path $RepoRoot "dev_env\build\build_pyinstaller.bat"
+            package_system = "pyinstaller"
+            cli_exe = Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_CLI_v$($Version)_windows_amd64\SSA_CLI_v$($Version)_windows_amd64.exe"
+            gui_exe = Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_GUI_v$($Version)_windows_amd64\SSA_GUI_v$($Version)_windows_amd64.exe"
+            build_info = @(
+                Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_CLI_v$($Version)_windows_amd64\_internal\config\build_info.json",
+                Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_GUI_v$($Version)_windows_amd64\_internal\config\build_info.json"
+            )
+            release_zips = @(
+                [ordered]@{
+                    source = Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_CLI_v$($Version)_windows_amd64"
+                    zip = Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_pyinstaller_cli.zip"
+                },
+                [ordered]@{
+                    source = Join-Path $RepoRoot "launchers\dist\windows_amd64\SSA_GUI_v$($Version)_windows_amd64"
+                    zip = Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_pyinstaller_gui.zip"
+                }
+            )
+        }
+        nuitka = [ordered]@{
+            build_script = Join-Path $RepoRoot "dev_env\build\build_nuitka.bat"
+            package_system = "nuitka"
+            cli_exe = Join-Path $RepoRoot "builds\nuitka\windows_amd64\cli_entry.dist\SSA_CLI_v$($Version)_windows_amd64.exe"
+            gui_exe = Join-Path $RepoRoot "builds\nuitka\windows_amd64\gui_entry.dist\SSA_GUI_v$($Version)_windows_amd64.exe"
+            build_info = @(
+                Join-Path $RepoRoot "builds\nuitka\windows_amd64\cli_entry.dist\config\build_info.json",
+                Join-Path $RepoRoot "builds\nuitka\windows_amd64\gui_entry.dist\config\build_info.json"
+            )
+            release_zips = @(
+                [ordered]@{
+                    source = Join-Path $RepoRoot "builds\nuitka\windows_amd64\cli_entry.dist"
+                    zip = Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_nuitka_cli.zip"
+                },
+                [ordered]@{
+                    source = Join-Path $RepoRoot "builds\nuitka\windows_amd64\gui_entry.dist"
+                    zip = Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_nuitka_gui.zip"
+                }
+            )
+        }
+        pyoxidizer = [ordered]@{
+            build_script = Join-Path $RepoRoot "dev_env\build\build_pyoxidizer.bat"
+            package_system = "pyoxidizer"
+            cli_exe = $null
+            gui_exe = Join-Path $RepoRoot "builds\pyoxidizer\windows_amd64\SSA_Consulta_Rapida.exe"
+            build_info = @(
+                Join-Path $RepoRoot "builds\pyoxidizer\windows_amd64\config\build_info.json"
+            )
+            release_zips = @(
+                [ordered]@{
+                    source = Join-Path $RepoRoot "builds\pyoxidizer\windows_amd64"
+                    zip = Join-Path $RepoRoot "builds\packages\windows_amd64\SSA_Consulta_Rapida_v$($Version)_windows_amd64_pyoxidizer.zip"
+                }
+            )
+        }
+    }
+}
+
+function Invoke-CheckedProcess {
+    param(
+        [Parameter(Mandatory = $true)] [string] $RepoRoot,
+        [Parameter(Mandatory = $true)] [string] $CommandPath,
+        [string[]] $Arguments = @()
+    )
+
+    Push-Location $RepoRoot
+    try {
+        & $CommandPath @Arguments
+        if ($LASTEXITCODE -ne 0) {
+            throw "Comando falhou: $CommandPath $($Arguments -join ' ')"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Assert-ExistingFile {
+    param([Parameter(Mandatory = $true)] [string] $Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Arquivo obrigatorio ausente: $Path"
+    }
+}
+
+function Assert-ExistingDirectory {
+    param([Parameter(Mandatory = $true)] [string] $Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        throw "Diretorio obrigatorio ausente: $Path"
+    }
+}
+
+function Assert-BuildInfo {
+    param(
+        [Parameter(Mandatory = $true)] [string[]] $BuildInfoPaths,
+        [Parameter(Mandatory = $true)] [string] $ExpectedCommit,
+        [Parameter(Mandatory = $true)] [string] $ExpectedPlatform,
+        [Parameter(Mandatory = $true)] [string] $ExpectedSystem
+    )
+
+    $records = @()
+    foreach ($path in $BuildInfoPaths) {
+        Assert-ExistingFile $path
+        $info = Get-Content $path -Raw -Encoding UTF8 | ConvertFrom-Json
+        if ($info.git_commit -ne $ExpectedCommit) {
+            throw "build_info stale em ${path}: $($info.git_commit) != $ExpectedCommit"
+        }
+        if ($info.platform -ne $ExpectedPlatform) {
+            throw "build_info platform invalido em ${path}: $($info.platform)"
+        }
+        if ($info.build_system -ne $ExpectedSystem) {
+            throw "build_info build_system invalido em ${path}: $($info.build_system)"
+        }
+        $records += $info
+    }
+    return $records
+}
+
+function Assert-ExeMetadata {
+    param(
+        [Parameter(Mandatory = $true)] [string[]] $ExePaths,
+        [Parameter(Mandatory = $true)] [string] $ExpectedVersion
+    )
+
+    $records = @()
+    foreach ($path in $ExePaths | Where-Object { $_ }) {
+        Assert-ExistingFile $path
+        $info = [System.Diagnostics.FileVersionInfo]::GetVersionInfo((Resolve-Path $path).Path)
+        if ($info.FileVersion -ne $ExpectedVersion) {
+            throw "FileVersion invalido em ${path}: $($info.FileVersion) != $ExpectedVersion"
+        }
+        if ($info.ProductVersion -ne $ExpectedVersion) {
+            throw "ProductVersion invalido em ${path}: $($info.ProductVersion) != $ExpectedVersion"
+        }
+        if ([string]::IsNullOrWhiteSpace($info.ProductName)) {
+            throw "ProductName vazio em ${path}"
+        }
+        $records += [ordered]@{
+            path = $path
+            file_version = $info.FileVersion
+            product_version = $info.ProductVersion
+            product_name = $info.ProductName
+            file_description = $info.FileDescription
+            original_filename = $info.OriginalFilename
+        }
+    }
+    return $records
+}
+
+function Invoke-Smoke {
+    param(
+        [Parameter(Mandatory = $true)] [string] $BackendName,
+        [Parameter(Mandatory = $true)] [hashtable] $Config
+    )
+
+    if ($BackendName -eq "pyoxidizer") {
+        $versionOutput = (& $Config.gui_exe --version 2>&1)
+        if ($LASTEXITCODE -ne 0) {
+            throw "Smoke PyOxidizer --version falhou."
+        }
+        $versionText = ($versionOutput | Out-String).Trim()
+        if ([string]::IsNullOrWhiteSpace($versionText)) {
+            throw "Smoke PyOxidizer --version nao retornou texto."
+        }
+        return [ordered]@{
+            verification_type = "version_check"
+            command = "--version"
+            exit_code = 0
+            output = $versionText
+        }
+    }
+
+    $inputText = "q`n"
+    $inputText | & $Config.cli_exe --skip-import | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Smoke CLI falhou para ${BackendName}."
+    }
+    return [ordered]@{
+        verification_type = "functional_cli_check"
+        command = "CLI --skip-import"
+        exit_code = 0
+        output = ""
+    }
+}
+
+function Write-BackendReleaseZips {
+    param(
+        [Parameter(Mandatory = $true)] [array] $ReleaseZips
+    )
+
+    $outDir = Split-Path -Parent $ReleaseZips[0].zip
+    New-Item -ItemType Directory -Force $outDir | Out-Null
+    foreach ($item in $ReleaseZips) {
+        Assert-ExistingDirectory $item.source
+        Compress-Archive -Force -Path $item.source -DestinationPath $item.zip
+    }
+}
+
+function Assert-ZipContents {
+    param(
+        [Parameter(Mandatory = $true)] [array] $ZipPaths
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $records = @()
+    foreach ($path in $ZipPaths) {
+        Assert-ExistingFile $path
+        $archive = [System.IO.Compression.ZipFile]::OpenRead((Resolve-Path $path).Path)
+        try {
+            $entries = @($archive.Entries | ForEach-Object { $_.FullName })
+            $hasBuildInfo = [bool]($entries | Where-Object { $_ -like "*config/build_info.json" -or $_ -like "*config\build_info.json" })
+            $hasGuide = [bool]($entries | Where-Object { $_ -like "*$MandatoryGuideName" })
+            $hasExe = [bool]($entries | Where-Object { $_ -like "*.exe" })
+            if (-not $hasBuildInfo) {
+                throw "ZIP sem build_info.json: $path"
+            }
+            if (-not $hasGuide) {
+                throw "ZIP sem ${MandatoryGuideName}: $path"
+            }
+            if (-not $hasExe) {
+                throw "ZIP sem exe: $path"
+            }
+            $records += [ordered]@{
+                path = $path
+                entry_count = $entries.Count
+                has_build_info = $hasBuildInfo
+                has_guide = $hasGuide
+                has_exe = $hasExe
+            }
+        }
+        finally {
+            $archive.Dispose()
+        }
+    }
+    return $records
+}
+
+function Get-ArtifactHash {
+    param([Parameter(Mandatory = $true)] [string[]] $Paths)
+
+    $records = @()
+    foreach ($path in $Paths) {
+        Assert-ExistingFile $path
+        $hash = Get-FileHash -Algorithm SHA256 -LiteralPath $path
+        $records += [ordered]@{
+            path = $hash.Path
+            sha256 = $hash.Hash
+            length = (Get-Item -LiteralPath $path).Length
+        }
+    }
+    return $records
+}
+
+function Invoke-DistributionPackage {
+    param(
+        [Parameter(Mandatory = $true)] [string] $RepoRoot,
+        [Parameter(Mandatory = $true)] [string] $BackendName,
+        [Parameter(Mandatory = $true)] [bool] $SkipInstallerFlag
+    )
+
+    $args = @("run", "--python", "3.13", $DistributionScript, "--build-system", $BackendName)
+    if ($SkipInstallerFlag) {
+        $args += "--skip-installer"
+    }
+    Invoke-CheckedProcess $RepoRoot "uv" $args
+}
+
+function Write-ReleaseReport {
+    param(
+        [Parameter(Mandatory = $true)] [string] $RepoRoot,
+        [Parameter(Mandatory = $true)] [hashtable] $Report
+    )
+
+    $reportDir = Join-Path $RepoRoot "builds\reports"
+    New-Item -ItemType Directory -Force $reportDir | Out-Null
+    $reportPath = Join-Path $reportDir "release_report_windows_amd64.json"
+    $Report | ConvertTo-Json -Depth 12 | Set-Content -Path $reportPath -Encoding UTF8
+    return $reportPath
+}
+
+Assert-WindowsHost
+Assert-PowerShellHost
+$repoRoot = Resolve-RepoRoot
+$selectedBackends = Get-SelectedBackends $Backend
+$version = Get-AppVersion $repoRoot
+$windowsVersion = Get-WindowsVersionText $version
+$gitHead = Get-GitHead $repoRoot
+$dirtyEntries = Assert-CleanReleaseWorkspace $repoRoot
+
+Assert-Tool "git" "instale Git para Windows"
+Assert-Tool "uv" "instale uv"
+Assert-Tool "rcedit.exe" "scoop install rcedit"
+if (-not $SkipInstaller) {
+    Assert-Tool "iscc" "instale Inno Setup ou use -SkipInstaller"
+}
+
+if (-not $Yes) {
+    Write-Host "Repo: $repoRoot"
+    Write-Host "HEAD: $($gitHead.commit)"
+    Write-Host "Backends: $($selectedBackends -join ', ')"
+    $confirm = Read-Host "Continuar? [s/N]"
+    if ($confirm.ToLowerInvariant() -ne "s") {
+        throw "Operacao cancelada pelo usuario."
+    }
+}
+
+$configs = Get-BackendConfig $repoRoot $version
+$scorecard = Get-BackendScorecard
+$results = @()
+
+foreach ($backendName in $selectedBackends) {
+    $config = $configs[$backendName]
+    if (-not $SkipBuild) {
+        Invoke-CheckedProcess $repoRoot $config.build_script @("--silent")
+    }
+
+    $buildInfoRecords = Assert-BuildInfo $config.build_info $gitHead.commit $Platform $config.package_system
+    $metadataRecords = Assert-ExeMetadata @($config.cli_exe, $config.gui_exe) $windowsVersion
+    $smokeRecord = Invoke-Smoke $backendName $config
+
+    if (-not $SkipPackage) {
+        Write-BackendReleaseZips $config.release_zips
+        Invoke-DistributionPackage $repoRoot $config.package_system ([bool] $SkipInstaller)
+    }
+
+    $zipPaths = @($config.release_zips | ForEach-Object { $_.zip })
+    $zipRecords = Assert-ZipContents $zipPaths
+    $hashRecords = Get-ArtifactHash $zipPaths
+
+    $results += [ordered]@{
+        backend = $backendName
+        scorecard = $scorecard[$backendName]
+        build_info = $buildInfoRecords
+        exe_metadata = $metadataRecords
+        smoke = $smokeRecord
+        zip_validation = $zipRecords
+        hashes = $hashRecords
+    }
+}
+
+$report = [ordered]@{
+    schema_version = 1
+    generated_at = (Get-Date).ToString("o")
+    platform = $Platform
+    repo_root = $repoRoot
+    powershell = [ordered]@{
+        edition = $PSVersionTable.PSEdition
+        version = $PSVersionTable.PSVersion.ToString()
+    }
+    os = [System.Environment]::OSVersion.VersionString
+    git = $gitHead
+    dirty_entries = $dirtyEntries
+    selected_backends = $selectedBackends
+    backend_scorecard = $scorecard
+    results = $results
+}
+
+$reportPath = Write-ReleaseReport $repoRoot $report
+Write-Host "Release Windows concluido. Report: $reportPath"

--- a/docs/BUILD_3X3_RUNBOOK.md
+++ b/docs/BUILD_3X3_RUNBOOK.md
@@ -152,6 +152,7 @@ Regras Debian:
 3. AppImage aceita apenas `pyinstaller` e `nuitka`
 4. `--with-local-data` nao e suportado via SSH; execute localmente no host Debian se precisar desse modo
 5. PowerShell nao entra neste fluxo
+6. backends rodam em serie por desenho; Nuitka e PyOxidizer pressionam CPU/RAM/IO e paralelizar build completo so deve ser feito em slice proprio com medicao de recursos
 
 ### Debian 13 via WSL
 

--- a/docs/BUILD_3X3_RUNBOOK.md
+++ b/docs/BUILD_3X3_RUNBOOK.md
@@ -116,6 +116,43 @@ Regra de integridade:
 .\dev_env\build\build_pyoxidizer.bat --silent
 ```
 
+### Debian 13 deterministico local ou via SSH
+
+Use este fluxo para release Debian AMD64. Ele roda somente em shell POSIX,
+chama somente wrappers `.sh`, valida workspace limpo, `build_info.json`,
+guia de migracao, conteudo do `.deb` e escreve relatorio com hashes.
+
+Local no Debian/WSL:
+
+```bash
+bash dev_env/build/release_debian.sh --backend pyinstaller,nuitka,pyoxidizer --package deb -y
+```
+
+Via SSH para host Debian:
+
+```bash
+bash dev_env/build/release_debian.sh --ssh-host user@debian-host --ssh-repo /home/user/SSA_Consulta_Rapida --backend pyinstaller,nuitka,pyoxidizer --package deb -y
+```
+
+AppImage e opcional e existe somente para `pyinstaller` e `nuitka`:
+
+```bash
+bash dev_env/build/release_debian.sh --backend pyinstaller,nuitka --package appimage -y
+```
+
+Saida de auditoria:
+
+```text
+builds/reports/release_report_debian_amd64.json
+```
+
+Regras Debian:
+1. workspace sujo bloqueia o release
+2. `.deb` aceita `pyinstaller`, `nuitka` e `pyoxidizer`
+3. AppImage aceita apenas `pyinstaller` e `nuitka`
+4. `--with-local-data` nao e suportado via SSH; execute localmente no host Debian se precisar desse modo
+5. PowerShell nao entra neste fluxo
+
 ### Debian 13 via WSL
 
 ```bash

--- a/docs/BUILD_3X3_RUNBOOK.md
+++ b/docs/BUILD_3X3_RUNBOOK.md
@@ -24,6 +24,12 @@ uv run --python 3.13 python -V
 ```
 
 3. Inno Setup para empacotador (`iscc`) quando for gerar instalador.
+4. `rcedit` no `PATH` para build PyOxidizer Windows com icone:
+
+```powershell
+scoop install rcedit
+rcedit
+```
 
 ### Debian 13 via WSL
 

--- a/docs/BUILD_3X3_RUNBOOK.md
+++ b/docs/BUILD_3X3_RUNBOOK.md
@@ -10,6 +10,11 @@ Padrao reproduzivel para gerar e validar build nas 3 plataformas e 3 backends, c
 2. Nao commitar artefatos de build (`builds/`, `launchers/dist/`, `dist_packages/`).
 3. Rodar smoke fora do repo (`C:\Windows\Temp` ou `/tmp`).
 4. Garantir runtime dirs visiveis: `config`, `data`, `docs_entrada`, `docs_saida`, `exportacao`.
+5. Nao misturar shells:
+   - Windows: PowerShell chama `.bat` com `.\` e caminhos `\`.
+   - Debian/WSL/Linux: shell POSIX chama `.sh` com `/`.
+   - macOS: shell POSIX chama `.sh` ou `uv` com `/`.
+6. Nao chamar `bash dev_env/...` no PowerShell e nao chamar `.\dev_env\...bat` no WSL/Linux/macOS.
 
 ## Pre requisitos por host
 
@@ -24,12 +29,21 @@ uv run --python 3.13 python -V
 ```
 
 3. Inno Setup para empacotador (`iscc`) quando for gerar instalador.
-4. `rcedit` no `PATH` para build PyOxidizer Windows com icone:
+4. `rcedit` no `PATH` para build PyOxidizer Windows com icone e metadata:
 
 ```powershell
 scoop install rcedit
-rcedit
+rcedit.exe --help
 ```
+
+`rcedit` e um editor de recursos PE do Windows. Ele altera icone, `FileVersion`,
+`ProductVersion` e strings de versao em executaveis `.exe`.
+
+Regra de uso no projeto:
+1. PyInstaller Windows recebe metadata no momento do build via `--version-file`.
+2. Nao aplicar `rcedit` manualmente sobre PyInstaller onefile pronto; isso pode quebrar o arquivo PKG embutido.
+3. PyOxidizer Windows usa `rcedit` no script de build para aplicar icone e metadata.
+4. Nuitka Windows deve continuar usando recursos/versionamento no proprio fluxo de build.
 
 ### Debian 13 via WSL
 
@@ -63,9 +77,9 @@ export UV_PROJECT_ENVIRONMENT=.venv-linux
 ### Windows
 
 ```powershell
-dev_env/build/build_pyinstaller.bat --silent
-dev_env/build/build_nuitka.bat --silent
-dev_env/build/build_pyoxidizer.bat --silent
+.\dev_env\build\build_pyinstaller.bat --silent
+.\dev_env\build\build_nuitka.bat --silent
+.\dev_env\build\build_pyoxidizer.bat --silent
 ```
 
 ### Debian 13 via WSL
@@ -108,6 +122,29 @@ if (-not $CLI_BIN) {
   throw "Nenhum binario SSA_CLI_v*_windows_amd64.exe encontrado em $DIST_ROOT"
 }
 & $CLI_BIN --help
+```
+
+### Windows metadata (PowerShell)
+
+```powershell
+$EXES = @(
+  ".\launchers\dist\windows_amd64\SSA_CLI_v4.37_windows_amd64\SSA_CLI_v4.37_windows_amd64.exe",
+  ".\launchers\dist\windows_amd64\SSA_GUI_v4.37_windows_amd64\SSA_GUI_v4.37_windows_amd64.exe",
+  ".\builds\nuitka\windows_amd64\cli_entry.dist\SSA_CLI_v4.37_windows_amd64.exe",
+  ".\builds\nuitka\windows_amd64\gui_entry.dist\SSA_GUI_v4.37_windows_amd64.exe",
+  ".\builds\pyoxidizer\windows_amd64\SSA_Consulta_Rapida.exe"
+)
+$ROWS = @()
+foreach ($EXE in $EXES) {
+  $INFO = [System.Diagnostics.FileVersionInfo]::GetVersionInfo((Resolve-Path $EXE).Path)
+  $ROWS += [pscustomobject]@{
+    Path = $EXE
+    FileVersion = $INFO.FileVersion
+    ProductVersion = $INFO.ProductVersion
+    ProductName = $INFO.ProductName
+  }
+}
+$ROWS | Format-Table -AutoSize
 ```
 
 ### Linux/WSL

--- a/docs/BUILD_3X3_RUNBOOK.md
+++ b/docs/BUILD_3X3_RUNBOOK.md
@@ -74,6 +74,40 @@ export UV_PROJECT_ENVIRONMENT=.venv-linux
 
 ## Build por backend
 
+### Windows deterministico
+
+Use este fluxo para release local Windows. Ele executa preflight, seleciona
+backends, chama somente wrappers `.bat`, valida `build_info.json`, valida
+metadata dos EXEs, gera ZIPs por backend, roda smoke minimo e escreve relatorio.
+
+```powershell
+.\dev_env\build\release_windows.ps1
+```
+
+Modo nao interativo:
+
+```powershell
+.\dev_env\build\release_windows.ps1 -Backend pyinstaller,nuitka,pyoxidizer -Yes
+```
+
+Sem instalador Inno:
+
+```powershell
+.\dev_env\build\release_windows.ps1 -Backend pyinstaller -Yes -SkipInstaller
+```
+
+Saida de auditoria:
+
+```text
+builds\reports\release_report_windows_amd64.json
+```
+
+Regra de integridade:
+1. workspace sujo bloqueia o release
+2. `build_info.git_commit` precisa bater com `git rev-parse HEAD`
+3. ZIP precisa conter EXE, `config/build_info.json` e `GUIA_MIGRACAO_NOVA_INSTALACAO.md`
+4. PowerShell nao chama shell POSIX neste fluxo
+
 ### Windows
 
 ```powershell

--- a/docs/BUILD_MULTIPLATFORM.md
+++ b/docs/BUILD_MULTIPLATFORM.md
@@ -4,7 +4,7 @@ Sistema automatizado para criacao de executaveis SSA Consulta Rapida para Window
 
 ## CURRENT TRUTH (4.37 local / v4.36 published)
 
-- Sync deste guia: `2026-03-26 11:40 -0300`.
+- Sync deste guia: `2026-04-27 12:45 -0300`.
 - Relatorio consolidado deste ciclo:
   - `docs/BUILD_EXECUTION_AUDIT_20260311.md`
 - Runbook operacional 3x3:
@@ -21,10 +21,14 @@ Sistema automatizado para criacao de executaveis SSA Consulta Rapida para Window
     - `dev_env/build/build_pyinstaller.bat --silent`
     - `dev_env/build/build_nuitka.bat --silent`
     - `dev_env/build/build_pyoxidizer.bat --silent`
-  - Debian via WSL:
+  - Debian AMD64:
     - `bash dev_env/build/build_pyinstaller_debian.sh --silent`
     - `bash dev_env/build/build_nuitka_debian.sh --silent`
     - `bash dev_env/build/build_pyoxidizer_debian.sh --silent`
+  - Debian ARM64:
+    - `bash dev_env/build/build_pyinstaller_debian_arm64.sh --silent`
+    - `bash dev_env/build/build_nuitka_debian_arm64.sh --silent`
+    - `bash dev_env/build/build_pyoxidizer_debian_arm64.sh --silent`
 
 ## Local de saida e staging
 
@@ -72,10 +76,14 @@ launchers/
 │   │   ├── venv/               # Ambiente virtual macOS
 │   │   ├── requirements.txt    # Deps especificas macOS
 │   │   └── build_config.json   # Config PyInstaller macOS
-│   └── debian_amd64/
-│       ├── venv/               # Ambiente virtual Linux
-│       ├── requirements.txt    # Deps especificas Linux
-│       └── build_config.json   # Config PyInstaller Linux
+│   ├── debian_amd64/
+│   │   ├── venv/               # Ambiente virtual Linux AMD64
+│   │   ├── requirements.txt    # Deps especificas Linux AMD64
+│   │   └── build_config.json   # Config PyInstaller Linux AMD64
+│   └── debian_arm64/
+│       ├── venv/               # Ambiente virtual Linux ARM64
+│       ├── requirements.txt    # Deps especificas Linux ARM64
+│       └── build_config.json   # Config PyInstaller Linux ARM64
 ├── dist/                       # Executaveis gerados
 │   ├── windows_amd64/
 │   │   ├── SSA_CLI_v3.10_windows_amd64.exe
@@ -104,6 +112,7 @@ uv run --python 3.13 launchers/build_multiplatform.py
 uv run --python 3.13 launchers/build_multiplatform.py --platform windows_amd64
 uv run --python 3.13 launchers/build_multiplatform.py --platform macos_arm64
 uv run --python 3.13 launchers/build_multiplatform.py --platform debian_amd64
+uv run --python 3.13 launchers/build_multiplatform.py --platform debian_arm64
 ```
 
 ### Build de todos os apps da plataforma atual
@@ -145,8 +154,9 @@ O script automaticamente:
 - Pandas (Apple Silicon)
 - PyQt6 (ARM64)
 
-**Debian AMD64:**
+**Debian AMD64/ARM64:**
 - PyInstaller 6.0+
+- Nuitka 4.0+ para trilha Nuitka
 - Pandas
 - PyQt6
 - Bibliotecas sistema (libGL, libX11)
@@ -189,9 +199,15 @@ Exemplo:
 
 ### Empacotamento Debian no baseline atual
 
-- Saida operacional oficial para Debian: ZIP.
-- AppImage/.deb nao sao gerados automaticamente pelo pipeline canonico atual.
-- Se necessario, tratar AppImage/.deb como etapa manual/laboratorio fora do fluxo padrao.
+- Saida operacional oficial para Debian continua sendo ZIP pelo pipeline canonico.
+- `.deb` e AppImage existem como etapa manual de release por arquitetura, fora do `build_multiplatform.py`.
+- Scripts disponiveis:
+  - `dev_env/build/package_debian_amd64_deb.sh`
+  - `dev_env/build/package_debian_amd64_appimage.sh`
+  - `dev_env/build/package_debian_arm64_deb.sh`
+  - `dev_env/build/package_debian_arm64_appimage.sh`
+- Os scripts removem residuos locais do pacote final: `venv`, `.bak`, bancos locais, planilhas e `.env`.
+- AppImage suporta `--prepare-only` para validar o AppDir quando `appimagetool` nao esta instalado.
 
 ### Manifesto de Release
 Cada build gera um `release_manifest.json`:

--- a/docs/GUIA_DISTRIBUICAO.md
+++ b/docs/GUIA_DISTRIBUICAO.md
@@ -126,6 +126,30 @@ Importante:
 
 ### 4) Criar .deb e AppImage Debian manualmente
 
+Fluxo recomendado para Debian AMD64:
+
+```bash
+bash dev_env/build/release_debian.sh --backend pyinstaller,nuitka,pyoxidizer --package deb -y
+```
+
+Fluxo remoto por SSH:
+
+```bash
+bash dev_env/build/release_debian.sh --ssh-host user@host --ssh-repo /home/user/SSA_Consulta_Rapida --backend pyinstaller,nuitka,pyoxidizer --package deb -y
+```
+
+AppImage Debian AMD64:
+
+```bash
+bash dev_env/build/release_debian.sh --backend pyinstaller,nuitka --package appimage -y
+```
+
+O orquestrador valida workspace limpo, `config/build_info.json`,
+`docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md`, conteudo de `.deb` e gera
+`builds/reports/release_report_debian_amd64.json`.
+
+Comandos manuais por wrapper continuam disponiveis:
+
 ```bash
 bash dev_env/build/package_debian_amd64_deb.sh --build-system pyinstaller
 bash dev_env/build/package_debian_amd64_appimage.sh --build-system pyinstaller --prepare-only

--- a/docs/GUIA_DISTRIBUICAO.md
+++ b/docs/GUIA_DISTRIBUICAO.md
@@ -42,7 +42,8 @@ usando o fluxo canonico atual.
 
 Nota Debian:
 - no baseline atual, Debian usa pacote ZIP canonico.
-- AppImage/.deb ficam como trilha futura e nao sao etapa automatica do pipeline oficial.
+- `.deb` e AppImage ficam como etapa manual de release por arquitetura.
+- scripts disponiveis para AMD64 e ARM64 ficam em `dev_env/build/package_debian_*`.
 
 ## Build Canonico
 
@@ -58,6 +59,7 @@ uv run --python 3.13 launchers/build_multiplatform.py --apps cli gui
 uv run --python 3.13 launchers/build_multiplatform.py --platform windows_amd64 --apps cli gui
 uv run --python 3.13 launchers/build_multiplatform.py --platform macos_arm64 --apps cli gui
 uv run --python 3.13 launchers/build_multiplatform.py --platform debian_amd64 --apps cli gui
+uv run --python 3.13 launchers/build_multiplatform.py --platform debian_arm64 --apps cli gui
 ```
 
 ### 3) Verificar saida do build
@@ -122,6 +124,21 @@ Importante:
 - `nuitka` e `pyoxidizer` estao mantidos como trilha experimental neste ciclo.
 - Para release operacional, usar PyInstaller como padrao.
 
+### 4) Criar .deb e AppImage Debian manualmente
+
+```bash
+bash dev_env/build/package_debian_amd64_deb.sh --build-system pyinstaller
+bash dev_env/build/package_debian_amd64_appimage.sh --build-system pyinstaller --prepare-only
+bash dev_env/build/package_debian_arm64_deb.sh --build-system pyinstaller
+bash dev_env/build/package_debian_arm64_appimage.sh --build-system pyinstaller --prepare-only
+```
+
+Notas Debian:
+- `.deb` aceita `pyinstaller`, `nuitka` e `pyoxidizer`.
+- AppImage aceita `pyinstaller` e `nuitka`.
+- `--prepare-only` valida AppDir sem exigir `appimagetool`.
+- Os pacotes finais removem residuos locais: `venv`, backups `.bak`, bancos, planilhas e `.env`.
+
 ## Mapa de Pastas de Build
 
 ### Pastas temporarias (nunca versionar)
@@ -140,6 +157,7 @@ Importante:
 ### Artefatos finais de distribuicao (nunca versionar)
 
 - ZIP/installer final: `dist_packages/`
+- `.deb` e AppImage Debian manual: `builds/packages/<plataforma>/`
 - Script `.iss` gerado: `dist_packages/installer_<backend>.iss`
 
 ### Exes principais esperados (Windows)
@@ -149,12 +167,14 @@ Importante:
 - Nuitka: `builds/nuitka/windows_amd64/gui_entry.dist/SSA_GUI_v<versao>_windows_amd64.exe`
 - PyOxidizer: `builds/pyoxidizer/windows_amd64/SSA_Consulta_Rapida.exe`
 
-### Exes principais esperados (Debian via WSL)
+### Exes principais esperados (Debian)
 
-- Tradicional (PyInstaller, onedir): `launchers/dist/debian_amd64/SSA_GUI_v<versao>_debian_amd64/SSA_GUI_v<versao>_debian_amd64`
-- Tradicional (equivalente/espelho): `builds/pyinstaller/debian_amd64/SSA_GUI_v<versao>_debian_amd64/SSA_GUI_v<versao>_debian_amd64`
-- Nuitka: `builds/nuitka/debian_amd64/gui_entry.dist/SSA_GUI_v<versao>_debian_amd64`
-- PyOxidizer: `builds/pyoxidizer/debian_amd64/SSA_Consulta_Rapida`
+Use `<plataforma>` como `debian_amd64` ou `debian_arm64`.
+
+- Tradicional (PyInstaller, onedir): `launchers/dist/<plataforma>/SSA_GUI_v<versao>_<plataforma>/SSA_GUI_v<versao>_<plataforma>`
+- Tradicional (equivalente/espelho): `builds/pyinstaller/<plataforma>/SSA_GUI_v<versao>_<plataforma>/SSA_GUI_v<versao>_<plataforma>`
+- Nuitka: `builds/nuitka/<plataforma>/gui_entry.dist/SSA_GUI_v<versao>_<plataforma>`
+- PyOxidizer: `builds/pyoxidizer/<plataforma>/SSA_Consulta_Rapida`
 
 ## Estrutura Esperada dos Pacotes
 

--- a/docs/GUIA_DISTRIBUICAO.md
+++ b/docs/GUIA_DISTRIBUICAO.md
@@ -160,6 +160,7 @@ bash dev_env/build/package_debian_arm64_appimage.sh --build-system pyinstaller -
 Notas Debian:
 - `.deb` aceita `pyinstaller`, `nuitka` e `pyoxidizer`.
 - AppImage aceita `pyinstaller` e `nuitka`.
+- Debian ARM64 requer host Debian ARM64 nativo; este fluxo nao faz cross-compilation.
 - `--prepare-only` valida AppDir sem exigir `appimagetool`.
 - Os pacotes finais removem residuos locais: `venv`, backups `.bak`, bancos, planilhas e `.env`.
 

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -124,9 +124,9 @@ Escopo desta atualizacao:
 
 Backup e mudanca aplicada:
 1. backup timestamp criado antes da alteracao:
-   - `C:\\Users\\mauri\\.wslconfig.backup_20260428_182150`
+   - arquivo `.wslconfig.backup_<timestamp>` no perfil do usuario Windows
 2. arquivo atualizado:
-   - `C:\\Users\\mauri\\.wslconfig`
+   - `.wslconfig` no perfil do usuario Windows
 3. conteudo aplicado:
    - `[wsl2]`
    - `guiApplications=false`
@@ -137,12 +137,11 @@ Backup e mudanca aplicada:
 
 Evidencia com VPN ligada (estado atual):
 1. host VPN:
-   - IP corporativo ativo: `10.30.15.132`
-   - rota VPN para varias redes via `10.30.15.131`
+   - IP corporativo ativo observado em faixa privada corporativa
+   - rota VPN para redes corporativas via gateway privado corporativo
 2. WSL apos mirrored:
-   - interface `eth0` em `10.30.15.132/24`
-   - interface `eth3` em `10.5.0.2/16`
-   - rota default visivel no snapshot: `default via 192.168.0.1 dev eth7`
+   - interfaces do WSL em modo mirrored observadas em faixas privadas locais/corporativas
+   - rota default visivel para gateway privado local
 3. conectividade WSL validada:
    - `curl -I https://api.github.com` -> `HTTP/2 200`
    - `gh api rate_limit` -> resposta valida
@@ -194,8 +193,8 @@ Pendencias de compilacao/executavel:
 
 WSL x VPN (operacional):
 1. com VPN desconectada:
-   - WSL `eth0` em `172.28.122.3/20`, gateway `172.28.112.1`
-   - adapter Check Point observado em `10.5.0.2/16`
+   - WSL em faixa privada NAT local
+   - adapter Check Point observado em faixa privada corporativa
 2. sem overlap direto nesse snapshot, mas a VPN pode injetar rotas amplas e quebrar NAT do WSL
 3. acao sugerida para proximo ciclo operacional:
    - testar `networkingMode=mirrored` no `.wslconfig`

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -5,6 +5,33 @@ O escopo fica dividido por prioridade para manter a entrega segura e incremental
 
 ## ACTIVE PRIORITIES
 
+## Update 2026-04-29 19:40 - Windows release orchestrator
+
+Escopo desta atualizacao:
+1. criar orquestrador Windows deterministico para release local
+2. eliminar mistura manual de sintaxe PowerShell com shell POSIX no fluxo Windows
+3. exigir fonte limpa e `build_info.json` alinhado ao HEAD antes de validar artefato
+
+Fluxo novo:
+1. `dev_env/build/release_windows.ps1`
+2. seleciona `pyinstaller`, `nuitka`, `pyoxidizer` ou multiplos backends
+3. chama somente wrappers Windows `.bat`
+4. gera ZIPs em `builds/packages/windows_amd64`
+5. chama `scripts/create_distribution.py` para pacotes canonicos
+6. valida metadata PE com `[System.Diagnostics.FileVersionInfo]`
+7. valida ZIP com EXE, `config/build_info.json` e `GUIA_MIGRACAO_NOVA_INSTALACAO.md`
+8. gera `builds/reports/release_report_windows_amd64.json`
+
+Regra de seguranca/reprodutibilidade:
+1. nao ha `AllowDirty`
+2. workspace sujo bloqueia release
+3. smoke PyOxidizer precisa retornar texto em `--version`
+4. falha em um backend para o processo, por politica fail-fast de release
+
+Pendencia proximo slice:
+1. criar orquestrador Debian local/remoto equivalente, sem chamar PowerShell
+2. definir se o Debian remoto sera por `ssh` ou apenas comando local documentado
+
 ## Update 2026-04-29 19:05 - PyOxidizer metadata clean rebuild correction
 
 Correcao de estado:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -5,6 +5,45 @@ O escopo fica dividido por prioridade para manter a entrega segura e incremental
 
 ## ACTIVE PRIORITIES
 
+## Update 2026-04-28 18:22 - WSL mirrored applied with VPN ON (operational fix)
+
+Escopo desta atualizacao:
+1. corrigir quebra de internet no WSL com VPN endpoint ligada
+2. aplicar mudanca operacional sem tocar runtime do app
+3. registrar evidencia tecnica de antes/depois
+
+Backup e mudanca aplicada:
+1. backup timestamp criado antes da alteracao:
+   - `C:\\Users\\mauri\\.wslconfig.backup_20260428_182150`
+2. arquivo atualizado:
+   - `C:\\Users\\mauri\\.wslconfig`
+3. conteudo aplicado:
+   - `[wsl2]`
+   - `guiApplications=false`
+   - `networkingMode=mirrored`
+   - `dnsTunneling=true`
+   - `autoProxy=true`
+4. WSL reiniciado com `wsl --shutdown`
+
+Evidencia com VPN ligada (estado atual):
+1. host VPN:
+   - IP corporativo ativo: `10.30.15.132`
+   - rota VPN para varias redes via `10.30.15.131`
+2. WSL apos mirrored:
+   - interface `eth0` em `10.30.15.132/24`
+   - interface `eth3` em `10.5.0.2/16`
+   - rota default visivel no snapshot: `default via 192.168.0.1 dev eth7`
+3. conectividade WSL validada:
+   - `curl -I https://api.github.com` -> `HTTP/2 200`
+   - `gh api rate_limit` -> resposta valida
+
+Resultado:
+1. mitigacao operacional aplicada e validada no ambiente atual
+2. WSL voltou a ter acesso externo mesmo com VPN ligada
+
+Pendencia residual:
+1. monitorar estabilidade em proximas sessoes (mudancas de politica de rota da VPN podem alterar comportamento)
+
 ## Update 2026-04-28 18:05 - test gate hardening + WSL/VPN network note
 
 Escopo desta atualizacao:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -5,6 +5,53 @@ O escopo fica dividido por prioridade para manter a entrega segura e incremental
 
 ## ACTIVE PRIORITIES
 
+## Update 2026-04-28 14:31 - W11 AMD64 release hardening status
+
+Escopo desta atualizacao:
+1. registrar o estado real do host atual apos a migracao para Windows 11
+2. corrigir a leitura operacional sobre Debian neste computador
+3. separar o que foi corrigido nos scripts do que foi efetivamente buildado
+
+Estado do host atual:
+1. Windows 11 local: AMD64
+2. WSL local: Debian Trixie AMD64
+3. Debian ARM64 e macOS ARM64 nao foram buildados neste host
+4. os scripts Debian ARM64 foram ajustados por risco de release, mas seguem sem build local nesta maquina
+
+Status tecnico do ciclo:
+1. HEAD detached foi corrigido operacionalmente para branch local `dev`
+2. stash de seguranca criado antes da troca:
+   - `stash@{0}: wip-before-reattach-dev-2026-04-28T14-30-26`
+3. artefatos Windows gerados antes do ultimo patch de performance precisam rebuild antes de publicar
+4. correcoes de empacotamento incluem guia de migracao e `config/build_info.json`
+5. import externo explicito foi liberado para arquivos escolhidos pelo usuario
+6. abertura de detalhes com derivadas teve hotspot de scan por no removido
+
+Evidencia de performance:
+1. alvo medido: SSA `202206235`
+2. base local: `data/ssas.db`, `80459 x 84`
+3. antes: `tree_html_no_cache` em `12.818s`
+4. depois: `tree_html_no_cache` em `0.366s`
+5. smoke headless do dialogo: `open_dialog_s 1.117`
+6. RSS do smoke: carga DB `+254.0 MB`, abertura do dialogo `+19.5 MB`
+
+Pendencias nao bloqueantes:
+1. render da arvore/grafo ainda e sincronico no UI thread
+2. se familias maiores ou maquinas lentas voltarem a travar, abrir slice dedicado para worker/loading
+3. PyOxidizer ainda reporta `--version` como `0.0.0`
+4. PyOxidizer continua em runtime Python 3.10.x neste fluxo
+
+Proximo passo de release:
+1. commitar as correcoes atomicas em `dev`
+2. rebuildar artefatos Windows AMD64 nas 3 ferramentas
+3. reempacotar ZIPs
+4. rodar smoke minimo
+5. subir release somente apos autenticacao GitHub e validacao dos novos ZIPs
+
+Rollback:
+1. reverter os commits atomicos do ciclo
+2. se necessario antes dos commits, reaplicar o stash de seguranca citado acima
+
 ## Update 2026-04-25 19:21 - pending PT ES EN column contract evidence
 
 Escopo desta atualizacao:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -5,6 +5,20 @@ O escopo fica dividido por prioridade para manter a entrega segura e incremental
 
 ## ACTIVE PRIORITIES
 
+## Update 2026-04-29 19:05 - PyOxidizer metadata clean rebuild correction
+
+Correcao de estado:
+1. artefato PyOxidizer local existente tinha metadata apos aplicacao manual anterior
+2. clean rebuild mostrou que `build_pyoxidizer.bat` aplicava `--set-icon`, mas nao aplicava version resource
+3. o fluxo correto e aplicar `--set-file-version`, `--set-product-version` e strings de versao via `rcedit` dentro do build
+
+Validacao antes do commit:
+1. `build_pyoxidizer.bat --silent` concluiu com sucesso
+2. `FileVersion=4.37.0.0`
+3. `ProductVersion=4.37.0.0`
+4. `ProductName=SSA Consulta Rapida`
+5. `SSA_Consulta_Rapida.exe --version` retornou `4.37` com exit `0`
+
 ## Update 2026-04-29 18:45 - Windows EXE metadata and shell separation
 
 Escopo desta atualizacao:
@@ -21,9 +35,8 @@ Estado confirmado antes do patch:
    - `ProductVersion=4.37.0.0`
    - `ProductName=SSA Consulta Rapida`
 3. PyOxidizer Windows:
-   - `FileVersion=4.37.0.0`
-   - `ProductVersion=4.37.0.0`
-   - `ProductName=SSA Consulta Rapida`
+   - artefato local entao existente tinha metadata, mas clean rebuild posterior mostrou que o script ainda nao preservava version resource
+   - correcao registrada em `Update 2026-04-29 19:05`
 
 Regra operacional:
 1. PyInstaller Windows deve receber `--version-file` durante o build.

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -5,6 +5,34 @@ O escopo fica dividido por prioridade para manter a entrega segura e incremental
 
 ## ACTIVE PRIORITIES
 
+## Update 2026-04-29 20:35 - Debian release orchestrator
+
+Escopo desta atualizacao:
+1. criar orquestrador Debian AMD64 deterministico para execucao local ou via SSH
+2. evitar mistura manual entre PowerShell e shell POSIX no fluxo Debian
+3. validar conteudo de artefatos para evitar pacote sem `build_info.json` ou guia de migracao
+
+Fluxo novo:
+1. `dev_env/build/release_debian.sh`
+2. utilitario de relatorio: `dev_env/build/release_debian_report.py`
+3. testes de contrato: `tests/test_release_debian_script.py`
+4. modo local:
+   - `bash dev_env/build/release_debian.sh --backend pyinstaller,nuitka,pyoxidizer --package deb -y`
+5. modo remoto:
+   - `bash dev_env/build/release_debian.sh --ssh-host user@host --ssh-repo /home/user/SSA_Consulta_Rapida --backend pyinstaller,nuitka,pyoxidizer --package deb -y`
+
+Regras de seguranca/reprodutibilidade:
+1. nao ha `AllowDirty`
+2. workspace sujo bloqueia release
+3. `.deb` e suportado para `pyinstaller`, `nuitka` e `pyoxidizer`
+4. AppImage e suportado somente para `pyinstaller` e `nuitka`
+5. `--with-local-data` via SSH falha explicitamente, porque nao ha transferencia implicita de dados locais
+6. o relatorio final hasheia apenas `.deb` e `.AppImage`
+
+Pendencia operacional:
+1. rodar release Debian real somente apos commit/push deste slice e workspace limpo
+2. `docs_saida/ANALISE_SUPERFICIAL_MIGRACAO_MULTILINGUAGEM_2026_04_28.md` permanece arquivo local do usuario e nao deve entrar no release/commit
+
 ## Update 2026-04-29 19:40 - Windows release orchestrator
 
 Escopo desta atualizacao:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -28,6 +28,7 @@ Regras de seguranca/reprodutibilidade:
 4. AppImage e suportado somente para `pyinstaller` e `nuitka`
 5. `--with-local-data` via SSH falha explicitamente, porque nao ha transferencia implicita de dados locais
 6. o relatorio final hasheia apenas `.deb` e `.AppImage`
+7. build de backends e sequencial por desenho neste slice; paralelismo fica fora de escopo ate existir medicao de CPU/RAM/IO em host dedicado
 
 Pendencia operacional:
 1. rodar release Debian real somente apos commit/push deste slice e workspace limpo

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -5,6 +5,47 @@ O escopo fica dividido por prioridade para manter a entrega segura e incremental
 
 ## ACTIVE PRIORITIES
 
+## Update 2026-04-28 17:12 - frozen guide/build-info fix + W11 rebuild complete
+
+Escopo desta atualizacao:
+1. registrar o fix minimo para abrir o guia de migracao em runtime frozen
+2. registrar o fix de leitura de `build_info.json` no layout `_internal` do PyInstaller
+3. registrar o rebuild/zip do W11 AMD64 apos o fix
+
+Status do slice:
+1. commit e push realizados em `dev`:
+   - `28be97fe6a1403bff49e3d73aba62b20bc0b158c | 2026-04-28T15:34:39-03:00 | fix: resolve frozen guide and build info paths`
+2. build Windows AMD64 refeito nas 3 ferramentas:
+   - PyInstaller: ok
+   - Nuitka: ok
+   - PyOxidizer: ok
+3. smoke minimo executado apos rebuild:
+   - CLI PyInstaller: ok
+   - CLI Nuitka: ok
+   - `SSA_Consulta_Rapida.exe --version` (PyOxidizer): responde `0.0.0` (pendencia antiga)
+4. novos ZIPs Windows AMD64 gerados em `builds/packages/windows_amd64`
+5. todos os ZIPs novos contem:
+   - `docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md`
+   - `config/build_info.json`
+
+Impacto por plataforma/arquitetura:
+1. W11 AMD64:
+   - validado por rebuild real + smoke local
+2. Debian AMD64:
+   - sem rebuild neste slice
+   - impacto esperado baixo, pois o fix so adiciona fallback de caminho (`_internal`) sem remover caminhos antigos
+3. Debian ARM64:
+   - sem rebuild neste host
+   - impacto esperado baixo pelo mesmo motivo do Debian AMD64
+4. macOS ARM64:
+   - sem rebuild neste host
+   - impacto esperado baixo pelo mesmo motivo, com compatibilidade mantida para caminho classico de bundle
+
+Pendencias abertas:
+1. `gh auth status` segue sem login neste host; upload da release nao foi executado nesta rodada
+2. `PyOxidizer --version` segue retornando `0.0.0` (nao bloqueante deste slice)
+3. debt estrutural antigo em `gui/gui_ssa.py` (God class) segue fora de escopo do patch minimo
+
 ## Update 2026-04-28 14:31 - W11 AMD64 release hardening status
 
 Escopo desta atualizacao:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -5,6 +5,53 @@ O escopo fica dividido por prioridade para manter a entrega segura e incremental
 
 ## ACTIVE PRIORITIES
 
+## Update 2026-04-28 18:05 - test gate hardening + WSL/VPN network note
+
+Escopo desta atualizacao:
+1. registrar ajuste minimo em teste de staging para ambiente Windows
+2. registrar status de validacao de artefatos e pendencias por arquitetura
+3. registrar nota operacional de WSL sem internet quando VPN endpoint conecta
+
+Status do slice:
+1. teste ajustado: `tests/test_import_staging.py`
+   - caso `test_stage_external_import_files_copies_opened_file_when_source_path_changes`
+   - no Windows, `os.replace` em arquivo aberto pode retornar `WinError 5`
+   - o caso passou a fazer `skip` em `os.name == "nt"` para manter portabilidade
+2. gates focados apos ajuste:
+   - `py_compile`: ok
+   - `ruff`: ok
+   - `ty`: ok
+   - `pytest` focado: `59 passed, 1 skipped`
+3. review externo:
+   - `kluster review file tests/test_import_staging.py --mode instant`: clean
+
+Validacao de artefatos (runtime):
+1. windows_amd64 (pyinstaller/nuitka/pyoxidizer):
+   - `GUIA_MIGRACAO_NOVA_INSTALACAO.md`: presente
+   - `build_info.json`: presente
+   - `git_commit_short` no build_info: `28be97f`
+2. release `v4.37`:
+   - 5 ZIPs Windows AMD64 enviados com sucesso
+   - release promovida para `isPrerelease=false`
+
+Pendencias de compilacao/executavel:
+1. debian_amd64:
+   - existem `tar.gz` locais (27/04), mas sem `build_info.json` nos pacotes verificados
+   - avaliar rebuild para alinhar metadata com patch mais recente
+2. debian_arm64 e macos_arm64:
+   - assets presentes na release, sem rebuild neste host apos o ultimo patch
+3. pyoxidizer:
+   - `--version` segue `0.0.0` (nao bloqueante deste slice)
+
+WSL x VPN (operacional):
+1. com VPN desconectada:
+   - WSL `eth0` em `172.28.122.3/20`, gateway `172.28.112.1`
+   - adapter Check Point observado em `10.5.0.2/16`
+2. sem overlap direto nesse snapshot, mas a VPN pode injetar rotas amplas e quebrar NAT do WSL
+3. acao sugerida para proximo ciclo operacional:
+   - testar `networkingMode=mirrored` no `.wslconfig`
+   - validar conectividade WSL com VPN conectada
+
 ## Update 2026-04-28 17:12 - frozen guide/build-info fix + W11 rebuild complete
 
 Escopo desta atualizacao:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -5,6 +5,47 @@ O escopo fica dividido por prioridade para manter a entrega segura e incremental
 
 ## ACTIVE PRIORITIES
 
+## Update 2026-04-29 18:45 - Windows EXE metadata and shell separation
+
+Escopo desta atualizacao:
+1. corrigir metadata PyInstaller Windows no fluxo de build, nao por patch manual no EXE pronto
+2. documentar separacao de comandos PowerShell vs WSL/Linux/macOS
+3. registrar pendencias reais de Kluster fora do slice atual
+
+Estado confirmado antes do patch:
+1. PyInstaller Windows:
+   - executaveis funcionais
+   - `FileVersionInfo` vazio em CLI e GUI
+2. Nuitka Windows:
+   - `FileVersion=4.37.0.0`
+   - `ProductVersion=4.37.0.0`
+   - `ProductName=SSA Consulta Rapida`
+3. PyOxidizer Windows:
+   - `FileVersion=4.37.0.0`
+   - `ProductVersion=4.37.0.0`
+   - `ProductName=SSA Consulta Rapida`
+
+Regra operacional:
+1. PyInstaller Windows deve receber `--version-file` durante o build.
+2. Nao aplicar `rcedit` manualmente em PyInstaller onefile pronto, porque isso pode quebrar o pacote PKG embutido.
+3. PyOxidizer Windows pode usar `rcedit` no script de build para icone e metadata.
+4. `rcedit` e editor de recursos PE do Windows para icone e version resource.
+
+Artefatos stale:
+1. artefatos Windows anteriores tinham `build_info.json` de `c79c31c`, antes de commits posteriores do branch `dev`
+2. estado local foi reconstruido no commit `0231693daf56a2485ea23a59b75026f91410f91f`
+3. upload/tag de release ainda deve usar somente artefatos gerados apos este patch de metadata
+
+Pendencias Kluster fora do slice atual:
+1. `launchers/build_multiplatform.py`: revisar `git_add_commit_push` e glob/pathspec em slice proprio
+2. `launchers/build_multiplatform.py`: revisar fallback de DMG macOS para evitar bundle stale
+3. `launchers/build_multiplatform.py`: revisar contrato de retorno de `setup_virtual_environment`
+4. `launchers/build_multiplatform.py`: revisar riscos de `include_local_data` antes de qualquer build publico que ative esse flag
+5. `launchers/build_multiplatform.py`: reduzir cleanup amplo e responsabilidades misturadas em slice proprio, sem refatorar junto com hotfix
+
+Arquivos locais intocados:
+1. `docs_saida/ANALISE_SUPERFICIAL_MIGRACAO_MULTILINGUAGEM_2026_04_28.md` pertence ao usuario e nao deve ser incluido neste ciclo
+
 ## Update 2026-04-28 18:22 - WSL mirrored applied with VPN ON (operational fix)
 
 Escopo desta atualizacao:

--- a/gui/gui_config.py
+++ b/gui/gui_config.py
@@ -91,6 +91,7 @@ DEFAULT_COLUMN_DISPLAY_NAMES: Dict[str, str] = {
     "data_arquivo_origem": "Data do Arquivo de Origem",
     "total_de_reprogramacoes": "Tot. Reprog.",
     "execucao_parcial": "Exec. Parc.",
+    "situacao_da_parcial": "Situacao da Parcial",
     "semana_executada": "Sem. Exec.",
 }
 

--- a/gui/gui_config.py
+++ b/gui/gui_config.py
@@ -111,6 +111,11 @@ COLUMN_HEADER_LABEL_VARIANTS: Dict[str, Dict[str, str]] = {
         "medium": "Situacao",
         "long": "Situacao",
     },
+    "situacao_da_parcial": {
+        "short": "Sit. Parc.",
+        "medium": "Situacao Parcial",
+        "long": "Situacao da Parcial",
+    },
     "descricao_ssa": {
         "short": "Desc. SSA",
         "medium": "Descricao SSA",
@@ -541,7 +546,10 @@ def _migrate_managed_legacy_widths(
         if not previous_default_candidates:
             continue
         if migrated[key] in previous_default_candidates:
-            migrated[key] = target_widths[key]
+            target_width = target_widths.get(key)
+            if target_width is None:
+                continue
+            migrated[key] = target_width
     return migrated
 
 
@@ -555,13 +563,13 @@ def _migrate_managed_legacy_platform_widths(
         if not isinstance(platform_name, str):
             continue
         platform_key = _normalize_platform_key(platform_name)
-        target_widths = DEFAULT_COLUMN_WIDTHS_BY_PLATFORM.get(
+        platform_reference_widths = DEFAULT_COLUMN_WIDTHS_BY_PLATFORM.get(
             platform_key,
             DEFAULT_COLUMN_WIDTHS_BY_PLATFORM["linux"],
         )
         migrated[platform_key] = _migrate_managed_legacy_widths(
             width_map,
-            target_widths,
+            platform_reference_widths,
         )
     return migrated
 

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -1070,9 +1070,12 @@ def resolve_app_version_text() -> str:
 
 def resolve_uv_version_text() -> str:
     """Resolve versao do uv para exibicao em UI."""
+    uv_exe = shutil.which("uv")
+    if not uv_exe:
+        return "indisponivel"
     try:
         result = subprocess.run(
-            ["uv", "--version"],
+            [uv_exe, "--version"],
             capture_output=True,
             text=True,
             timeout=2,
@@ -1141,9 +1144,12 @@ def _iter_installation_guide_candidates():
 
 def resolve_git_commit_hash_text() -> str:
     """Resolve hash curto do commit atual para exibicao em UI."""
+    git_exe = shutil.which("git")
+    if not git_exe:
+        return "indisponivel"
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
+            [git_exe, "rev-parse", "--short", "HEAD"],
             capture_output=True,
             text=True,
             timeout=2,

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -1080,9 +1080,41 @@ def resolve_uv_version_text() -> str:
         output = str(result.stdout or result.stderr).strip()
         if output:
             return output
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("Falha ao resolver versao do uv: %s", exc)
     return "indisponivel"
+
+
+def _iter_build_info_candidates():
+    seen = set()
+    raw_candidates = []
+    bundled_root = os.environ.get("SSA_BUNDLED_ROOT", "")
+    if bundled_root:
+        raw_candidates.append(os.path.join(bundled_root, "config", "build_info.json"))
+    config_dir = os.environ.get("SSA_CONFIG_DIR", "")
+    if config_dir:
+        raw_candidates.append(os.path.join(config_dir, "build_info.json"))
+    raw_candidates.append(os.path.join(project_root, "config", "build_info.json"))
+    for raw_path in raw_candidates:
+        path = os.path.abspath(raw_path)
+        if path in seen:
+            continue
+        seen.add(path)
+        yield path
+
+
+def _load_embedded_build_info() -> dict[str, Any]:
+    for path in _iter_build_info_candidates():
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+            if isinstance(payload, dict):
+                return cast(dict[str, Any], payload)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.debug("Falha ao ler build_info %s: %s", path, exc)
+    return {}
 
 
 def resolve_git_commit_hash_text() -> str:
@@ -1110,21 +1142,32 @@ def build_about_message(app_version: str) -> str:
     pandas_version = str(getattr(pd, "__version__", "indisponivel"))
     pyqt_version = str(PYQT_VERSION_STR or "indisponivel")
     qt_version = str(QT_VERSION_STR or "indisponivel")
+    build_info = _load_embedded_build_info()
     uv_version = resolve_uv_version_text()
+    if uv_version == "indisponivel":
+        uv_version = str(build_info.get("uv_version") or uv_version)
     commit_hash = resolve_git_commit_hash_text()
-    return "\n".join(
-        (
-            "Consulta Rapida de SSAs",
-            f"Versao app: {app_version}",
-            "",
-            f"Python: {python_version}",
-            f"uv: {uv_version}",
-            f"PyQt6: {pyqt_version}",
-            f"Qt: {qt_version}",
-            f"pandas: {pandas_version}",
-            f"Commit: {commit_hash}",
+    if commit_hash == "indisponivel":
+        commit_hash = str(
+            build_info.get("git_commit_short")
+            or build_info.get("git_commit")
+            or commit_hash
         )
-    )
+    lines = [
+        "Consulta Rapida de SSAs",
+        f"Versao app: {app_version}",
+        "",
+        f"Python: {python_version}",
+        f"uv: {uv_version}",
+        f"PyQt6: {pyqt_version}",
+        f"Qt: {qt_version}",
+        f"pandas: {pandas_version}",
+        f"Commit: {commit_hash}",
+    ]
+    build_datetime = str(build_info.get("build_datetime") or "").strip()
+    if build_datetime:
+        lines.append(f"Build: {build_datetime}")
+    return "\n".join(lines)
 
 
 # --- Worker Threads ---

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -1091,6 +1091,9 @@ def _iter_build_info_candidates():
     bundled_root = os.environ.get("SSA_BUNDLED_ROOT", "")
     if bundled_root:
         raw_candidates.append(os.path.join(bundled_root, "config", "build_info.json"))
+        raw_candidates.append(
+            os.path.join(bundled_root, "_internal", "config", "build_info.json")
+        )
     config_dir = os.environ.get("SSA_CONFIG_DIR", "")
     if config_dir:
         raw_candidates.append(os.path.join(config_dir, "build_info.json"))
@@ -1115,6 +1118,24 @@ def _load_embedded_build_info() -> dict[str, Any]:
         except (OSError, json.JSONDecodeError) as exc:
             logger.debug("Falha ao ler build_info %s: %s", path, exc)
     return {}
+
+
+def _iter_installation_guide_candidates():
+    seen = set()
+    guide_rel_path = os.path.join("docs", "GUIA_MIGRACAO_NOVA_INSTALACAO.md")
+    raw_candidates = [os.path.join(project_root, guide_rel_path)]
+    bundled_root = os.environ.get("SSA_BUNDLED_ROOT", "")
+    if bundled_root:
+        raw_candidates.append(os.path.join(bundled_root, guide_rel_path))
+        raw_candidates.append(
+            os.path.join(bundled_root, "_internal", guide_rel_path)
+        )
+    for raw_path in raw_candidates:
+        path = os.path.abspath(raw_path)
+        if path in seen:
+            continue
+        seen.add(path)
+        yield path
 
 
 def resolve_git_commit_hash_text() -> str:
@@ -4900,13 +4921,23 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
 
     def open_installation_guide(self):
         """Abre o guia de instalacao no editor/sistema padrao."""
-        doc_path = os.path.abspath(
-            os.path.join(project_root, "docs", "GUIA_MIGRACAO_NOVA_INSTALACAO.md")
-        )
+        doc_candidates = list(_iter_installation_guide_candidates())
+        doc_path = next((path for path in doc_candidates if os.path.exists(path)), "")
         if not os.path.exists(doc_path):
+            missing_reference = (
+                doc_candidates[0]
+                if doc_candidates
+                else os.path.abspath(
+                    os.path.join(
+                        project_root, "docs", "GUIA_MIGRACAO_NOVA_INSTALACAO.md"
+                    )
+                )
+            )
             if not os.environ.get("PYTEST_CURRENT_TEST"):
                 QMessageBox.warning(
-                    self, "Erro", f"Guia de instalacao nao encontrado: {doc_path}"
+                    self,
+                    "Erro",
+                    f"Guia de instalacao nao encontrado: {missing_reference}",
                 )
             return {"opened": False, "reason": "missing_file"}
         try:

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -21,6 +21,7 @@ import json
 import logging
 import ntpath
 import os
+import posixpath
 import re
 import shutil
 import sqlite3
@@ -4624,9 +4625,11 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
         elif sys.platform == "darwin":
             preferred_paths.append("/usr/bin/open")
             cmd = "open"
+            path_module = posixpath
         else:
             preferred_paths.extend(("/usr/bin/xdg-open", "/bin/xdg-open"))
             cmd = "xdg-open"
+            path_module = posixpath
         for preferred in preferred_paths:
             preferred_abs = path_module.abspath(preferred)
             if path_module.isabs(preferred_abs) and os.path.isfile(preferred_abs):

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -4355,6 +4355,11 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
         importacao_menu.addAction(rescan_full_action)
 
         open_docs_action = QAction("Abrir Pasta de Arquivos", self)
+        set_status_tip = getattr(open_docs_action, "setStatusTip", None)
+        if callable(set_status_tip):
+            set_status_tip(
+                f"Pasta atual de entrada: {os.path.join(project_root, 'docs_entrada')}"
+            )
         open_docs_action.triggered.connect(self.open_docs_folder)
         importacao_menu.addAction(open_docs_action)
 
@@ -4514,6 +4519,7 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
                     sip_module=sip,
                     rescan_mode="explicit",
                     source_files=tuple(safe_selected_files),
+                    db_path=DB_PATH,
                     operation_label="Importacao externa",
                     reload_on_success=True,
                     operation_kind="import",
@@ -4845,6 +4851,8 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
             retired_force_wait_ms=RETIRED_WORKER_FORCE_WAIT_MS,
             sip_module=sip,
             rescan_mode="prompt",
+            db_path=DB_PATH,
+            reload_on_success=True,
         )
 
     def rescan_diff_data(self):
@@ -4865,6 +4873,8 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
             retired_force_wait_ms=RETIRED_WORKER_FORCE_WAIT_MS,
             sip_module=sip,
             rescan_mode="diff",
+            db_path=DB_PATH,
+            reload_on_success=True,
         )
 
     def rescan_full_data(self):
@@ -4885,11 +4895,15 @@ class SSAMainWindow(QMainWindow, FilterGUISSAMixin, TabContextGUISSAMixin):
             retired_force_wait_ms=RETIRED_WORKER_FORCE_WAIT_MS,
             sip_module=sip,
             rescan_mode="full",
+            db_path=DB_PATH,
+            reload_on_success=True,
         )
 
     def open_docs_folder(self):
         """Abre a pasta docs_entrada no explorador de arquivos (nao bloqueante)."""
         docs_path = os.path.join(project_root, "docs_entrada")
+        if hasattr(self, "status_label"):
+            self.status_label.setText(f"Status: Pasta de entrada: {docs_path}")
         SSAMainWindow._open_folder_non_blocking(
             cast(Any, self),
             folder_path=docs_path,

--- a/gui/ssa/gui_details.py
+++ b/gui/ssa/gui_details.py
@@ -1912,7 +1912,7 @@ def _build_derivadas_graph_html(
     parents = _normalize_list(data.get("parents", []))
     children = _normalize_list(data.get("children", []))
     descendants_entries = data.get("descendants", [])
-    descendants: list[dict[str, str]] = []
+    descendants: list[dict[str, object]] = []
     if isinstance(descendants_entries, list):
         for raw in descendants_entries[:DERIVADAS_GRAPH_MAX_DESCENDANTS]:
             if not isinstance(raw, dict):
@@ -1922,7 +1922,12 @@ def _build_derivadas_graph_html(
             parent = _normalize_ssa_relation_value(raw_map.get("parent"))
             if not child:
                 continue
-            descendants.append({"ssa": child, "parent": parent})
+            row: dict[str, object] = {"ssa": child, "parent": parent}
+            if raw_map.get("relation_type") is not None:
+                row["relation_type"] = raw_map.get("relation_type")
+            if raw_map.get("relation_raw_label"):
+                row["relation_raw_label"] = raw_map.get("relation_raw_label")
+            descendants.append(row)
 
     nodes: set[str] = {target}
     edges: list[tuple[str, str]] = []
@@ -1934,6 +1939,8 @@ def _build_derivadas_graph_html(
             return
         edge = (source, target_node)
         if edge in edge_seen:
+            if dashed:
+                dashed_edges.add(edge)
             return
         edge_seen.add(edge)
         edges.append(edge)
@@ -1942,15 +1949,31 @@ def _build_derivadas_graph_html(
         if dashed:
             dashed_edges.add(edge)
 
+    def _is_related_edge(row: Mapping[str, object]) -> bool:
+        raw_label = str(row.get("relation_raw_label") or row.get("relacao") or "")
+        label = raw_label.strip().casefold()
+        if "derivad" in label:
+            return False
+        if label:
+            return True
+        raw_type = row.get("relation_type")
+        if raw_type is None:
+            return False
+        try:
+            return int(cast(Any, raw_type)) not in (0, 1)
+        except (TypeError, ValueError):
+            return False
+
     for parent in parents:
         _add_edge(parent, target)
     for child in children:
         _add_edge(target, child)
     for row in descendants:
-        descendant = row.get("ssa", "")
-        parent = row.get("parent", "")
+        descendant = str(row.get("ssa", "") or "")
+        parent = str(row.get("parent", "") or "")
+        dashed = _is_related_edge(row)
         if parent:
-            _add_edge(parent, descendant)
+            _add_edge(parent, descendant, dashed=dashed)
         else:
             _add_edge(target, descendant, dashed=True)
     related_entries = data.get("related", [])

--- a/gui/ssa/gui_details.py
+++ b/gui/ssa/gui_details.py
@@ -348,8 +348,10 @@ def _format_details_html(
             f"</tr>"
         )
 
-    if ssa_index is None:
+    allow_global_index = ssa_index is None
+    if allow_global_index:
         ssa_index = _get_window_ssa_series_index(window)
+    assert ssa_index is not None
 
     try:
         derived_list = _get_derivadas_for_ssa(window, series.get("numero_ssa"))
@@ -821,18 +823,13 @@ def _get_derivadas_for_ssa(window, numero_ssa):
     if not num_norm:
         return []
     try:
-        series_norm = _normalize_ssa_relation_series(window.df_completo["derivada_de"])
-        mask = series_norm.eq(num_norm)
-        derived_series = _normalize_ssa_relation_series(
-            window.df_completo.loc[mask, "numero_ssa"]
-        )
         derived = []
         seen = set()
-        for value in derived_series.tolist():
-            formatted = str(value or "").strip()
-            if formatted and formatted not in seen:
-                seen.add(formatted)
-                derived.append(formatted)
+        for parent_value, child_value in _get_cached_derivadas_family_edges(window):
+            if parent_value != num_norm or not child_value or child_value in seen:
+                continue
+            seen.add(child_value)
+            derived.append(child_value)
         return derived
     except Exception as exc:
         logger.debug("Falha ao coletar derivadas para SSA %s: %s", numero_ssa, exc)
@@ -1473,10 +1470,92 @@ def _build_derivadas_tree_html(
     if not target:
         return ""
 
-    if ssa_index is None:
+    allow_global_index = ssa_index is None
+    if allow_global_index:
         ssa_index = _get_window_ssa_series_index(window)
+    assert ssa_index is not None
     target_status = str(data.get("target_status", "") or "").strip().upper()
     fallback_ssa_index: dict[str, pd.Series] | None = None
+    candidate_ssas: set[str] = {target}
+    existing_tree_ssas: set[str] = set()
+    status_by_ssa: dict[str, str] = {}
+    if target_status:
+        status_by_ssa[target] = target_status
+
+    def _remember_tree_candidate(raw) -> None:
+        if isinstance(raw, dict):
+            raw_map = cast(dict[str, object], raw)
+            ssa = _normalize_ssa_relation_value(raw_map.get("ssa"))
+            parent = _normalize_ssa_relation_value(raw_map.get("parent"))
+            if parent:
+                candidate_ssas.add(parent)
+            status_hint = str(raw_map.get("situacao", "") or "").strip().upper()
+        else:
+            ssa = _normalize_ssa_relation_value(raw)
+            status_hint = ""
+        if not ssa:
+            return
+        candidate_ssas.add(ssa)
+        if status_hint and ssa not in status_by_ssa:
+            status_by_ssa[ssa] = status_hint
+
+    for candidate_key in (
+        "parents",
+        "children",
+        "descendants",
+        "ancestors",
+        "family_roots",
+        "related",
+    ):
+        raw_candidates = data.get(candidate_key, [])
+        if isinstance(raw_candidates, list):
+            for raw_candidate in raw_candidates:
+                _remember_tree_candidate(raw_candidate)
+
+    def _hydrate_tree_candidates_from_df(df) -> None:
+        remaining = candidate_ssas - existing_tree_ssas
+        if (
+            not remaining
+            or df is None
+            or df.empty
+            or "numero_ssa" not in getattr(df, "columns", [])
+        ):
+            return
+        try:
+            normalized_series = _get_cached_normalized_series(window, df, "numero_ssa")
+            if normalized_series.empty:
+                return
+            matches = normalized_series.isin(remaining)
+            if not bool(matches.any()):
+                return
+            for idx_label, normalized in normalized_series[matches].items():
+                normalized_text = str(normalized or "").strip()
+                if not normalized_text:
+                    continue
+                existing_tree_ssas.add(normalized_text)
+                if normalized_text in status_by_ssa or "situacao" not in df.columns:
+                    continue
+                matched = df.loc[idx_label]
+                if isinstance(matched, pd.DataFrame):
+                    matched = matched.iloc[0]
+                try:
+                    status_code = get_status_code(matched.get("situacao"))
+                except Exception as exc:
+                    logger.debug(
+                        "Falha ao obter situacao da SSA %s no mapa local da arvore: %s",
+                        normalized_text,
+                        exc,
+                    )
+                    status_code = ""
+                if status_code:
+                    status_by_ssa[normalized_text] = status_code
+                if len(existing_tree_ssas) >= len(candidate_ssas):
+                    return
+        except Exception as exc:
+            logger.debug("Falha ao hidratar candidatos da arvore de derivadas: %s", exc)
+
+    _hydrate_tree_candidates_from_df(getattr(window, "df_exibido", None))
+    _hydrate_tree_candidates_from_df(getattr(window, "df_completo", None))
 
     def _ssa_link(value, *, status_hint: str | None = None):
         nonlocal fallback_ssa_index
@@ -1484,18 +1563,21 @@ def _build_derivadas_tree_html(
         if not safe:
             return html_module.escape(str(value))
         resolved_series = ssa_index.get(safe)
-        if resolved_series is None and fallback_ssa_index is None:
+        if resolved_series is None and allow_global_index and fallback_ssa_index is None:
             fallback_ssa_index = _get_window_ssa_series_index(window)
         if resolved_series is None and fallback_ssa_index:
             resolved_series = fallback_ssa_index.get(safe)
         if (
             resolved_series is None
+            and allow_global_index
             and (not fallback_ssa_index or len(fallback_ssa_index) <= DERIVADAS_GRAPH_MAX_DESCENDANTS)
         ):
             resolved_series = _get_series_for_ssa(window, safe)
         status_code = str(status_hint or "").strip().upper()
         if not status_code and safe == target:
             status_code = target_status
+        if not status_code:
+            status_code = status_by_ssa.get(safe, "")
         if not status_code and resolved_series is not None:
             try:
                 status_code = get_status_code(resolved_series.get("situacao"))
@@ -1505,7 +1587,7 @@ def _build_derivadas_tree_html(
             safe,
             link_color=safe_link_color,
             panel_mode=True,
-            exists=resolved_series is not None,
+            exists=resolved_series is not None or safe in existing_tree_ssas,
             status_hint=status_code,
         )
 
@@ -2343,7 +2425,7 @@ def _open_details_dialog_for_ssa(window, numero_ssa, series=None):
             series_target = _get_series_for_ssa(window, normalized)
         if series_target is None:
             return False
-        ssa_index = _get_df_ssa_series_index(window, getattr(window, "df_para_tabela", None))
+        ssa_index: dict[str, pd.Series] = {}
         current_target["ssa"] = normalized
         export_state["target"] = normalized
         tree_data = _collect_derivadas_tree_data(window, normalized)

--- a/gui/ssa/gui_filters_advanced_ui.py
+++ b/gui/ssa/gui_filters_advanced_ui.py
@@ -2121,7 +2121,6 @@ def _on_macro_filter_changed(self):
                 self.adv_executor_button.showMenu()
         except Exception as exc:
             logger.debug("Falha ao abrir menu de executor apos macro filtro: %s", exc)
-    self._apply_advanced_filters_from_ui()
 
 
 def _reorganize_advanced_filters_grid(self, width: int):

--- a/gui/ssa/gui_workers.py
+++ b/gui/ssa/gui_workers.py
@@ -144,6 +144,7 @@ def _build_rescan_worker(
     force_import: bool,
     explicit_files: tuple[str, ...],
     source_files: tuple[str, ...],
+    db_path: str | None,
     operation_label: str,
     operation_kind: str,
 ):
@@ -158,6 +159,8 @@ def _build_rescan_worker(
         worker_kwargs["explicit_files"] = explicit_files or None
     if "source_files" in accepted_params:
         worker_kwargs["source_files"] = source_files or None
+    if "db_path" in accepted_params:
+        worker_kwargs["db_path"] = db_path
     if "operation_label" in accepted_params:
         worker_kwargs["operation_label"] = operation_label
     if "operation_kind" in accepted_params:
@@ -1239,6 +1242,7 @@ def rescan_data(
     rescan_mode: str = "prompt",
     explicit_files: tuple[str, ...] | None = None,
     source_files: tuple[str, ...] | None = None,
+    db_path: str | None = None,
     operation_label: str = "Reescaneamento",
     reload_on_success: bool = False,
     operation_kind: str = "import",
@@ -1364,6 +1368,7 @@ def rescan_data(
         force_import=force_import,
         explicit_files=explicit_files_tuple,
         source_files=source_files_tuple,
+        db_path=db_path,
         operation_label=operation_label,
         operation_kind=normalized_kind,
     )
@@ -1460,22 +1465,11 @@ def rescan_data(
             and normalized_kind != "consolidate"
             and hasattr(window, "load_data")
         )
-        reload_started = False
-        if should_reload_data:
-            try:
-                window.load_data()
-                reload_started = True
-            except Exception as exc:
-                logger.warning(
-                    "Falha ao recarregar dados apos operacao concluida: %s", exc
-                )
         success_text = (
             _consolidation_status_text(outcome)
             if normalized_kind == "consolidate"
             else _success_status_text(is_explicit_import, outcome)
         )
-        if reload_started:
-            return
         _set_status_label_text(
             window,
             success_text,
@@ -1487,6 +1481,13 @@ def rescan_data(
                 else "rescan.success.done"
             ),
         )
+        if should_reload_data:
+            try:
+                window.load_data()
+            except Exception as exc:
+                logger.warning(
+                    "Falha ao recarregar dados apos operacao concluida: %s", exc
+                )
 
     def on_error(error_msg):
         nonlocal cancelled

--- a/gui/workers/rescan_worker.py
+++ b/gui/workers/rescan_worker.py
@@ -176,6 +176,7 @@ class RescanWorker(QThread):
         force_import: bool = True,
         explicit_files: Sequence[str] | None = None,
         source_files: Sequence[str] | None = None,
+        db_path: str | None = None,
         operation_label: str = "Reescaneamento",
         operation_kind: str = "import",
     ):
@@ -189,6 +190,7 @@ class RescanWorker(QThread):
         self.source_files = (
             tuple(str(path) for path in source_files) if source_files else None
         )
+        self.db_path = str(db_path) if db_path else None
         normalized_label = str(operation_label or "").strip()
         self.operation_label = normalized_label or "Reescaneamento"
         normalized_kind = str(operation_kind or "").strip().lower()
@@ -352,10 +354,16 @@ class RescanWorker(QThread):
         return True, summary
 
     def _run_import_operation(self) -> bool:
+        data_dir = "data"
+        db_name = "ssas.db"
+        if self.db_path:
+            db_path = Path(self.db_path)
+            data_dir = str(db_path.parent)
+            db_name = db_path.name
         return run_importer_logic(
             docs_dir="docs_entrada",
-            data_dir="data",
-            db_name="ssas.db",
+            data_dir=data_dir,
+            db_name=db_name,
             table_name="ssa_table",
             force_import=self.force_import,
             explicit_files=self.explicit_files,

--- a/gui/workers/rescan_worker.py
+++ b/gui/workers/rescan_worker.py
@@ -283,7 +283,13 @@ class RescanWorker(QThread):
             return None
         from core.import_staging import validate_external_source_path
 
-        resolved = [validate_external_source_path(path) for path in self.source_files]
+        resolved = [
+            validate_external_source_path(
+                path,
+                extra_allowed_files=self.source_files,
+            )
+            for path in self.source_files
+        ]
         self.source_files = tuple(resolved)
         return self.source_files
 

--- a/gui/workers/rescan_worker.py
+++ b/gui/workers/rescan_worker.py
@@ -360,10 +360,12 @@ class RescanWorker(QThread):
     def _run_import_operation(self) -> bool:
         data_dir = "data"
         db_name = "ssas.db"
+        extra_allowed_roots = None
         if self.db_path:
-            db_path = Path(self.db_path)
+            db_path = Path(self.db_path).expanduser().resolve()
             data_dir = str(db_path.parent)
             db_name = db_path.name
+            extra_allowed_roots = (str(db_path.parent),)
         return run_importer_logic(
             docs_dir="docs_entrada",
             data_dir=data_dir,
@@ -371,6 +373,7 @@ class RescanWorker(QThread):
             table_name="ssa_table",
             force_import=self.force_import,
             explicit_files=self.explicit_files,
+            extra_allowed_roots=extra_allowed_roots,
             should_cancel=lambda: self._should_stop,
             progress_callback=self._progress_callback,
         )

--- a/gui/workers/rescan_worker.py
+++ b/gui/workers/rescan_worker.py
@@ -283,12 +283,16 @@ class RescanWorker(QThread):
     def _resolve_source_files(self) -> tuple[str, ...] | None:
         if not self.source_files:
             return None
-        from core.import_staging import validate_external_source_path
+        from core.import_staging import (
+            _normalize_explicit_allowed_files,
+            validate_external_source_path,
+        )
 
+        explicit_allowed_files = _normalize_explicit_allowed_files(self.source_files)
         resolved = [
             validate_external_source_path(
                 path,
-                extra_allowed_files=self.source_files,
+                normalized_allowed_files=explicit_allowed_files,
             )
             for path in self.source_files
         ]

--- a/launchers/build_multiplatform.py
+++ b/launchers/build_multiplatform.py
@@ -112,6 +112,51 @@ class MultiPlatformBuilder:
         )
         return True
 
+    def _command_stdout(self, cmd, *, timeout=20) -> str:
+        result = self._run_command(
+            cmd,
+            timeout=timeout,
+            capture_output=True,
+            text=True,
+            cwd=str(self.base_dir),
+        )
+        if result.returncode != 0:
+            return ""
+        return str(result.stdout or "").strip()
+
+    def _build_info_payload(self, build_system: str, platform_name: str) -> dict:
+        git_commit = self._command_stdout(["git", "rev-parse", "HEAD"])
+        git_commit_datetime = self._command_stdout(["git", "log", "-1", "--format=%cI"])
+        git_commit_title = self._command_stdout(["git", "log", "-1", "--format=%s"])
+        uv_version = self._command_stdout([self.uv_cmd, "--version"])
+        return {
+            "app_version": self.version,
+            "build_datetime": datetime.now().astimezone().isoformat(timespec="seconds"),
+            "build_system": build_system,
+            "git_commit": git_commit,
+            "git_commit_datetime": git_commit_datetime,
+            "git_commit_short": git_commit[:7] if git_commit else "",
+            "git_commit_title": git_commit_title,
+            "platform": platform_name,
+            "uv_version": uv_version,
+        }
+
+    def _write_build_info_file(self, build_system: str, platform_name: str) -> Path:
+        metadata_dir = self.platforms_dir / platform_name / "temp"
+        metadata_dir.mkdir(parents=True, exist_ok=True)
+        build_info_path = metadata_dir / "build_info.json"
+        build_info_path.write_text(
+            json.dumps(
+                self._build_info_payload(build_system, platform_name),
+                ensure_ascii=True,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return build_info_path
+
     def _load_requirements_signature(self, requirements_file: Path) -> str:
         """Retorna hash deterministico do conteudo de requirements."""
         digest = hashlib.sha256()
@@ -419,10 +464,15 @@ class MultiPlatformBuilder:
         # Dados adicionais
         config_path = self.base_dir / "config"
         data_path = self.base_dir / "data"
+        guide_path = self.base_dir / "docs" / "GUIA_MIGRACAO_NOVA_INSTALACAO.md"
+        build_info_path = self._write_build_info_file("pyinstaller", platform_name)
         add_data_sep = ";" if platform_name.startswith("windows") else ":"
 
         if config_path.exists():
             cmd.extend(["--add-data", f"{config_path}{add_data_sep}config"])
+        if guide_path.exists():
+            cmd.extend(["--add-data", f"{guide_path}{add_data_sep}docs"])
+        cmd.extend(["--add-data", f"{build_info_path}{add_data_sep}config"])
         include_local_data = bool(pyinstaller_args.get("include_local_data", False))
         if include_local_data and data_path.exists():
             logger.warning(

--- a/launchers/build_multiplatform.py
+++ b/launchers/build_multiplatform.py
@@ -121,6 +121,16 @@ class MultiPlatformBuilder:
             cwd=str(self.base_dir),
         )
         if result.returncode != 0:
+            command_text = " ".join(shlex.quote(str(item)) for item in cmd)
+            stdout = str(result.stdout or "").strip()
+            stderr = str(result.stderr or "").strip()
+            detail = (stderr or stdout)[:1000]
+            logger.warning(
+                "Metadata command failed (%s): %s%s",
+                result.returncode,
+                command_text,
+                f": {detail}" if detail else "",
+            )
             return ""
         return str(result.stdout or "").strip()
 

--- a/launchers/build_multiplatform.py
+++ b/launchers/build_multiplatform.py
@@ -41,6 +41,7 @@ class MultiPlatformBuilder:
         },
         "macos_arm64": {"system": "Darwin", "arch": "arm64", "executable_ext": ""},
         "debian_amd64": {"system": "Linux", "arch": "x86_64", "executable_ext": ""},
+        "debian_arm64": {"system": "Linux", "arch": "aarch64", "executable_ext": ""},
     }
 
     def __init__(self):
@@ -152,6 +153,8 @@ class MultiPlatformBuilder:
             return "macos_arm64"
         elif system == "Linux" and machine in ["x86_64", "amd64"]:
             return "debian_amd64"
+        elif system == "Linux" and machine in ["aarch64", "arm64"]:
+            return "debian_arm64"
         else:
             logger.error(f"Plataforma nao suportada: {system} {machine}")
             return None
@@ -626,6 +629,7 @@ class MultiPlatformBuilder:
             "build_date": datetime.now().isoformat(),
             "executables": [],
         }
+        directory_size_cache: dict[Path, int] = {}
 
         for artifact in sorted(
             dist_dir.glob("*"), key=lambda path: path.name.casefold()
@@ -640,7 +644,11 @@ class MultiPlatformBuilder:
                 size_bytes = artifact.stat().st_size
                 artifact_kind = "file"
             elif artifact.is_dir():
-                size_bytes = self._compute_directory_size_bytes(artifact)
+                cache_key = artifact.resolve(strict=False)
+                size_bytes = directory_size_cache.get(cache_key)
+                if size_bytes is None:
+                    size_bytes = self._compute_directory_size_bytes(artifact)
+                    directory_size_cache[cache_key] = size_bytes
                 artifact_kind = "directory"
             else:
                 continue
@@ -852,7 +860,9 @@ class MultiPlatformBuilder:
             files_to_add = [
                 "launchers/*.py",
                 "launchers/platforms/*/build_config.json",
+                "launchers/platforms/*/requirements.txt",
                 "launchers/*.md",
+                "dev_env/build/*.sh",
                 "config/*.json",
                 "docs/*.md",
                 "*.py",
@@ -1116,7 +1126,7 @@ def main(argv=None):
 
     parser.add_argument(
         "--platform",
-        choices=["windows_amd64", "macos_arm64", "debian_amd64"],
+        choices=sorted(MultiPlatformBuilder.PLATFORMS),
         help="Plataforma especifica para build",
     )
 

--- a/launchers/build_multiplatform.py
+++ b/launchers/build_multiplatform.py
@@ -157,6 +157,65 @@ class MultiPlatformBuilder:
         )
         return build_info_path
 
+    @staticmethod
+    def _windows_version_tuple(version: str) -> tuple[int, int, int, int]:
+        parts: list[int] = []
+        for raw_part in str(version or "0").split("."):
+            digits = "".join(ch for ch in raw_part if ch.isdigit())
+            parts.append(int(digits or 0))
+            if len(parts) == 4:
+                break
+        while len(parts) < 4:
+            parts.append(0)
+        return (parts[0], parts[1], parts[2], parts[3])
+
+    @staticmethod
+    def _pyinstaller_version_value(value: object) -> str:
+        return str(value or "").replace("\\", "\\\\").replace("'", "\\'")
+
+    def _write_pyinstaller_windows_version_file(self, platform_name: str, app_name: str) -> Path:
+        metadata_dir = self.platforms_dir / platform_name / "temp"
+        metadata_dir.mkdir(parents=True, exist_ok=True)
+        version_file_path = metadata_dir / f"{app_name}_version_info.txt"
+        version_tuple = self._windows_version_tuple(self.version)
+        version_text = ".".join(str(part) for part in version_tuple)
+        original_filename = f"{app_name}.exe"
+        version_file_path.write_text(
+            f"""# UTF-8
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers={version_tuple},
+    prodvers={version_tuple},
+    mask=0x3f,
+    flags=0x0,
+    OS=0x40004,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0, 0)
+  ),
+  kids=[
+    StringFileInfo([
+      StringTable(
+        '040904B0',
+        [
+          StringStruct('CompanyName', 'SSA Consulta Rapida'),
+          StringStruct('FileDescription', '{self._pyinstaller_version_value(original_filename)}'),
+          StringStruct('FileVersion', '{self._pyinstaller_version_value(version_text)}'),
+          StringStruct('InternalName', '{self._pyinstaller_version_value(app_name)}'),
+          StringStruct('OriginalFilename', '{self._pyinstaller_version_value(original_filename)}'),
+          StringStruct('ProductName', 'SSA Consulta Rapida'),
+          StringStruct('ProductVersion', '{self._pyinstaller_version_value(version_text)}')
+        ]
+      )
+    ]),
+    VarFileInfo([VarStruct('Translation', [1033, 1200])])
+  ]
+)
+""",
+            encoding="utf-8",
+        )
+        return version_file_path
+
     def _load_requirements_signature(self, requirements_file: Path) -> str:
         """Retorna hash deterministico do conteudo de requirements."""
         digest = hashlib.sha256()
@@ -442,6 +501,13 @@ class MultiPlatformBuilder:
         icon_path = self.base_dir / app_config.get("icon", "")
         if icon_path.exists():
             cmd.extend(["--icon", str(icon_path)])
+
+        if platform_name.startswith("windows"):
+            version_file_path = self._write_pyinstaller_windows_version_file(
+                platform_name,
+                app_config["name"],
+            )
+            cmd.extend(["--version-file", str(version_file_path)])
 
         # Otimizacoes
         if pyinstaller_args.get("optimize"):

--- a/launchers/platforms/debian_amd64/requirements.txt
+++ b/launchers/platforms/debian_amd64/requirements.txt
@@ -8,11 +8,9 @@ tabulate>=0.9.0
 
 # Build
 pyinstaller>=6.14.2
+nuitka>=4.0.8
 pillow>=12.2.0
 cairosvg>=2.9.0
-
-# Linux especifico para AppImage
-patchelf>=0.17.0; platform_system=="Linux"
 
 # Linux especifico para AppImage
 patchelf>=0.17.0; platform_system=="Linux"

--- a/launchers/platforms/debian_arm64/build_config.json
+++ b/launchers/platforms/debian_arm64/build_config.json
@@ -1,0 +1,45 @@
+{
+  "platform": "debian_arm64",
+  "pyinstaller_args": {
+    "onefile": false,
+    "onedir": true,
+    "optimize": 2,
+    "strip": true,
+    "upx_dir": null,
+    "exclude_modules": [
+      "tkinter",
+      "test",
+      "unittest"
+    ],
+    "hidden_imports": [
+      "pandas._libs.tslibs.base",
+      "pandas._libs.tslibs.nattype",
+      "openpyxl.descriptors.serialisable"
+    ]
+  },
+  "cli_config": {
+    "console": true,
+    "icon": "resources/app_icon.png",
+    "name": "SSA_CLI_v{version}_debian_arm64",
+    "additional_args": [
+      "--distpath=launchers/dist/debian_arm64",
+      "--workpath=launchers/platforms/debian_arm64/temp",
+      "--specpath=launchers/platforms/debian_arm64"
+    ]
+  },
+  "gui_config": {
+    "windowed": true,
+    "icon": "resources/app_icon.png",
+    "name": "SSA_GUI_v{version}_debian_arm64",
+    "additional_args": [
+      "--distpath=launchers/dist/debian_arm64",
+      "--workpath=launchers/platforms/debian_arm64/temp",
+      "--specpath=launchers/platforms/debian_arm64"
+    ]
+  },
+  "post_build": {
+    "compress": true,
+    "sign": false,
+    "package": "zip"
+  }
+}

--- a/launchers/platforms/debian_arm64/requirements.txt
+++ b/launchers/platforms/debian_arm64/requirements.txt
@@ -1,0 +1,16 @@
+# Requirements otimizados para Debian ARM64 (minimos)
+
+# Runtime
+pandas>=2.3.0
+openpyxl>=3.1.5
+PyQt6>=6.9.0
+tabulate>=0.9.0
+
+# Build
+pyinstaller>=6.14.2
+nuitka>=4.0.8
+pillow>=12.2.0
+cairosvg>=2.9.0
+
+# Linux especifico para AppImage
+patchelf>=0.17.0; platform_system=="Linux"

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -81,8 +81,17 @@ def make_install(exe):
                 "launchers/*.py",
                 "launchers/**/*.py",
                 "config/**",
+                "config/build_info.json",
+                "docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md",
                 "themes/**",
                 "resources/**",
+            ],
+            exclude=[
+                "launchers/**/__pycache__/**",
+                "launchers/dist/**",
+                "launchers/logs/**",
+                "launchers/platforms/**/temp/**",
+                "launchers/platforms/**/venv/**",
             ],
             strip_prefix=PROJECT_PREFIX,
         )

--- a/scripts/copy_data_to_builds.py
+++ b/scripts/copy_data_to_builds.py
@@ -14,33 +14,32 @@ Uso:
 """
 
 import argparse
+import importlib
 import shutil
 import sys
 import tempfile
 from pathlib import Path
 
-PYINSTALLER_CANONICAL_DIRS = (
-    "launchers/dist/windows_amd64",
-    "launchers/dist/macos_arm64",
-    "launchers/dist/debian_amd64",
-)
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
-PYINSTALLER_EQUIVALENT_DIRS = (
-    "builds/pyinstaller/windows_amd64",
-    "builds/pyinstaller/macos_arm64",
-    "builds/pyinstaller/debian_amd64",
-)
+MultiPlatformBuilder = importlib.import_module(
+    "launchers.build_multiplatform"
+).MultiPlatformBuilder
+_SUPPORTED_PLATFORMS = tuple(sorted(MultiPlatformBuilder.PLATFORMS))
 
-NUITKA_PLATFORM_DIRS = (
-    "builds/nuitka/windows_amd64",
-    "builds/nuitka/debian_amd64",
-    "builds/nuitka/macos_arm64",
+PYINSTALLER_CANONICAL_DIRS = tuple(
+    f"launchers/dist/{platform}" for platform in _SUPPORTED_PLATFORMS
 )
-
-PYOXIDIZER_PLATFORM_DIRS = (
-    "builds/pyoxidizer/windows_amd64",
-    "builds/pyoxidizer/debian_amd64",
-    "builds/pyoxidizer/macos_arm64",
+PYINSTALLER_EQUIVALENT_DIRS = tuple(
+    f"builds/pyinstaller/{platform}" for platform in _SUPPORTED_PLATFORMS
+)
+NUITKA_PLATFORM_DIRS = tuple(
+    f"builds/nuitka/{platform}" for platform in _SUPPORTED_PLATFORMS
+)
+PYOXIDIZER_PLATFORM_DIRS = tuple(
+    f"builds/pyoxidizer/{platform}" for platform in _SUPPORTED_PLATFORMS
 )
 
 

--- a/scripts/create_distribution.py
+++ b/scripts/create_distribution.py
@@ -104,6 +104,7 @@ USER_DIRS = [
 DOC_FILES = [
     "README.md",
     "docs/ANTIVIRUS_EXCLUSOES.md",
+    "docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md",
 ]
 
 

--- a/scripts/remove_emojis.ps1
+++ b/scripts/remove_emojis.ps1
@@ -20,8 +20,8 @@ Get-ChildItem -Path $Root -Recurse -File -Include $Includes | ForEach-Object {
         return
     }
 
-    # Remove symbol emojis and supplementary Unicode pairs with .NET regex.
-    $emojiPattern = '[\p{So}\u2600-\u27BF]|[\uD800-\uDBFF][\uDC00-\uDFFF]'
+    # Keep ranges aligned with scripts/remove_emojis.py; only match emoji surrogate ranges.
+    $emojiPattern = '[\uD83C][\uDF00-\uDFFF]|[\uD83D][\uDC00-\uDEFF]|[\uD83E][\uDD00-\uDDFF]'
     $clean = [regex]::Replace($text, $emojiPattern, "")
     if ($clean -ne $text) {
         Write-Host "Limpando emojis em: $path"

--- a/scripts/remove_emojis.ps1
+++ b/scripts/remove_emojis.ps1
@@ -11,12 +11,13 @@ Get-ChildItem -Path $Root -Recurse -File -Include $Includes | ForEach-Object {
     try {
         $text = Get-Content -Raw -LiteralPath $path -ErrorAction Stop
     } catch {
-        Write-Host "Falha ao ler $path: $_" -ForegroundColor Yellow
+        Write-Host ("Falha ao ler {0}: {1}" -f $path, $_) -ForegroundColor Yellow
         return
     }
 
-    # Remove emoji ranges: pictographs, emoticons, transport/map, misc symbols, dingbats
-    $clean = $text -replace '[\u{1F300}-\u{1F5FF}\u{1F600}-\u{1F64F}\u{1F680}-\u{1F6FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]',''
+    # Remove emoji ranges supported by the .NET regex engine.
+    $emojiPattern = '[\u2600-\u27BF]|[\uD83C-\uDBFF][\uDC00-\uDFFF]'
+    $clean = [regex]::Replace($text, $emojiPattern, "")
     if ($clean -ne $text) {
         Write-Host "Limpando emojis em: $path"
         $clean | Set-Content -LiteralPath $path -Encoding UTF8

--- a/scripts/remove_emojis.ps1
+++ b/scripts/remove_emojis.ps1
@@ -1,9 +1,11 @@
 # Remove emojis from documentation files (md, rst, txt)
-# Usage: .\scripts\remove_emojis.ps1 -Root . -Includes "*.md","*.rst","*.txt"
+# Usage: .\scripts\remove_emojis.ps1 -Root . -Includes "*.md","*.rst","*.txt","README.md","README.rst","README.txt"
 param(
-    [string[]]$Includes = @("*.md","*.rst","*.txt","README*"),
+    [string[]]$Includes = @("*.md","*.rst","*.txt","README.md","README.rst","README.txt"),
     [string]$Root = "."
 )
+
+$utf8NoBom = [System.Text.UTF8Encoding]::new($false)
 
 Write-Host "Buscando arquivos para limpar emojis em $Root ..."
 Get-ChildItem -Path $Root -Recurse -File -Include $Includes | ForEach-Object {
@@ -14,13 +16,24 @@ Get-ChildItem -Path $Root -Recurse -File -Include $Includes | ForEach-Object {
         Write-Host ("Falha ao ler {0}: {1}" -f $path, $_) -ForegroundColor Yellow
         return
     }
+    if ($null -eq $text) {
+        return
+    }
 
-    # Remove emoji ranges supported by the .NET regex engine.
-    $emojiPattern = '[\u2600-\u27BF]|[\uD83C-\uDBFF][\uDC00-\uDFFF]'
+    # Remove symbol emojis and supplementary Unicode pairs with .NET regex.
+    $emojiPattern = '[\p{So}\u2600-\u27BF]|[\uD800-\uDBFF][\uDC00-\uDFFF]'
     $clean = [regex]::Replace($text, $emojiPattern, "")
     if ($clean -ne $text) {
         Write-Host "Limpando emojis em: $path"
-        $clean | Set-Content -LiteralPath $path -Encoding UTF8
+        try {
+            [System.IO.File]::WriteAllText(
+                $path,
+                $clean,
+                $utf8NoBom
+            )
+        } catch {
+            Write-Host ("Falha ao escrever {0}: {1}" -f $path, $_) -ForegroundColor Yellow
+        }
     }
 }
 

--- a/scripts/remove_emojis.py
+++ b/scripts/remove_emojis.py
@@ -21,8 +21,6 @@ EMOJI_RANGES = [
     (0x1F600, 0x1F64F),  # Emoticons
     (0x1F680, 0x1F6FF),  # Transport and map symbols
     (0x1F900, 0x1F9FF),  # Supplemental Symbols and Pictographs
-    (0x2600, 0x26FF),  # Misc symbols
-    (0x2700, 0x27BF),  # Dingbats
 ]
 
 EXTS = (".md", ".rst", ".txt")

--- a/scripts/sync_pyinstaller_outputs.py
+++ b/scripts/sync_pyinstaller_outputs.py
@@ -16,10 +16,19 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import importlib
 import shutil
+import sys
 from pathlib import Path
 
-PLATFORMS = ("windows_amd64", "debian_amd64", "macos_arm64")
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+MultiPlatformBuilder = importlib.import_module(
+    "launchers.build_multiplatform"
+).MultiPlatformBuilder
+PLATFORMS = tuple(sorted(MultiPlatformBuilder.PLATFORMS))
 
 
 def _sync_platform(repo_root: Path, platform: str, verbose: bool) -> bool:
@@ -58,8 +67,7 @@ def main() -> int:
     args = parser.parse_args()
 
     verbose = not args.quiet
-    repo_root = Path(__file__).resolve().parents[1]
-
+    repo_root = PROJECT_ROOT
     platforms = [args.platform] if args.platform else list(PLATFORMS)
     any_synced = False
     for platform in platforms:

--- a/tests/test_app_logic_filter_contract.py
+++ b/tests/test_app_logic_filter_contract.py
@@ -74,6 +74,40 @@ def _fake_extract_transition(file_path: str, should_cancel=None):  # noqa: ARG00
     )
 
 
+def test_run_importer_logic_accepts_explicit_external_db_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from utils import path_safety
+
+    project_root = tmp_path / "project"
+    docs_dir = project_root / "docs_entrada"
+    docs_dir.mkdir(parents=True)
+    external_data_dir = tmp_path / "selected_db"
+    external_data_dir.mkdir()
+
+    monkeypatch.setattr(path_safety, "ALLOWED_ROOTS", [project_root])
+    monkeypatch.setattr(app_logic, "project_root_path", project_root)
+
+    with pytest.raises(path_safety.PathSafetyError):
+        app_logic.run_importer_logic(
+            docs_dir=str(docs_dir),
+            data_dir=str(external_data_dir),
+            db_name="custom.sqlite",
+            force_import=False,
+        )
+
+    result = app_logic.run_importer_logic(
+        docs_dir=str(docs_dir),
+        data_dir=str(external_data_dir),
+        db_name="custom.sqlite",
+        force_import=False,
+        extra_allowed_roots=(external_data_dir,),
+    )
+
+    assert result is False
+
+
 def _prepare_import_update_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_build_multiplatform_manifest.py
+++ b/tests/test_build_multiplatform_manifest.py
@@ -10,6 +10,30 @@ from pathlib import Path
 from launchers.build_multiplatform import MultiPlatformBuilder
 
 
+def test_command_stdout_logs_metadata_command_failure(monkeypatch):
+    builder = MultiPlatformBuilder()
+    warnings = []
+
+    def fake_run_command(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            ["git", "bad"],
+            returncode=7,
+            stdout="stdout detail",
+            stderr="stderr detail",
+        )
+
+    monkeypatch.setattr(builder, "_run_command", fake_run_command)
+    monkeypatch.setattr(
+        "launchers.build_multiplatform.logger.warning",
+        lambda *args, **_kwargs: warnings.append(args),
+    )
+
+    assert builder._command_stdout(["git", "bad"]) == ""
+    assert warnings
+    assert "Metadata command failed" in warnings[0][0]
+    assert "stderr detail" in "".join(str(item) for item in warnings[0])
+
+
 def test_create_manifest_lists_root_artifacts_and_skips_hidden(tmp_path):
     builder = MultiPlatformBuilder()
     builder.dist_dir = tmp_path / "dist"

--- a/tests/test_build_multiplatform_manifest.py
+++ b/tests/test_build_multiplatform_manifest.py
@@ -295,3 +295,15 @@ def test_build_multiplatform_script_runs_without_explicit_pythonpath():
 
     assert result.returncode == 0
     assert "Plataformas suportadas:" in result.stdout
+    assert "debian_arm64: Linux aarch64" in result.stdout
+
+
+def test_detect_current_platform_maps_linux_arm64(monkeypatch):
+    builder = MultiPlatformBuilder()
+
+    monkeypatch.setattr("launchers.build_multiplatform.platform.system", lambda: "Linux")
+    monkeypatch.setattr(
+        "launchers.build_multiplatform.platform.machine", lambda: "aarch64"
+    )
+
+    assert builder.detect_current_platform() == "debian_arm64"

--- a/tests/test_build_multiplatform_manifest.py
+++ b/tests/test_build_multiplatform_manifest.py
@@ -118,6 +118,17 @@ def test_build_executable_uses_platform_specific_add_data_separator(
     assert "--icon" in windows_cmd
     icon_value = windows_cmd[windows_cmd.index("--icon") + 1]
     assert icon_value.replace("\\", "/").endswith("resources/app_icon.ico")
+    assert "--version-file" in windows_cmd
+    version_file_value = Path(windows_cmd[windows_cmd.index("--version-file") + 1])
+    version_file_text = version_file_value.read_text(encoding="utf-8")
+    version_tuple = builder._windows_version_tuple(builder.version)
+    version_text = ".".join(str(part) for part in version_tuple)
+    assert f"filevers={version_tuple}" in version_file_text
+    assert f"prodvers={version_tuple}" in version_file_text
+    assert f"StringStruct('FileVersion', '{version_text}')" in version_file_text
+    assert f"StringStruct('ProductVersion', '{version_text}')" in version_file_text
+    assert "StringStruct('ProductName', 'SSA Consulta Rapida')" in version_file_text
+    assert "SSA_CLI_test.exe" in version_file_text
 
     captured_cmds.clear()
     config["cli_config"]["icon"] = "resources/app_icon.icns"
@@ -133,6 +144,7 @@ def test_build_executable_uses_platform_specific_add_data_separator(
         for idx, value in enumerate(mac_cmd)
         if idx > 0 and mac_cmd[idx - 1] == "--add-data"
     )
+    assert "--version-file" not in mac_cmd
 
 
 def test_post_process_macos_creates_dmg_when_configured(tmp_path, monkeypatch):

--- a/tests/test_build_multiplatform_manifest.py
+++ b/tests/test_build_multiplatform_manifest.py
@@ -59,6 +59,11 @@ def test_build_executable_uses_platform_specific_add_data_separator(
         "print('ok')\n", encoding="utf-8"
     )
     (builder.base_dir / "config").mkdir(parents=True, exist_ok=True)
+    (builder.base_dir / "docs").mkdir(parents=True, exist_ok=True)
+    (builder.base_dir / "docs" / "GUIA_MIGRACAO_NOVA_INSTALACAO.md").write_text(
+        "guide",
+        encoding="utf-8",
+    )
     (builder.base_dir / "resources").mkdir(parents=True, exist_ok=True)
     (builder.base_dir / "resources" / "app_icon.ico").write_bytes(b"ico")
     (builder.base_dir / "resources" / "app_icon.icns").write_bytes(b"icns")
@@ -99,9 +104,20 @@ def test_build_executable_uses_platform_specific_add_data_separator(
     assert "--add-data" in windows_cmd
     add_data_value = windows_cmd[windows_cmd.index("--add-data") + 1]
     assert add_data_value.endswith(";config")
+    assert any(
+        value.endswith(";docs")
+        and "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in value
+        for idx, value in enumerate(windows_cmd)
+        if idx > 0 and windows_cmd[idx - 1] == "--add-data"
+    )
+    assert any(
+        value.endswith(";config") and "build_info.json" in value
+        for idx, value in enumerate(windows_cmd)
+        if idx > 0 and windows_cmd[idx - 1] == "--add-data"
+    )
     assert "--icon" in windows_cmd
     icon_value = windows_cmd[windows_cmd.index("--icon") + 1]
-    assert icon_value.endswith("resources/app_icon.ico")
+    assert icon_value.replace("\\", "/").endswith("resources/app_icon.ico")
 
     captured_cmds.clear()
     config["cli_config"]["icon"] = "resources/app_icon.icns"
@@ -111,6 +127,12 @@ def test_build_executable_uses_platform_specific_add_data_separator(
     assert "--add-data" in mac_cmd
     add_data_value = mac_cmd[mac_cmd.index("--add-data") + 1]
     assert add_data_value.endswith(":config")
+    assert any(
+        value.endswith(":docs")
+        and "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in value
+        for idx, value in enumerate(mac_cmd)
+        if idx > 0 and mac_cmd[idx - 1] == "--add-data"
+    )
 
 
 def test_post_process_macos_creates_dmg_when_configured(tmp_path, monkeypatch):

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from datetime import datetime, timedelta
+from typing import Any
 
 import pandas as pd
 
@@ -48,9 +49,9 @@ def test_dataframe_hash_handles_mixed_dict_keys() -> None:
 
 def test_dataframe_hash_handles_cyclic_object_cells() -> None:
     cache = CacheManager()
-    cyclic = []
+    cyclic: list[Any] = []
     cyclic.append(cyclic)
-    different = ["changed"]
+    different: list[Any] = ["changed"]
     different.append(different)
     frame = pd.DataFrame({"a": [cyclic]})
     other_frame = pd.DataFrame({"a": [different]})
@@ -134,7 +135,7 @@ def test_cache_stats_estimates_memory_outside_lock(monkeypatch) -> None:
             return False
 
     tracking_lock = TrackingLock()
-    cache._lock = tracking_lock
+    setattr(cache, "_lock", tracking_lock)
 
     def guarded_getsizeof(value):
         assert not tracking_lock.owned

--- a/tests/test_caching_atomic_save.py
+++ b/tests/test_caching_atomic_save.py
@@ -154,3 +154,20 @@ def test_acquire_cache_lock_preserves_active_lock_and_times_out(tmp_path, monkey
         caching._acquire_cache_lock(lock_path)
 
     assert os.path.exists(lock_path)
+
+
+def test_acquire_cache_lock_removes_partial_lock_when_pid_write_fails(
+    tmp_path, monkeypatch
+):
+    cache_file = tmp_path / "file_cache.json"
+    lock_path = str(cache_file) + ".lock"
+
+    def fail_write(fd, data):  # noqa: ARG001
+        raise OSError("write failed")
+
+    monkeypatch.setattr(caching.os, "write", fail_write)
+
+    with pytest.raises(RuntimeError, match="Failed to write cache lock metadata"):
+        caching._acquire_cache_lock(lock_path)
+
+    assert not os.path.exists(lock_path)

--- a/tests/test_config_manager_atomic_save.py
+++ b/tests/test_config_manager_atomic_save.py
@@ -125,8 +125,10 @@ def test_save_settings_creates_new_file_with_private_mode(tmp_path, monkeypatch)
 
     config_manager.save_settings({"secret": "local"})
 
-    assert stat.S_IMODE(settings_path.stat().st_mode) == 0o600
     assert json.loads(settings_path.read_text(encoding="utf-8")) == {"secret": "local"}
+    if os.name == "nt":
+        return
+    assert stat.S_IMODE(settings_path.stat().st_mode) == 0o600
 
 
 def test_save_settings_preserves_existing_file_mode(tmp_path, monkeypatch):
@@ -139,10 +141,12 @@ def test_save_settings_preserves_existing_file_mode(tmp_path, monkeypatch):
 
     config_manager.save_settings({"mode": "preserved"})
 
-    assert stat.S_IMODE(settings_path.stat().st_mode) == 0o640
     assert json.loads(settings_path.read_text(encoding="utf-8")) == {
         "mode": "preserved"
     }
+    if os.name == "nt":
+        return
+    assert stat.S_IMODE(settings_path.stat().st_mode) == 0o640
 
 
 def test_load_settings_reports_user_and_default_paths_when_missing(

--- a/tests/test_convert_icon.py
+++ b/tests/test_convert_icon.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from launchers import convert_icon
 from struct import unpack
 
@@ -73,7 +75,7 @@ def test_convert_svg_to_ico_uses_sizes_on_single_base_image(monkeypatch):
 
 
 def test_app_icon_ico_contains_expected_sizes_via_pillow() -> None:
-    from PIL import Image
+    Image = pytest.importorskip("PIL.Image", reason="Pillow optional in base env")
 
     with Image.open("resources/app_icon.ico") as image:
         ico_sizes = image.info.get("sizes", set())

--- a/tests/test_create_distribution.py
+++ b/tests/test_create_distribution.py
@@ -49,6 +49,14 @@ def test_create_zip_package_uses_canonical_pyinstaller_dir(
 
     gui_exe = canonical_dir / "SSA_GUI_v1_windows_amd64.exe"
     gui_exe.write_text("fake exe", encoding="utf-8")
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    (project_root / "README.md").write_text("readme", encoding="utf-8")
+    (docs_dir / "ANTIVIRUS_EXCLUSOES.md").write_text("av", encoding="utf-8")
+    (docs_dir / "GUIA_MIGRACAO_NOVA_INSTALACAO.md").write_text(
+        "guide",
+        encoding="utf-8",
+    )
 
     monkeypatch.setattr(create_distribution, "PROJECT_ROOT", project_root)
     monkeypatch.setattr(create_distribution, "DIST_OUTPUT", dist_output)
@@ -72,6 +80,10 @@ def test_create_zip_package_uses_canonical_pyinstaller_dir(
     with zipfile.ZipFile(result, "r") as zf:
         names = zf.namelist()
         assert any(name.endswith("SSA_GUI_v1_windows_amd64.exe") for name in names)
+        assert any(
+            name.endswith("docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md")
+            for name in names
+        )
 
 
 def test_create_zip_package_excludes_local_data_and_excel_from_canonical_pyinstaller(

--- a/tests/test_debian_packaging_scripts.py
+++ b/tests/test_debian_packaging_scripts.py
@@ -38,8 +38,11 @@ ARCH_WRAPPERS = (
 
 
 def _run_help(script: Path) -> str:
+    script_arg = str(script)
+    if script.drive:
+        script_arg = f"/mnt/{script.drive.rstrip(':').lower()}{script.as_posix()[2:]}"
     result = subprocess.run(
-        ["bash", str(script), "--help"],
+        ["bash", script_arg, "--help"],
         capture_output=True,
         text=True,
         check=False,
@@ -100,6 +103,10 @@ def test_debian_deb_engine_is_arch_aware_without_hardcoded_target() -> None:
     assert "SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}" in content
     assert "pyinstaller | nuitka | pyoxidizer" in content
     assert "--gui" in content
+    assert "default_package_staging_dir deb" in content
+    assert '${CLI_TARGET#"${PACKAGE_ROOT}"}' in content
+    assert "${CLI_TARGET#${PACKAGE_ROOT}}" not in content
+    assert "${CLI_TARGET/${PACKAGE_ROOT}/}" not in content
     assert "debian_arm64" not in content
     assert "debian_amd64" not in content
     assert "aarch64" not in content
@@ -115,6 +122,10 @@ def test_debian_appimage_engine_is_arch_aware_without_hardcoded_target() -> None
     assert "SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}" in content
     assert "--prepare-only" in content
     assert "pyinstaller | nuitka" in content
+    assert "default_package_staging_dir appimage" in content
+    assert '${APP_EXEC#"${APPDIR}"}' in content
+    assert "${APP_EXEC#${APPDIR}}" not in content
+    assert "${APP_EXEC/${APPDIR}/}" not in content
     assert "sed -i" not in content
     assert "debian_arm64" not in content
     assert "debian_amd64" not in content
@@ -125,6 +136,8 @@ def test_debian_appimage_engine_is_arch_aware_without_hardcoded_target() -> None
 def test_debian_package_common_removes_local_data_and_build_residue() -> None:
     content = COMMON_SCRIPT.read_text(encoding="utf-8")
     assert "-name venv" in content
+    assert "-name .git" in content
+    assert "-name .ssh" in content
     assert "-name '*.bak'" in content
     assert "-name '*.bak.*'" in content
     assert "-name '*.db'" in content
@@ -135,6 +148,10 @@ def test_debian_package_common_removes_local_data_and_build_residue() -> None:
     assert "jq -er" in content
     assert "${REPO_ROOT}/build" in content
     assert "${REPO_ROOT}/builds/packages" in content
+    assert "default_package_staging_dir" in content
+    assert '[[ "${REPO_ROOT}" == /mnt/* ]]' in content
+    assert "ssa_consulta_rapida_package" in content
+    assert "chmod 700" in content
 
     assert "clean_release_tree" in DEB_ENGINE_SCRIPT.read_text(encoding="utf-8")
     assert "clean_release_tree" in APPIMAGE_ENGINE_SCRIPT.read_text(encoding="utf-8")

--- a/tests/test_debian_packaging_scripts.py
+++ b/tests/test_debian_packaging_scripts.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from main import _get_project_root
+
+
+REPO_ROOT = Path(_get_project_root())
+BUILD_DIR = REPO_ROOT / "dev_env/build"
+COMMON_SCRIPT = BUILD_DIR / "package_debian_common.sh"
+DEB_ENGINE_SCRIPT = BUILD_DIR / "package_debian_deb.sh"
+APPIMAGE_ENGINE_SCRIPT = BUILD_DIR / "package_debian_appimage.sh"
+ARM64_DEB_SCRIPT = BUILD_DIR / "package_debian_arm64_deb.sh"
+ARM64_APPIMAGE_SCRIPT = BUILD_DIR / "package_debian_arm64_appimage.sh"
+AMD64_DEB_SCRIPT = BUILD_DIR / "package_debian_amd64_deb.sh"
+AMD64_APPIMAGE_SCRIPT = BUILD_DIR / "package_debian_amd64_appimage.sh"
+
+
+ARCH_WRAPPERS = (
+    (
+        ARM64_DEB_SCRIPT,
+        ARM64_APPIMAGE_SCRIPT,
+        "debian_arm64",
+        "arm64",
+        "^(aarch64|arm64)$",
+        "aarch64",
+    ),
+    (
+        AMD64_DEB_SCRIPT,
+        AMD64_APPIMAGE_SCRIPT,
+        "debian_amd64",
+        "amd64",
+        "^(x86_64|amd64)$",
+        "x86_64",
+    ),
+)
+
+
+def _run_help(script: Path) -> str:
+    result = subprocess.run(
+        ["bash", str(script), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def test_debian_package_scripts_exist_for_both_architectures() -> None:
+    for deb_script, appimage_script, *_ in ARCH_WRAPPERS:
+        assert deb_script.is_file()
+        assert appimage_script.is_file()
+
+    assert COMMON_SCRIPT.is_file()
+    assert DEB_ENGINE_SCRIPT.is_file()
+    assert APPIMAGE_ENGINE_SCRIPT.is_file()
+
+
+def test_debian_arch_wrappers_only_set_arch_policy() -> None:
+    for deb_script, appimage_script, platform, package_arch, machine_regex, appimage_arch in ARCH_WRAPPERS:
+        for script in (deb_script, appimage_script):
+            content = script.read_text(encoding="utf-8")
+            assert f'export DEBIAN_PLATFORM="{platform}"' in content
+            assert f'export DEBIAN_PACKAGE_ARCH="{package_arch}"' in content
+            assert f"export DEBIAN_MACHINE_REGEX='{machine_regex}'" in content
+            assert f'export DEBIAN_APPIMAGE_ARCH="{appimage_arch}"' in content
+            assert "exec \"${SCRIPT_DIR}/package_debian_" in content
+            assert "copy_dir_checked" not in content
+            assert "dpkg-deb --build" not in content
+            assert "appimagetool" not in content
+
+
+def test_debian_package_scripts_expose_arch_specific_help_contract() -> None:
+    arm_deb_help = _run_help(ARM64_DEB_SCRIPT)
+    arm_appimage_help = _run_help(ARM64_APPIMAGE_SCRIPT)
+    amd_deb_help = _run_help(AMD64_DEB_SCRIPT)
+    amd_appimage_help = _run_help(AMD64_APPIMAGE_SCRIPT)
+
+    assert ".deb Debian arm64/aarch64" in arm_deb_help
+    assert "AppImage Debian arm64/aarch64" in arm_appimage_help
+    assert "builds/packages/debian_arm64" in arm_deb_help
+    assert "appimagetool aarch64" in arm_appimage_help
+
+    assert ".deb Debian amd64/x86_64" in amd_deb_help
+    assert "AppImage Debian amd64/x86_64" in amd_appimage_help
+    assert "builds/packages/debian_amd64" in amd_deb_help
+    assert "appimagetool x86_64" in amd_appimage_help
+
+
+def test_debian_deb_engine_is_arch_aware_without_hardcoded_target() -> None:
+    content = DEB_ENGINE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "Architecture: ${DEBIAN_PACKAGE_ARCH}" in content
+    assert "${DEBIAN_PLATFORM}" in content
+    assert "${DEBIAN_ARCH_LABEL}" in content
+    assert "SSA_CLI_v${APP_VERSION}_${DEBIAN_PLATFORM}" in content
+    assert "SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}" in content
+    assert "pyinstaller | nuitka | pyoxidizer" in content
+    assert "--gui" in content
+    assert "debian_arm64" not in content
+    assert "debian_amd64" not in content
+    assert "aarch64" not in content
+    assert "x86_64" not in content
+
+
+def test_debian_appimage_engine_is_arch_aware_without_hardcoded_target() -> None:
+    content = APPIMAGE_ENGINE_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'ARCH="${DEBIAN_APPIMAGE_ARCH}"' in content
+    assert "Exec=AppRun" in content
+    assert "Desktop Entry" in content
+    assert "SSA_GUI_v${APP_VERSION}_${DEBIAN_PLATFORM}" in content
+    assert "--prepare-only" in content
+    assert "pyinstaller | nuitka" in content
+    assert "sed -i" not in content
+    assert "debian_arm64" not in content
+    assert "debian_amd64" not in content
+    assert "aarch64" not in content
+    assert "x86_64" not in content
+
+
+def test_debian_package_common_removes_local_data_and_build_residue() -> None:
+    content = COMMON_SCRIPT.read_text(encoding="utf-8")
+    assert "-name venv" in content
+    assert "-name '*.bak'" in content
+    assert "-name '*.bak.*'" in content
+    assert "-name '*.db'" in content
+    assert "-name '*.sqlite3'" in content
+    assert "-name '*.xlsx'" in content
+    assert "-name '.env'" in content
+    assert "realpath -m" in content
+    assert "jq -er" in content
+    assert "${REPO_ROOT}/build" in content
+    assert "${REPO_ROOT}/builds/packages" in content
+
+    assert "clean_release_tree" in DEB_ENGINE_SCRIPT.read_text(encoding="utf-8")
+    assert "clean_release_tree" in APPIMAGE_ENGINE_SCRIPT.read_text(encoding="utf-8")

--- a/tests/test_derivadas_queries.py
+++ b/tests/test_derivadas_queries.py
@@ -202,6 +202,27 @@ def test_snapshot_preserves_relation_metadata_for_graph_rendering(temp_db):
     assert child["relation_raw_label"] == "Relacionada"
 
 
+def test_snapshot_ignores_invalid_relation_type_for_graph_rendering(temp_db):
+    _seed_graph(temp_db)
+    with sqlite3.connect(temp_db) as conn:
+        conn.execute(
+            """
+            UPDATE ssa_derivada_matrix
+            SET relation_type = 'bad', relation_raw_label = 'Relacionada'
+            WHERE parent_ssa = '202500001' AND child_ssa = '202500002'
+            """
+        )
+        conn.commit()
+
+    snapshot = get_ssa_hierarchy_snapshot(temp_db, "202500001", max_distance=5)
+
+    child = next(
+        item for item in snapshot["family_descendants"] if item["ssa"] == "202500002"
+    )
+    assert "relation_type" not in child
+    assert child["relation_raw_label"] == "Relacionada"
+
+
 def test_snapshot_for_child_includes_parent_and_sibling_family(temp_db):
     _seed_graph(temp_db)
 

--- a/tests/test_derivadas_queries.py
+++ b/tests/test_derivadas_queries.py
@@ -181,6 +181,27 @@ def test_snapshot_returns_gui_friendly_payload(temp_db):
     ]
 
 
+def test_snapshot_preserves_relation_metadata_for_graph_rendering(temp_db):
+    _seed_graph(temp_db)
+    with sqlite3.connect(temp_db) as conn:
+        conn.execute(
+            """
+            UPDATE ssa_derivada_matrix
+            SET relation_type = 2, relation_raw_label = 'Relacionada'
+            WHERE parent_ssa = '202500001' AND child_ssa = '202500002'
+            """
+        )
+        conn.commit()
+
+    snapshot = get_ssa_hierarchy_snapshot(temp_db, "202500001", max_distance=5)
+
+    child = next(
+        item for item in snapshot["family_descendants"] if item["ssa"] == "202500002"
+    )
+    assert child["relation_type"] == 2
+    assert child["relation_raw_label"] == "Relacionada"
+
+
 def test_snapshot_for_child_includes_parent_and_sibling_family(temp_db):
     _seed_graph(temp_db)
 

--- a/tests/test_derivadas_queries.py
+++ b/tests/test_derivadas_queries.py
@@ -195,9 +195,11 @@ def test_snapshot_preserves_relation_metadata_for_graph_rendering(temp_db):
 
     snapshot = get_ssa_hierarchy_snapshot(temp_db, "202500001", max_distance=5)
 
-    child = next(
+    child_matches = [
         item for item in snapshot["family_descendants"] if item["ssa"] == "202500002"
-    )
+    ]
+    assert child_matches
+    child = child_matches[0]
     assert child["relation_type"] == 2
     assert child["relation_raw_label"] == "Relacionada"
 
@@ -216,9 +218,11 @@ def test_snapshot_ignores_invalid_relation_type_for_graph_rendering(temp_db):
 
     snapshot = get_ssa_hierarchy_snapshot(temp_db, "202500001", max_distance=5)
 
-    child = next(
+    child_matches = [
         item for item in snapshot["family_descendants"] if item["ssa"] == "202500002"
-    )
+    ]
+    assert child_matches
+    child = child_matches[0]
     assert "relation_type" not in child
     assert child["relation_raw_label"] == "Relacionada"
 

--- a/tests/test_dev_env_build_scripts.py
+++ b/tests/test_dev_env_build_scripts.py
@@ -107,6 +107,9 @@ def test_nuitka_windows_and_pyoxidizer_stage_include_docs_and_build_info() -> No
     assert "Error importing numpy" in pyoxidizer_script
     assert "rcedit.exe" in pyoxidizer_script
     assert "--set-icon" in pyoxidizer_script
+    assert "--set-file-version" in pyoxidizer_script
+    assert "--set-product-version" in pyoxidizer_script
+    assert '--set-version-string "ProductName" "SSA Consulta Rapida"' in pyoxidizer_script
     assert r"config\version.json" in pyoxidizer_script
     assert "build_info.json" in pyoxidizer_script
     assert "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in pyoxidizer_script

--- a/tests/test_dev_env_build_scripts.py
+++ b/tests/test_dev_env_build_scripts.py
@@ -25,15 +25,27 @@ def test_pyoxidizer_default_project_root_uses_empty_strip_prefix() -> None:
     assert 'PROJECT_ROOT in ("", ".")' in root_text
     assert '""\n    if PROJECT_ROOT in ("", ".")' in root_text
     assert 'strip_prefix=PROJECT_PREFIX' in root_text
+    assert '"launchers/platforms/**/venv/**"' in root_text
+    assert '"launchers/platforms/**/temp/**"' in root_text
+    assert '"launchers/dist/**"' in root_text
+    assert '"docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md"' in root_text
+    assert '"config/build_info.json"' in root_text
 
 
 def test_pyoxidizer_debian_uses_root_config_kept_in_sync() -> None:
-    script = (PROJECT_ROOT / "dev_env" / "build" / "build_pyoxidizer_debian.sh").read_text(
-        encoding="utf-8"
-    )
-    assert 'PYOX_CONFIG="${REPO_ROOT}/pyoxidizer.bzl"' in script
-    assert '--var SSA_PROJECT_ROOT "${REPO_ROOT}"' in script
-    assert '--path "${REPO_ROOT}"' in script
+    for platform, script_name in (
+        ("debian_amd64", "build_pyoxidizer_debian.sh"),
+        ("debian_arm64", "build_pyoxidizer_debian_arm64.sh"),
+    ):
+        script = (PROJECT_ROOT / "dev_env" / "build" / script_name).read_text(
+            encoding="utf-8"
+        )
+        assert 'PYOX_CONFIG="${REPO_ROOT}/pyoxidizer.bzl"' in script
+        assert '--var SSA_PROJECT_ROOT "${REPO_ROOT}"' in script
+        assert '--path "${REPO_ROOT}"' in script
+        assert 'BUILD_INFO_FILE="${REPO_ROOT}/config/build_info.json"' in script
+        assert "cleanup_build_info" in script
+        assert f'"pyoxidizer" "{platform}"' in script
 
 
 def test_nuitka_debian_serializes_patchelf_install() -> None:
@@ -61,3 +73,29 @@ def test_nuitka_debian_uses_platform_venv_and_requirements() -> None:
         assert 'uv venv --python 3.13 "${VENV_DIR}"' in script
         assert 'uv pip install --python "${PYTHON_EXE}" -r "${REQUIREMENTS_FILE}"' in script
         assert '"${PYTHON_EXE}" -m nuitka' in script
+        assert '--include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md' in script
+        assert '--include-data-file="${BUILD_INFO_FILE}=config/build_info.json"' in script
+        assert 'NUITKA_OUTPUT_DIR=' in script
+        assert 'trap cleanup_build_work_dir EXIT' in script
+
+
+def test_nuitka_windows_and_pyoxidizer_stage_include_docs_and_build_info() -> None:
+    nuitka_script = (PROJECT_ROOT / "dev_env" / "build" / "build_nuitka_clean.bat").read_text(
+        encoding="utf-8"
+    )
+    pyoxidizer_script = (PROJECT_ROOT / "dev_env" / "build" / "build_pyoxidizer.bat").read_text(
+        encoding="utf-8"
+    )
+
+    assert "--include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md" in nuitka_script
+    assert "--include-data-file=%BUILD_INFO_FILE%=config/build_info.json" in nuitka_script
+    assert "--format=%%cI" in nuitka_script
+    assert "--format=%%s" in nuitka_script
+    assert 'set "MSVC_LINK="' in pyoxidizer_script
+    assert "if not defined MSVC_LINK" in pyoxidizer_script
+    assert "where link.exe" in pyoxidizer_script
+    assert 'set "APP_VERSION=%%A"' in pyoxidizer_script
+    assert "build_info.json" in pyoxidizer_script
+    assert "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in pyoxidizer_script
+    assert "--format=%%cI" in pyoxidizer_script
+    assert "--format=%%s" in pyoxidizer_script

--- a/tests/test_dev_env_build_scripts.py
+++ b/tests/test_dev_env_build_scripts.py
@@ -45,3 +45,19 @@ def test_nuitka_debian_serializes_patchelf_install() -> None:
     assert 'exec 9>"${APT_LOCK_FILE}"' in script
     assert "flock 9" in script
     assert script.count("if ! command -v patchelf >/dev/null 2>&1; then") >= 2
+
+
+def test_nuitka_debian_uses_platform_venv_and_requirements() -> None:
+    for platform, script_name in (
+        ("debian_amd64", "build_nuitka_debian.sh"),
+        ("debian_arm64", "build_nuitka_debian_arm64.sh"),
+    ):
+        script = (PROJECT_ROOT / "dev_env" / "build" / script_name).read_text(
+            encoding="utf-8"
+        )
+
+        assert f'VENV_DIR="${{REPO_ROOT}}/launchers/platforms/{platform}/venv"' in script
+        assert f'REQUIREMENTS_FILE="${{REPO_ROOT}}/launchers/platforms/{platform}/requirements.txt"' in script
+        assert 'uv venv --python 3.13 "${VENV_DIR}"' in script
+        assert 'uv pip install --python "${PYTHON_EXE}" -r "${REQUIREMENTS_FILE}"' in script
+        assert '"${PYTHON_EXE}" -m nuitka' in script

--- a/tests/test_dev_env_build_scripts.py
+++ b/tests/test_dev_env_build_scripts.py
@@ -53,7 +53,8 @@ def test_nuitka_debian_serializes_patchelf_install() -> None:
         encoding="utf-8"
     )
 
-    assert 'APT_LOCK_FILE="${TMPDIR:-/tmp}/ssa_build_locks/patchelf_install.lock"' in script
+    assert 'APT_LOCK_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/ssa_consulta_rapida/build_locks"' in script
+    assert 'APT_LOCK_FILE="${APT_LOCK_DIR}/patchelf_install.lock"' in script
     assert 'exec 9>"${APT_LOCK_FILE}"' in script
     assert "flock 9" in script
     assert script.count("if ! command -v patchelf >/dev/null 2>&1; then") >= 2
@@ -74,9 +75,13 @@ def test_nuitka_debian_uses_platform_venv_and_requirements() -> None:
         assert 'uv pip install --python "${PYTHON_EXE}" -r "${REQUIREMENTS_FILE}"' in script
         assert '"${PYTHON_EXE}" -m nuitka' in script
         assert '--include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md' in script
+        assert script.count('--include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md') >= 2
         assert '--include-data-file="${BUILD_INFO_FILE}=config/build_info.json"' in script
         assert 'NUITKA_OUTPUT_DIR=' in script
         assert 'trap cleanup_build_work_dir EXIT' in script
+        assert 'SSA_NUITKA_WORK_ROOT' in script
+        assert 'mktemp -d "${TMPDIR:-/tmp}/ssa_nuitka_' in script
+        assert "ssa_nuitka_build" not in script
 
 
 def test_nuitka_windows_and_pyoxidizer_stage_include_docs_and_build_info() -> None:

--- a/tests/test_dev_env_build_scripts.py
+++ b/tests/test_dev_env_build_scripts.py
@@ -100,6 +100,14 @@ def test_nuitka_windows_and_pyoxidizer_stage_include_docs_and_build_info() -> No
     assert "if not defined MSVC_LINK" in pyoxidizer_script
     assert "where link.exe" in pyoxidizer_script
     assert 'set "APP_VERSION=%%A"' in pyoxidizer_script
+    assert 'set "PYOX_RUNTIME_PYTHON=3.10"' in pyoxidizer_script
+    assert "uv run --python %PYOX_RUNTIME_PYTHON%" in pyoxidizer_script
+    assert "SSA_PYOXIDIZER_SMOKE_LOG" in pyoxidizer_script
+    assert "Falha critica nas importacoes" in pyoxidizer_script
+    assert "Error importing numpy" in pyoxidizer_script
+    assert "rcedit.exe" in pyoxidizer_script
+    assert "--set-icon" in pyoxidizer_script
+    assert r"config\version.json" in pyoxidizer_script
     assert "build_info.json" in pyoxidizer_script
     assert "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in pyoxidizer_script
     assert "--format=%%cI" in pyoxidizer_script

--- a/tests/test_gui_about_message.py
+++ b/tests/test_gui_about_message.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from types import SimpleNamespace
 from typing import Any, cast
 
 from gui import gui_ssa
@@ -38,6 +39,30 @@ def test_build_about_message_uses_embedded_build_info(monkeypatch, tmp_path) -> 
     assert "uv: uv 0.9.18" in message
     assert "Commit: def5678" in message
     assert "Build: 2026-04-28T06:30:00-03:00" in message
+
+
+def test_resolve_uv_version_uses_resolved_executable(monkeypatch) -> None:
+    captured = {}
+
+    def _fake_run(cmd, **_kwargs):  # noqa: ANN001
+        captured["cmd"] = cmd
+        return SimpleNamespace(stdout="uv 0.9.18", stderr="")
+
+    monkeypatch.setattr(gui_ssa.shutil, "which", lambda name: f"/tools/{name}")
+    monkeypatch.setattr(gui_ssa.subprocess, "run", _fake_run)
+
+    assert gui_ssa.resolve_uv_version_text() == "uv 0.9.18"
+    assert captured["cmd"] == ["/tools/uv", "--version"]
+
+
+def test_resolve_git_commit_returns_unavailable_without_git(monkeypatch) -> None:
+    def _unexpected_run(*_args, **_kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("subprocess.run should not be called without git")
+
+    monkeypatch.setattr(gui_ssa.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(gui_ssa.subprocess, "run", _unexpected_run)
+
+    assert gui_ssa.resolve_git_commit_hash_text() == "indisponivel"
 
 
 def test_iter_build_info_candidates_includes_pyinstaller_internal(

--- a/tests/test_gui_about_message.py
+++ b/tests/test_gui_about_message.py
@@ -97,7 +97,6 @@ def test_open_installation_guide_uses_bundled_internal_docs(
     def _fake_popen(cmd, shell=False):  # noqa: ANN001
         opened["cmd"] = list(cmd)
         opened["shell"] = shell
-        return None
 
     monkeypatch.setattr(gui_ssa.subprocess, "Popen", _fake_popen)
 

--- a/tests/test_gui_about_message.py
+++ b/tests/test_gui_about_message.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+from typing import Any, cast
+
 from gui import gui_ssa
 
 
@@ -35,3 +38,72 @@ def test_build_about_message_uses_embedded_build_info(monkeypatch, tmp_path) -> 
     assert "uv: uv 0.9.18" in message
     assert "Commit: def5678" in message
     assert "Build: 2026-04-28T06:30:00-03:00" in message
+
+
+def test_iter_build_info_candidates_includes_pyinstaller_internal(
+    monkeypatch, tmp_path
+) -> None:
+    runtime_root = tmp_path / "runtime_root"
+    bundled_root = tmp_path / "bundle_root"
+    runtime_root.mkdir()
+    bundled_root.mkdir()
+    monkeypatch.setattr(gui_ssa, "project_root", str(runtime_root))
+    monkeypatch.setenv("SSA_BUNDLED_ROOT", str(bundled_root))
+    monkeypatch.delenv("SSA_CONFIG_DIR", raising=False)
+
+    candidates = list(gui_ssa._iter_build_info_candidates())
+
+    assert os.path.join(str(bundled_root), "config", "build_info.json") in candidates
+    assert os.path.join(str(bundled_root), "_internal", "config", "build_info.json") in candidates
+
+
+def test_open_installation_guide_uses_bundled_internal_docs(
+    monkeypatch, tmp_path
+) -> None:
+    runtime_root = tmp_path / "runtime_root"
+    bundled_root = tmp_path / "bundle_root"
+    guide_path = (
+        bundled_root / "_internal" / "docs" / "GUIA_MIGRACAO_NOVA_INSTALACAO.md"
+    )
+    runtime_root.mkdir()
+    guide_path.parent.mkdir(parents=True)
+    guide_path.write_text("guia", encoding="utf-8")
+    monkeypatch.setattr(gui_ssa, "project_root", str(runtime_root))
+    monkeypatch.setenv("SSA_BUNDLED_ROOT", str(bundled_root))
+    monkeypatch.setattr(gui_ssa, "QT_AVAILABLE", False)
+    monkeypatch.setattr(
+        gui_ssa.SSAMainWindow,
+        "_validate_local_open_target",
+        staticmethod(lambda path, **_kwargs: path),
+    )
+    monkeypatch.setattr(
+        gui_ssa.SSAMainWindow,
+        "_resolve_platform_open_command",
+        staticmethod(lambda: "fake-open"),
+    )
+    opened = {}
+
+    class _FakeLabel:
+        def __init__(self) -> None:
+            self.text = ""
+
+        def setText(self, value: str) -> None:
+            self.text = value
+
+    class _FakeWindow:
+        def __init__(self) -> None:
+            self.status_label = _FakeLabel()
+
+    def _fake_popen(cmd, shell=False):  # noqa: ANN001
+        opened["cmd"] = list(cmd)
+        opened["shell"] = shell
+        return None
+
+    monkeypatch.setattr(gui_ssa.subprocess, "Popen", _fake_popen)
+
+    result = gui_ssa.SSAMainWindow.open_installation_guide(cast(Any, _FakeWindow()))
+
+    assert result["opened"] is True
+    assert result["path"] == os.path.abspath(str(guide_path))
+    assert opened["cmd"] == ["fake-open", os.path.abspath(str(guide_path))]
+    assert opened["shell"] is False

--- a/tests/test_gui_about_message.py
+++ b/tests/test_gui_about_message.py
@@ -11,3 +11,27 @@ def test_build_about_message_includes_commit_hash(monkeypatch) -> None:
 
     assert "Versao app: 9.9.9" in message
     assert "Commit: abc1234" in message
+
+
+def test_build_about_message_uses_embedded_build_info(monkeypatch, tmp_path) -> None:
+    build_info = tmp_path / "build_info.json"
+    build_info.write_text(
+        '{"git_commit_short":"def5678","build_datetime":"2026-04-28T06:30:00-03:00","uv_version":"uv 0.9.18"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        gui_ssa,
+        "_iter_build_info_candidates",
+        lambda: (build_info,),
+        raising=False,
+    )
+    monkeypatch.setattr(gui_ssa, "resolve_uv_version_text", lambda: "indisponivel")
+    monkeypatch.setattr(
+        gui_ssa, "resolve_git_commit_hash_text", lambda: "indisponivel"
+    )
+
+    message = gui_ssa.build_about_message("9.9.9")
+
+    assert "uv: uv 0.9.18" in message
+    assert "Commit: def5678" in message
+    assert "Build: 2026-04-28T06:30:00-03:00" in message

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -4854,6 +4854,29 @@ class TestGUIFilterLogic:
 
         assert derived == ["102"]
 
+    def test_get_derivadas_for_ssa_uses_cached_family_edges(self, monkeypatch):
+        self.window.df_completo = pd.DataFrame(
+            {"numero_ssa": ["101", "102"], "derivada_de": ["100", "100"]}
+        )
+        monkeypatch.setattr(
+            ssa_gui_details,
+            "_get_cached_derivadas_family_edges",
+            lambda _window: [("100", "101"), ("100", "102"), ("100", "101")],
+        )
+
+        def _fail_full_column_scan(_series):
+            raise AssertionError("nao deve normalizar coluna inteira a cada consulta")
+
+        monkeypatch.setattr(
+            ssa_gui_details,
+            "_normalize_ssa_relation_series",
+            _fail_full_column_scan,
+        )
+
+        derived = ssa_gui_details._get_derivadas_for_ssa(self.window, "100")
+
+        assert derived == ["101", "102"]
+
     def test_get_series_for_ssa_uses_index_label_and_returns_correct_row(self):
         df = pd.DataFrame(
             {
@@ -6233,6 +6256,75 @@ class TestGUIFilterLogic:
         assert "dist=" not in html
         assert "&#8942;" in html
         assert "Sem Derivadas" in html
+
+    def test_open_details_dialog_does_not_build_full_ssa_index_before_render(self):
+        df = pd.DataFrame(
+            {
+                "numero_ssa": ["202218980", "202218786", "202218787"],
+                "descricao_ssa": ["Alvo", "Filha A", "Filha B"],
+                "derivada_de": ["", "202218980", "202218980"],
+                "situacao": ["APV", "STE", "SCA"],
+            }
+        )
+        self.window.df_completo = df
+        self.window.df_exibido = df
+        self.window.df_para_tabela = df
+
+        with patch(
+            "gui.ssa.gui_details._get_df_ssa_series_index",
+            side_effect=AssertionError("full index should not be built on open"),
+        ):
+            with patch("PyQt6.QtWidgets.QDialog.exec", return_value=0):
+                ssa_gui_details._open_details_dialog_for_ssa(
+                    self.window,
+                    "202218980",
+                    series=df.iloc[0],
+                )
+
+    def test_derivadas_tree_html_does_not_scan_dataframe_per_node(self, monkeypatch):
+        node_ids = ["202206235", *[f"202206{i:03d}" for i in range(100, 180)]]
+        self.window.df_completo = pd.DataFrame(
+            {
+                "numero_ssa": node_ids,
+                "situacao": ["APV", *["STE" for _ in node_ids[1:]]],
+                "derivada_de": ["", *["202206235" for _ in node_ids[1:]]],
+            }
+        )
+        self.window.df_exibido = self.window.df_completo.iloc[:1].copy()
+        tree_data = {
+            "target": "202206235",
+            "parents": [],
+            "children": [{"ssa": node_ids[1], "parent": "202206235"}],
+            "descendants": [
+                {"ssa": child, "parent": "202206235", "min_distance": 1}
+                for child in node_ids[1:]
+            ],
+            "ancestors": [],
+            "family_roots": ["202206235"],
+            "target_status": "",
+            "direct_children_count": len(node_ids) - 1,
+            "descendants_count": len(node_ids) - 1,
+            "render_family": True,
+        }
+
+        def _fail_per_node_scan(_window, numero_ssa):
+            raise AssertionError(f"per-node dataframe scan for {numero_ssa}")
+
+        monkeypatch.setattr(
+            ssa_gui_details,
+            "_get_series_for_ssa",
+            _fail_per_node_scan,
+        )
+
+        html = ssa_gui_details._build_derivadas_tree_html(
+            self.window,
+            "202206235",
+            tree_data_override=tree_data,
+            ssa_index={},
+        )
+
+        assert "202206235" in html
+        assert "202206100" in html
 
     def test_exclude_toggle_syncs_checkbox_state_across_tabs(self):
         """Toggle programático deve manter estado interno e checkboxes em sincronia."""

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -6369,13 +6369,12 @@ class TestGUIFilterLogic:
         with patch(
             "gui.ssa.gui_details._get_df_ssa_series_index",
             side_effect=AssertionError("full index should not be built on open"),
-        ):
-            with patch("PyQt6.QtWidgets.QDialog.exec", return_value=0):
-                ssa_gui_details._open_details_dialog_for_ssa(
-                    self.window,
-                    "202218980",
-                    series=df.iloc[0],
-                )
+        ), patch("PyQt6.QtWidgets.QDialog.exec", return_value=0):
+            ssa_gui_details._open_details_dialog_for_ssa(
+                self.window,
+                "202218980",
+                series=df.iloc[0],
+            )
 
     def test_derivadas_tree_html_does_not_scan_dataframe_per_node(self, monkeypatch):
         node_ids = ["202206235", *[f"202206{i:03d}" for i in range(100, 180)]]

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -616,11 +616,75 @@ class TestGUIFilterLogic:
         self.window._on_macro_filter_changed()
         QApplication.processEvents()
 
+        self.window._apply_advanced_filters_from_ui()
+        QApplication.processEvents()
+
         assert self.window._advanced_filters.get("derivada_all_ste") is True
         assert set(
             self.window._advanced_filters.get("situacao_exclude_values") or []
         ) == {"SAD", "SCA", "SES", "STE"}
         assert self.window.df_exibido["numero_ssa"].astype(str).tolist() == ["100"]
+
+    def test_macro_baixar_waits_for_apply_button_before_filtering(self):
+        macro_df = pd.DataFrame(
+            {
+                "numero_ssa": ["202600100", "202600101"],
+                "situacao": ["APV", "STE"],
+                "derivada_de": ["", "202600100"],
+                "localizacao_codigo": ["LOC1", "LOC2"],
+                "descricao_localizacao": ["Desc1", "Desc2"],
+                "equipamento": ["EQ1", "EQ2"],
+                "semana_cadastro": [202501, 202501],
+                "semana_programada": [202503, 202503],
+                "data_cadastro": ["2025-01-01", "2025-01-01"],
+                "descricao_ssa": ["Origem", "Filha"],
+                "setor_executor": ["IEE3", "IEE3"],
+                "setor_emissor": ["IEE3", "IEE3"],
+                "descricao_execucao": ["Exec A", "Exec B"],
+                "solicitante": ["User1", "User2"],
+            }
+        )
+        self.window.df_completo = macro_df.copy()
+        self.window.df_exibido = macro_df.copy()
+        self.window._df_last_search_filtered = macro_df.copy()
+        self.window.paginator.set_dataframe(macro_df.copy())
+        self.window.main_tabs.setCurrentIndex(1)
+        QApplication.processEvents()
+        self.window._refresh_advanced_filter_options()
+
+        macro_idx = self.window.adv_macro_combo.findData("ssas_para_baixar")
+        assert macro_idx >= 0
+
+        self.window.adv_macro_combo.setCurrentIndex(macro_idx)
+        self.window._on_macro_filter_changed()
+        QApplication.processEvents()
+
+        assert self.window._advanced_filters.get("macro_filter") in (None, "")
+        assert self.window.df_exibido["numero_ssa"].astype(str).tolist() == [
+            "202600100",
+            "202600101",
+        ]
+
+        self.window._apply_advanced_filters_from_ui()
+        QApplication.processEvents()
+
+        assert self.window._advanced_filters.get("macro_filter") == "ssas_para_baixar"
+        assert self.window.df_exibido["numero_ssa"].astype(str).tolist() == [
+            "202600100"
+        ]
+
+    def test_details_html_uses_display_label_for_situacao_da_parcial(self):
+        series = pd.Series(
+            {
+                "numero_ssa": "202600001",
+                "situacao_da_parcial": "Pendente",
+            }
+        )
+
+        html = ssa_gui_details._format_details_html(self.window, series)
+
+        assert "Situacao da Parcial" in html
+        assert "situacao_da_parcial" not in html
 
     def test_filters_summary_deduplicates_column_and_advanced_entries(self):
         self.window._active_column_filters["setor_executor"] = "IEE3"
@@ -4191,6 +4255,32 @@ class TestGUIFilterLogic:
         assert "stroke-dasharray" in html
         assert "marker-end" in html
         assert "Grafo de derivadas" in html
+
+    def test_build_derivadas_graph_html_dashes_relation_type_edges(self):
+        data: dict[str, object] = {
+            "target": "202600023",
+            "parents": [],
+            "children": ["202600024"],
+            "descendants": [
+                {
+                    "ssa": "202600024",
+                    "parent": "202600023",
+                    "relation_type": 2,
+                    "relation_raw_label": "Relacionada",
+                }
+            ],
+            "descendants_count": 1,
+        }
+
+        html = ssa_gui_details._build_derivadas_graph_html(
+            self.window,
+            data,
+            link_color="#4a90e2",
+            font_family="monospace",
+        )
+
+        assert 'data-from="202600023" data-to="202600024"' in html
+        assert "stroke-dasharray" in html
 
     def test_build_derivadas_graph_html_separates_sibling_edge_lanes(self):
         data: dict[str, object] = {

--- a/tests/test_gui_filter_logic.py
+++ b/tests/test_gui_filter_logic.py
@@ -983,6 +983,8 @@ class TestGUIFilterLogic:
             "_measure_header_text_px",
             lambda _window, text: len(str(text or "")) * 8,
         )
+        self.window._adaptive_header_label_width_cache = {}
+        self.window._adaptive_header_label_signatures = {}
         self.window._saved_gui_column_widths["numero_ssa"] = 100
 
         self.window.display_current_page(1)
@@ -1123,6 +1125,8 @@ class TestGUIFilterLogic:
             "_measure_header_text_px",
             lambda _window, text: len(str(text or "")) * 8,
         )
+        self.window._adaptive_header_label_width_cache = {}
+        self.window._adaptive_header_label_signatures = {}
 
         self.window.visible_columns = ["descricao_ssa"]
         self.window.display_current_page(1)
@@ -1235,11 +1239,11 @@ class TestGUIFilterLogic:
             }
         elif sys.platform == "win32":
             expected = {
-                "grau_prioridade_emissao": 96,
-                "grau_prioridade_planejamento": 98,
+                "grau_prioridade_emissao": 120,
+                "grau_prioridade_planejamento": 128,
                 "execucao_parcial": 78,
-                "total_de_reprogramacoes": 82,
-                "semana_executada": 60,
+                "total_de_reprogramacoes": 130,
+                "semana_executada": 92,
             }
         else:
             expected = {
@@ -5438,6 +5442,8 @@ class TestGUIFilterLogic:
             "_measure_header_text_px",
             lambda _window, text: len(str(text or "")) * 8,
         )
+        self.window._adaptive_header_label_width_cache = {}
+        self.window._adaptive_header_label_signatures = {}
         self.window._saved_gui_column_widths["numero_ssa"] = 50
         self.window.display_current_page(1)
         QApplication.processEvents()

--- a/tests/test_gui_main_configuration.py
+++ b/tests/test_gui_main_configuration.py
@@ -293,7 +293,7 @@ class TestGUIMainConfiguration:
         assert "execucao_parcial" in config["hidden_columns"]
         assert "responsavel_execucao" in config["hidden_columns"]
 
-    def test_load_gui_main_preferences_removes_hidden_overlap_from_display_columns(
+    def test_load_gui_main_preferences_prioritizes_display_columns_over_hidden_overlap(
         self,
     ):
         partial_config = {
@@ -338,6 +338,23 @@ class TestGUIMainConfiguration:
                 config = load_gui_main_preferences()
 
         assert config["column_widths"]["data_arquivo_origem"] == 100
+
+    def test_migrate_managed_legacy_widths_skips_missing_target_width(self):
+        from gui.gui_config import (
+            HARD_DEFAULT_GUI_MAIN_PREFERENCES,
+            _migrate_managed_legacy_widths,
+        )
+
+        legacy_width = HARD_DEFAULT_GUI_MAIN_PREFERENCES["column_widths"][
+            "descricao_ssa"
+        ]
+
+        migrated = _migrate_managed_legacy_widths(
+            {"descricao_ssa": legacy_width},
+            {},
+        )
+
+        assert migrated["descricao_ssa"] == legacy_width
 
     def test_load_gui_main_preferences_uses_platform_specific_widths(self):
         partial_config = {

--- a/tests/test_gui_main_configuration.py
+++ b/tests/test_gui_main_configuration.py
@@ -339,7 +339,8 @@ class TestGUIMainConfiguration:
 
         assert config["column_widths"]["data_arquivo_origem"] == 100
 
-    def test_migrate_managed_legacy_widths_skips_missing_target_width(self):
+    @staticmethod
+    def test_migrate_managed_legacy_widths_skips_missing_target_width():
         from gui.gui_config import (
             HARD_DEFAULT_GUI_MAIN_PREFERENCES,
             _migrate_managed_legacy_widths,

--- a/tests/test_gui_workers_rescan_data.py
+++ b/tests/test_gui_workers_rescan_data.py
@@ -686,6 +686,46 @@ def test_rescan_data_prompt_without_qmessagebox_uses_incremental_mode(tmp_path):
     assert captured_modes == [False]
 
 
+def test_rescan_data_passes_active_db_path_to_worker(tmp_path):
+    captured_db_paths: list[str | None] = []
+    active_db = tmp_path / "alternate" / "custom.sqlite"
+    active_db.parent.mkdir()
+    active_db.write_bytes(b"")
+
+    class _WorkerCaptureDbPath(_BaseWorker):
+        def __init__(
+            self,
+            _main_py_path: str,
+            _project_root: str,
+            db_path: str | None = None,
+        ):
+            super().__init__(_main_py_path, _project_root)
+            captured_db_paths.append(db_path)
+
+    project_root = _build_main_py(tmp_path)
+    window = _Window()
+    global_workers: list = []
+    global_meta: dict = {}
+
+    ssa_gui_workers.rescan_data(
+        window,
+        project_root=project_root,
+        rescan_worker_cls=_WorkerCaptureDbPath,
+        rescan_dialog_cls=_DialogNoop,
+        qmessagebox=None,
+        global_workers=global_workers,
+        global_meta=global_meta,
+        max_global_workers=8,
+        retired_ttl_sec=30.0,
+        retired_force_wait_ms=10,
+        sip_module=None,
+        rescan_mode="diff",
+        db_path=str(active_db),
+    )
+
+    assert captured_db_paths == [str(active_db)]
+
+
 def test_classify_workers_for_ttl_expires_oldest_when_above_cap():
     workers = ["w1", "w2", "w3"]
     meta = {"w1": 100.0, "w2": 101.0, "w3": 102.0}

--- a/tests/test_import_derivadas_trigger.py
+++ b/tests/test_import_derivadas_trigger.py
@@ -357,6 +357,45 @@ def test_run_importer_runs_db_only_derivadas_sync_for_regular_import(
     assert cached_files == [str(regular)]
 
 
+def test_db_only_derivadas_sync_progress_does_not_report_zero_sheet_files(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import core.app_logic as app_logic
+
+    monkeypatch.setattr(
+        app_logic,
+        "_run_derivadas_sync_phase",
+        lambda **kwargs: (
+            True,
+            [],
+            {
+                "db_stats": {"accepted_edges": 4},
+                "merge_stats": {"merged_edges": 4},
+            },
+        ),
+    )
+    events: list[tuple[str, dict]] = []
+
+    app_logic._run_optional_derivadas_sync(
+        auto_derivadas_sync_enabled=True,
+        successfully_processed_files=["Consulta SSA.xlsx"],
+        derivadas_sheet_files=[],
+        db_only_derivadas_sync=True,
+        should_cancel=None,
+        working_db_path="ssa.db",
+        table_name="ssa_table",
+        docs_dir="docs_entrada",
+        critical_errors=[],
+        emit_progress=lambda event, payload: events.append((event, payload)),
+    )
+
+    success_events = [payload for event, payload in events if event == "file_success"]
+    assert success_events
+    assert success_events[-1]["records"] == 4
+    assert "0 arquivos" not in success_events[-1]["filename"]
+    assert "banco atual" in success_events[-1]["filename"]
+
+
 def test_run_importer_runs_special_derivadas_sync_for_explicit_file_import(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_import_staging.py
+++ b/tests/test_import_staging.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import os
 from pathlib import Path
+from typing import Iterable
 
 import pytest
 
@@ -58,6 +59,44 @@ def test_validate_external_source_path_accepts_explicit_selected_file(
     assert resolved == str(source.resolve())
 
 
+def test_validate_external_source_path_ignores_missing_extra_allowed_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    source = outside_root / "entrada.xlsx"
+    source.write_text("payload", encoding="utf-8")
+    missing_source = outside_root / "ausente.xlsx"
+    monkeypatch.setattr(path_safety, "ALLOWED_ROOTS", [runtime_root])
+
+    resolved = import_staging.validate_external_source_path(
+        source,
+        extra_allowed_files=(missing_source, source),
+    )
+
+    assert resolved == str(source.resolve())
+
+
+def test_validate_external_source_path_rejects_explicit_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    monkeypatch.setattr(path_safety, "ALLOWED_ROOTS", [runtime_root])
+
+    with pytest.raises(ValueError):
+        import_staging.validate_external_source_path(
+            outside_root,
+            extra_allowed_files=(outside_root,),
+        )
+
+
 def test_stage_external_import_files_accepts_explicit_external_source(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -81,6 +120,49 @@ def test_stage_external_import_files_accepts_explicit_external_source(
     assert summary["unsupported"] == 0
     assert staged_files == [str(docs_dir / "entrada.xlsx")]
     assert (docs_dir / "entrada.xlsx").read_text(encoding="utf-8") == "payload"
+
+
+def test_stage_external_import_files_normalizes_explicit_allowlist_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    docs_dir = runtime_root / "docs_entrada"
+    docs_dir.mkdir(parents=True)
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    source_a = outside_root / "entrada_a.xlsx"
+    source_b = outside_root / "entrada_b.xlsx"
+    source_a.write_text("a", encoding="utf-8")
+    source_b.write_text("b", encoding="utf-8")
+    monkeypatch.setattr(path_safety, "ALLOWED_ROOTS", [runtime_root])
+    original_normalize = import_staging._normalize_explicit_allowed_files
+    call_count = 0
+
+    def counting_normalize(
+        extra_allowed_files: Iterable[str | os.PathLike[str]] | None,
+    ) -> set[Path]:
+        nonlocal call_count
+        call_count += 1
+        return original_normalize(extra_allowed_files)
+
+    monkeypatch.setattr(
+        import_staging,
+        "_normalize_explicit_allowed_files",
+        counting_normalize,
+    )
+
+    staged_files, summary = stage_external_import_files(
+        project_root=str(runtime_root),
+        source_files=(str(source_a), str(source_b)),
+    )
+
+    assert call_count == 1
+    assert summary["copied"] == 2
+    assert staged_files == [
+        str(docs_dir / "entrada_a.xlsx"),
+        str(docs_dir / "entrada_b.xlsx"),
+    ]
 
 
 def test_stage_external_import_files_creates_unique_name_with_collisions(

--- a/tests/test_import_staging.py
+++ b/tests/test_import_staging.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+import os
 from pathlib import Path
 
 import pytest
@@ -298,6 +299,8 @@ def test_stage_external_import_files_does_not_delete_file_on_create_collision(
     assert staged_files == []
     assert summary["copied"] == 0
     assert summary["failed"] == 1
+    assert source.read_text(encoding="utf-8") == "payload"
+    # A copy did not complete; the file created by the simulated racer remains.
     assert destination.read_text(encoding="utf-8") == "foreign"
 
 
@@ -305,6 +308,8 @@ def test_stage_external_import_files_copies_opened_file_when_source_path_changes
     tmp_path: Path,
     monkeypatch,
 ) -> None:
+    if os.name == "nt":
+        pytest.skip("os.replace over open file is not supported on Windows")
     docs_dir = tmp_path / "docs_entrada"
     docs_dir.mkdir()
     source_dir = tmp_path / "fontes"
@@ -388,4 +393,5 @@ def test_stage_external_import_files_reports_cleanup_failure_after_cancel(
     assert summary["failed"] == 1
     assert summary["staged"] == 0
     assert (docs_dir / "cancel.xlsx").exists()
+    assert (docs_dir / "cancel.xlsx").read_text(encoding="utf-8") == "payload"
     assert any("Falha ao remover arquivo staged apos cancelamento" in error for error in errors)

--- a/tests/test_import_staging.py
+++ b/tests/test_import_staging.py
@@ -7,6 +7,7 @@ import pytest
 
 from core import import_staging
 from core.import_staging import stage_external_import_files
+from utils import path_safety
 
 
 def test_stage_external_import_files_accepts_xlsx_and_xls(tmp_path: Path) -> None:
@@ -31,6 +32,54 @@ def test_stage_external_import_files_accepts_xlsx_and_xls(tmp_path: Path) -> Non
     assert len(staged_files) == 2
     assert (docs_dir / "entrada.xlsx").exists()
     assert (docs_dir / "entrada.xls").exists()
+
+
+def test_validate_external_source_path_accepts_explicit_selected_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    source = outside_root / "entrada.xlsx"
+    source.write_text("payload", encoding="utf-8")
+    monkeypatch.setattr(path_safety, "ALLOWED_ROOTS", [runtime_root])
+
+    with pytest.raises(ValueError):
+        import_staging.validate_external_source_path(source)
+
+    resolved = import_staging.validate_external_source_path(
+        source,
+        extra_allowed_files=(source,),
+    )
+
+    assert resolved == str(source.resolve())
+
+
+def test_stage_external_import_files_accepts_explicit_external_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    docs_dir = runtime_root / "docs_entrada"
+    docs_dir.mkdir(parents=True)
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    source = outside_root / "entrada.xlsx"
+    source.write_text("payload", encoding="utf-8")
+    monkeypatch.setattr(path_safety, "ALLOWED_ROOTS", [runtime_root])
+
+    staged_files, summary = stage_external_import_files(
+        project_root=str(runtime_root),
+        source_files=(str(source),),
+    )
+
+    assert summary["copied"] == 1
+    assert summary["failed"] == 0
+    assert summary["unsupported"] == 0
+    assert staged_files == [str(docs_dir / "entrada.xlsx")]
+    assert (docs_dir / "entrada.xlsx").read_text(encoding="utf-8") == "payload"
 
 
 def test_stage_external_import_files_creates_unique_name_with_collisions(

--- a/tests/test_release_debian_script.py
+++ b/tests/test_release_debian_script.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from main import _get_project_root
+
+
+PROJECT_ROOT = Path(_get_project_root())
+SCRIPT = PROJECT_ROOT / "dev_env" / "build" / "release_debian.sh"
+REPORT_SCRIPT = PROJECT_ROOT / "dev_env" / "build" / "release_debian_report.py"
+
+
+def _script_text() -> str:
+    assert SCRIPT.is_file()
+    return SCRIPT.read_text(encoding="utf-8")
+
+
+def test_release_debian_script_is_bash_only_and_interactive() -> None:
+    script = _script_text()
+
+    assert script.startswith("#!/usr/bin/env bash")
+    assert "set -euo pipefail" in script
+    assert "select_backend_interactively" in script
+    assert "read -r -p" in script
+    assert "--backend e obrigatorio em ambiente nao interativo" in script
+    assert "powershell" not in script.lower()
+    assert "pwsh" not in script.lower()
+    assert ".bat" not in script.lower()
+    assert "Compress-Archive" not in script
+    assert "FileVersionInfo" not in script
+
+
+def test_release_debian_script_has_local_and_ssh_modes() -> None:
+    script = _script_text()
+
+    assert "--ssh-host" in script
+    assert "--ssh-repo" in script
+    assert "run_remote_release" in script
+    assert "ssh " in script
+    assert "shell_quote" in script
+    assert "assert_ssh_host" in script
+    assert "assert_ssh_repo" in script
+    assert "assert_debian_host" in script
+    assert "assert_debian_amd64" in script
+    assert "--with-local-data nao e suportado via SSH" in script
+
+
+def test_release_debian_script_has_deterministic_preflight_and_report() -> None:
+    script = _script_text()
+
+    assert "assert_clean_release_workspace" in script
+    assert "AllowDirty" not in script
+    assert "rev-parse HEAD" in script
+    assert "status --porcelain" in script
+    assert "release_report_debian_amd64.json" in script
+    assert "write_release_report" in script
+    assert "build_info.json" in script
+    assert "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in script
+    report_script = REPORT_SCRIPT.read_text(encoding="utf-8")
+    assert "hashlib.sha256" in report_script
+
+
+def test_release_debian_script_calls_only_debian_wrappers() -> None:
+    script = _script_text()
+
+    assert "build_pyinstaller_debian.sh" in script
+    assert "build_nuitka_debian.sh" in script
+    assert "build_pyoxidizer_debian.sh" in script
+    assert "package_debian_amd64_deb.sh" in script
+    assert "package_debian_amd64_appimage.sh" in script
+    assert "AppImage pyoxidizer nao suportado" in script
+    assert "package_debian_arm64" not in script
+    assert "release_windows.ps1" not in script
+
+
+def test_release_debian_script_exposes_backend_scorecard() -> None:
+    script = _script_text()
+    report_script = REPORT_SCRIPT.read_text(encoding="utf-8")
+
+    assert "get_backend_scorecard" in script
+    assert "security_score" in report_script
+    assert "python_source_exposure_score" in report_script
+    assert "easy_user_dirs_score" in report_script
+    assert "package_size_score" in report_script

--- a/tests/test_release_debian_script.py
+++ b/tests/test_release_debian_script.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
+
+import pytest
 
 from main import _get_project_root
 
@@ -8,6 +11,7 @@ from main import _get_project_root
 PROJECT_ROOT = Path(_get_project_root())
 SCRIPT = PROJECT_ROOT / "dev_env" / "build" / "release_debian.sh"
 REPORT_SCRIPT = PROJECT_ROOT / "dev_env" / "build" / "release_debian_report.py"
+REPORT_MODULE = importlib.import_module("dev_env.build.release_debian_report")
 
 
 def _script_text() -> str:
@@ -101,3 +105,30 @@ def test_release_debian_script_exposes_backend_scorecard() -> None:
     assert "python_source_exposure_score" in report_script
     assert "easy_user_dirs_score" in report_script
     assert "package_size_score" in report_script
+
+
+def test_release_debian_report_read_json_errors_include_path(tmp_path) -> None:
+    missing = tmp_path / "missing.json"
+    with pytest.raises(REPORT_MODULE.ReleaseReportError, match="missing.json"):
+        REPORT_MODULE._read_json(missing)
+
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{", encoding="utf-8")
+    with pytest.raises(REPORT_MODULE.ReleaseReportError, match="JSON invalido"):
+        REPORT_MODULE._read_json(invalid)
+
+
+def test_release_debian_report_asset_payload_errors_include_path(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    asset = tmp_path / "package.deb"
+    asset.write_bytes(b"payload")
+
+    def fail_sha256(_path):
+        raise OSError("blocked")
+
+    monkeypatch.setattr(REPORT_MODULE, "_sha256", fail_sha256)
+
+    with pytest.raises(REPORT_MODULE.ReleaseReportError, match="package.deb"):
+        REPORT_MODULE._asset_payload(asset)

--- a/tests/test_release_debian_script.py
+++ b/tests/test_release_debian_script.py
@@ -11,7 +11,8 @@ REPORT_SCRIPT = PROJECT_ROOT / "dev_env" / "build" / "release_debian_report.py"
 
 
 def _script_text() -> str:
-    assert SCRIPT.is_file()
+    if not SCRIPT.is_file():
+        raise AssertionError(f"script ausente: {SCRIPT}")
     return SCRIPT.read_text(encoding="utf-8")
 
 
@@ -56,8 +57,22 @@ def test_release_debian_script_has_deterministic_preflight_and_report() -> None:
     assert "write_release_report" in script
     assert "build_info.json" in script
     assert "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in script
+    assert "bundle_roots" in script
+    assert "SSA_CLI_v${app_version}_debian_amd64" in script
+    assert "SSA_GUI_v${app_version}_debian_amd64" in script
+    assert "cli_entry.dist" in script
+    assert "gui_entry.dist" in script
     report_script = REPORT_SCRIPT.read_text(encoding="utf-8")
     assert "hashlib.sha256" in report_script
+
+
+def test_release_debian_script_normalizes_csv_tokens() -> None:
+    script = _script_text()
+
+    assert "[![:space:]]" in script
+    assert "join_csv" in script
+    assert 'BACKENDS_CSV="$(normalize_backends "${BACKENDS_CSV}")"' in script
+    assert 'PACKAGES_CSV="$(normalize_packages "${PACKAGES_CSV}")"' in script
 
 
 def test_release_debian_script_calls_only_debian_wrappers() -> None:

--- a/tests/test_release_debian_script.py
+++ b/tests/test_release_debian_script.py
@@ -36,9 +36,12 @@ def test_release_debian_script_has_local_and_ssh_modes() -> None:
 
     assert "--ssh-host" in script
     assert "--ssh-repo" in script
+    assert "caminho absoluto do repositorio no host remoto" in script
+    assert "Use caminho absoluto sem espacos/metacaracteres" in script
     assert "run_remote_release" in script
     assert "ssh " in script
-    assert "shell_quote" in script
+    assert "bash -s --" in script
+    assert "REMOTE_RELEASE" in script
     assert "assert_ssh_host" in script
     assert "assert_ssh_repo" in script
     assert "assert_debian_host" in script
@@ -71,6 +74,7 @@ def test_release_debian_script_normalizes_csv_tokens() -> None:
 
     assert "[![:space:]]" in script
     assert "join_csv" in script
+    assert 'while [[ "${csv}" == *, ]]' in script
     assert 'BACKENDS_CSV="$(normalize_backends "${BACKENDS_CSV}")"' in script
     assert 'PACKAGES_CSV="$(normalize_packages "${PACKAGES_CSV}")"' in script
 

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -35,6 +35,10 @@ def test_release_windows_script_has_deterministic_preflight_and_report() -> None
     assert '$Command -notin @("git", "uv")' in script
     assert script.index('Assert-Tool "git"') < script.index("$repoRoot = Resolve-RepoRoot")
     assert script.index('Assert-Tool "uv"') < script.index("$repoRoot = Resolve-RepoRoot")
+    assert '($selectedBackends -contains "pyoxidizer")' in script
+    assert script.index('Assert-Tool "rcedit.exe"') > script.index(
+        "$selectedBackends = Get-SelectedBackends $Backend"
+    )
     assert "Assert-CleanReleaseWorkspace" in script
     assert "AllowDirty" not in script
     assert "Get-GitHead" in script
@@ -55,7 +59,7 @@ def test_release_windows_script_calls_only_windows_build_wrappers() -> None:
     assert "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in script
     assert "Get-FileHash" in script
     assert "functional_cli_check" in script
-    assert "version_check" in script
+    assert "gui_version_check" in script
 
 
 def test_release_windows_script_exposes_backend_scorecard() -> None:

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from main import _get_project_root
+
+
+PROJECT_ROOT = Path(_get_project_root())
+SCRIPT = PROJECT_ROOT / "dev_env" / "build" / "release_windows.ps1"
+
+
+def _script_text() -> str:
+    assert SCRIPT.is_file()
+    return SCRIPT.read_text(encoding="utf-8")
+
+
+def test_release_windows_script_is_powershell_only_and_interactive() -> None:
+    script = _script_text()
+
+    assert "param(" in script
+    assert '[ValidateSet("pyinstaller", "nuitka", "pyoxidizer", "all")]' in script
+    assert "Read-Host" in script
+    assert "Assert-WindowsHost" in script
+    assert "Assert-PowerShellHost" in script
+    assert "bash " not in script
+    assert "wsl " not in script
+    assert ".sh" not in script
+
+
+def test_release_windows_script_has_deterministic_preflight_and_report() -> None:
+    script = _script_text()
+
+    assert "Assert-Tool" in script
+    assert "Assert-CleanReleaseWorkspace" in script
+    assert "AllowDirty" not in script
+    assert "Get-GitHead" in script
+    assert "Write-ReleaseReport" in script
+    assert "release_report_windows_amd64.json" in script
+    assert "$PSVersionTable" in script
+    assert "[System.Diagnostics.FileVersionInfo]" in script
+
+
+def test_release_windows_script_calls_only_windows_build_wrappers() -> None:
+    script = _script_text()
+
+    assert "build_pyinstaller.bat" in script
+    assert "build_nuitka.bat" in script
+    assert "build_pyoxidizer.bat" in script
+    assert "scripts\\create_distribution.py" in script
+    assert "build_info.json" in script
+    assert "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in script
+    assert "Get-FileHash" in script
+    assert "functional_cli_check" in script
+    assert "version_check" in script
+
+
+def test_release_windows_script_exposes_backend_scorecard() -> None:
+    script = _script_text()
+
+    assert "Get-BackendScorecard" in script
+    assert "security_score" in script
+    assert "python_source_exposure_score" in script
+    assert "easy_user_dirs_score" in script
+    assert "package_size_score" in script

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -10,7 +10,8 @@ SCRIPT = PROJECT_ROOT / "dev_env" / "build" / "release_windows.ps1"
 
 
 def _script_text() -> str:
-    assert SCRIPT.is_file()
+    if not SCRIPT.is_file():
+        raise AssertionError(f"script ausente: {SCRIPT}")
     return SCRIPT.read_text(encoding="utf-8")
 
 
@@ -31,6 +32,9 @@ def test_release_windows_script_has_deterministic_preflight_and_report() -> None
     script = _script_text()
 
     assert "Assert-Tool" in script
+    assert '$Command -notin @("git", "uv")' in script
+    assert script.index('Assert-Tool "git"') < script.index("$repoRoot = Resolve-RepoRoot")
+    assert script.index('Assert-Tool "uv"') < script.index("$repoRoot = Resolve-RepoRoot")
     assert "Assert-CleanReleaseWorkspace" in script
     assert "AllowDirty" not in script
     assert "Get-GitHead" in script

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -70,3 +70,15 @@ def test_release_windows_script_exposes_backend_scorecard() -> None:
     assert "python_source_exposure_score" in script
     assert "easy_user_dirs_score" in script
     assert "package_size_score" in script
+
+
+def test_release_windows_backend_paths_are_grouped_expressions() -> None:
+    script = _script_text()
+    backend_block = script.split("function Get-BackendConfig", 1)[1].split(
+        "function Invoke-CheckedProcess", 1
+    )[0]
+
+    for line in backend_block.splitlines():
+        stripped = line.strip()
+        if "Join-Path $RepoRoot" in stripped:
+            assert stripped.startswith(("(", "build_script = (", "cli_exe = (", "gui_exe = (", "source = (", "zip = ("))

--- a/tests/test_remove_emojis_script.py
+++ b/tests/test_remove_emojis_script.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.remove_emojis import remove_emojis_from_text
+
+
+def test_remove_emojis_ps1_preserves_non_emoji_supplementary_chars(
+    tmp_path: Path,
+) -> None:
+    shell = shutil.which("pwsh") or shutil.which("powershell")
+    if shell is None:
+        pytest.skip("PowerShell is not available")
+
+    script_path = Path("scripts/remove_emojis.ps1").resolve()
+    sample_path = tmp_path / "sample.md"
+    non_emoji = chr(0x20000)
+    technical_symbol = chr(0x2713)
+    emoji = chr(0x1F600)
+    sample_path.write_text(
+        f"keep {non_emoji} keep-symbol {technical_symbol} remove {emoji}",
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [
+            shell,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script_path),
+            "-Root",
+            str(tmp_path),
+            "-Includes",
+            "*.md",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    cleaned = sample_path.read_text(encoding="utf-8")
+    assert non_emoji in cleaned
+    assert technical_symbol in cleaned
+    assert emoji not in cleaned
+
+
+def test_remove_emojis_py_preserves_technical_symbols_and_non_emoji_planes() -> None:
+    non_emoji = chr(0x20000)
+    technical_symbol = chr(0x2713)
+    emoji = chr(0x1F600)
+
+    cleaned = remove_emojis_from_text(
+        f"keep {non_emoji} keep-symbol {technical_symbol} remove {emoji}"
+    )
+
+    assert non_emoji in cleaned
+    assert technical_symbol in cleaned
+    assert emoji not in cleaned

--- a/tests/test_rescan_worker_advanced.py
+++ b/tests/test_rescan_worker_advanced.py
@@ -29,6 +29,7 @@ if project_root not in sys.path:
 
 from gui.workers.rescan_worker import RescanOutcome  # noqa: E402
 from gui.workers.rescan_worker import RescanWorker, _LogHandler  # noqa: E402
+from utils import path_safety  # noqa: E402
 
 # =============================================================================
 # Fixtures
@@ -52,6 +53,28 @@ def rescan_worker(qapp):
     # Cleanup
     if worker._logger_attached:
         worker._detach_logger()
+
+
+def test_rescan_worker_accepts_explicit_external_source_file(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    source = outside_root / "entrada.xlsx"
+    source.write_text("payload", encoding="utf-8")
+    monkeypatch.setattr(path_safety, "ALLOWED_ROOTS", [runtime_root])
+
+    worker = RescanWorker(
+        main_py_path=str(runtime_root / "main.py"),
+        project_root=str(runtime_root),
+        source_files=(str(source),),
+    )
+
+    assert worker._resolve_source_files() == (str(source.resolve()),)
 
 
 @pytest.fixture

--- a/tests/test_rescan_worker_advanced.py
+++ b/tests/test_rescan_worker_advanced.py
@@ -620,6 +620,33 @@ class TestRescanWorkerIntegration:
 
                 assert call_kwargs["data_dir"] == str(active_db.parent)
                 assert call_kwargs["db_name"] == active_db.name
+                assert call_kwargs["extra_allowed_roots"] == (str(active_db.parent),)
+        finally:
+            if worker._logger_attached:
+                worker._detach_logger()
+
+    @staticmethod
+    def test_run_passes_external_active_db_parent_as_allowed_root(tmp_path):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        active_db = tmp_path / "selected_db" / "custom.sqlite"
+        active_db.parent.mkdir()
+        active_db.write_bytes(b"")
+        worker = RescanWorker(
+            main_py_path=str(project_root / "main.py"),
+            project_root=str(project_root),
+            db_path=str(active_db),
+        )
+        try:
+            with patch("gui.workers.rescan_worker.run_importer_logic") as mock_importer:
+                mock_importer.return_value = True
+                worker.run()
+
+                call_kwargs = mock_importer.call_args[1]
+
+                assert call_kwargs["data_dir"] == str(active_db.parent)
+                assert call_kwargs["db_name"] == active_db.name
+                assert call_kwargs["extra_allowed_roots"] == (str(active_db.parent),)
         finally:
             if worker._logger_attached:
                 worker._detach_logger()

--- a/tests/test_rescan_worker_advanced.py
+++ b/tests/test_rescan_worker_advanced.py
@@ -21,6 +21,7 @@ pytest.importorskip(
 from PyQt6.QtWidgets import QApplication
 
 from utils.path_safety import reserve_unique_path  # noqa: E402
+from core import import_staging
 from core.import_staging import stage_external_import_files
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -75,6 +76,44 @@ def test_rescan_worker_accepts_explicit_external_source_file(
     )
 
     assert worker._resolve_source_files() == (str(source.resolve()),)
+
+
+def test_rescan_worker_normalizes_explicit_allowlist_once(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    sources = (outside_root / "one.xlsx", outside_root / "two.xlsx")
+    for source in sources:
+        source.write_text("payload", encoding="utf-8")
+    monkeypatch.setattr(path_safety, "ALLOWED_ROOTS", [runtime_root])
+
+    original_normalize = import_staging._normalize_explicit_allowed_files
+    calls = 0
+
+    def counting_normalize(extra_allowed_files):
+        nonlocal calls
+        calls += 1
+        return original_normalize(extra_allowed_files)
+
+    monkeypatch.setattr(
+        import_staging,
+        "_normalize_explicit_allowed_files",
+        counting_normalize,
+    )
+
+    worker = RescanWorker(
+        main_py_path=str(runtime_root / "main.py"),
+        project_root=str(runtime_root),
+        source_files=tuple(str(source) for source in sources),
+    )
+
+    assert worker._resolve_source_files() == tuple(str(source.resolve()) for source in sources)
+    assert calls == 1
 
 
 @pytest.fixture

--- a/tests/test_rescan_worker_advanced.py
+++ b/tests/test_rescan_worker_advanced.py
@@ -561,6 +561,29 @@ class TestRescanWorkerIntegration:
             assert callable(call_kwargs["should_cancel"])
             assert callable(call_kwargs["progress_callback"])
 
+    def test_run_calls_importer_with_active_db_path(self, tmp_path):
+        active_db = tmp_path / "alternate_db" / "custom.sqlite"
+        active_db.parent.mkdir()
+        active_db.write_bytes(b"")
+        worker = RescanWorker(
+            main_py_path=str(tmp_path / "main.py"),
+            project_root=str(tmp_path),
+            db_path=str(active_db),
+        )
+        try:
+            with patch("gui.workers.rescan_worker.run_importer_logic") as mock_importer:
+                mock_importer.return_value = True
+                worker.run()
+
+                mock_importer.assert_called_once()
+                call_kwargs = mock_importer.call_args[1]
+
+                assert call_kwargs["data_dir"] == str(active_db.parent)
+                assert call_kwargs["db_name"] == active_db.name
+        finally:
+            if worker._logger_attached:
+                worker._detach_logger()
+
     def test_run_calls_importer_with_explicit_files(self, tmp_path):
         """Testa que run() encaminha explicit_files no modo de importacao explicita."""
         docs_dir = tmp_path / "docs_entrada"

--- a/tests/test_rescan_worker_advanced.py
+++ b/tests/test_rescan_worker_advanced.py
@@ -561,7 +561,8 @@ class TestRescanWorkerIntegration:
             assert callable(call_kwargs["should_cancel"])
             assert callable(call_kwargs["progress_callback"])
 
-    def test_run_calls_importer_with_active_db_path(self, tmp_path):
+    @staticmethod
+    def test_run_calls_importer_with_active_db_path(tmp_path):
         active_db = tmp_path / "alternate_db" / "custom.sqlite"
         active_db.parent.mkdir()
         active_db.write_bytes(b"")

--- a/utils/caching.py
+++ b/utils/caching.py
@@ -39,10 +39,8 @@ def _atomic_write_json(cache: Dict[str, Any], cache_file: str) -> None:
     tmp_path = None
     try:
         fd, tmp_path = tempfile.mkstemp(prefix=f".{base_name}.tmp.", dir=target_dir)
-        # Close raw descriptor before reopen to avoid leaks on fdopen/open errors.
-        os.close(fd)
-        fd = None
-        with open(tmp_path, "w", encoding="utf-8") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            fd = None
             json.dump(cache, f, indent=4)
             f.flush()
             try:
@@ -167,9 +165,27 @@ def _acquire_cache_lock(lock_path: str) -> int:
             try:
                 os.write(lock_fd, f"{os.getpid()}\n".encode("ascii", "ignore"))
             except OSError as exc:
-                logger.debug(
-                    "Failed to write cache lock metadata '%s': %s", lock_path, exc
-                )
+                try:
+                    os.close(lock_fd)
+                except OSError as close_exc:
+                    logger.warning(
+                        "Failed to close partial cache lock descriptor '%s': %s",
+                        lock_path,
+                        close_exc,
+                    )
+                try:
+                    os.remove(lock_path)
+                except FileNotFoundError:
+                    pass
+                except OSError as cleanup_exc:
+                    logger.warning(
+                        "Failed to remove partial cache lock file '%s': %s",
+                        lock_path,
+                        cleanup_exc,
+                    )
+                raise RuntimeError(
+                    f"Failed to write cache lock metadata '{lock_path}': {exc}"
+                ) from exc
             return lock_fd
         except FileExistsError:
             if _recover_stale_cache_lock(lock_path):
@@ -190,12 +206,18 @@ def _release_cache_lock(lock_fd: int, lock_path: str) -> None:
     except OSError as exc:
         logger.warning("Failed to close cache lock descriptor '%s': %s", lock_path, exc)
 
-    try:
-        os.remove(lock_path)
-    except FileNotFoundError:
-        return
-    except OSError as exc:
-        logger.warning("Failed to remove cache lock file '%s': %s", lock_path, exc)
+    deadline = time.monotonic() + _CACHE_LOCK_TIMEOUT_SEC
+    while True:
+        try:
+            os.remove(lock_path)
+            return
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            if time.monotonic() >= deadline:
+                logger.warning("Failed to remove cache lock file '%s': %s", lock_path, exc)
+                return
+            time.sleep(_CACHE_LOCK_RETRY_SEC)
 
 
 def _merge_cache_updates(cache_updates: Dict[str, Any], cache_file: str) -> None:

--- a/utils/caching.py
+++ b/utils/caching.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from utils.file_metadata import best_datetime_for_file
+from utils.path_safety import ensure_path_is_allowed
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +71,14 @@ def _atomic_write_json(cache: Dict[str, Any], cache_file: str) -> None:
 
 def _cache_lock_path(cache_file: str) -> str:
     """Return sidecar lock path used to serialize cache writes across processes."""
-    return f"{cache_file}.lock"
+    lock_path = f"{cache_file}.lock"
+    return str(
+        ensure_path_is_allowed(
+            lock_path,
+            purpose="cache_lock",
+            expect_directory=False,
+        )
+    )
 
 
 def _read_lock_pid(lock_path: str) -> Optional[int]:


### PR DESCRIPTION
## Escopo

Este PR leva `dev` para `main` com as correcoes acumuladas do ciclo v4.37:

- correcoes de paths frozen para docs e build_info em Windows/Debian
- inclusao do guia de migracao nos artefatos PyInstaller, Nuitka e PyOxidizer
- suporte a fontes externas explicitas no fluxo de importacao
- melhoria de performance no detalhe de SSA com derivadas
- ajuste de build/packaging Debian AMD64 e scripts ARM64 relacionados
- hardening de staging dos pacotes Debian para evitar conteudo indevido

## Validacao local ja executada

- shellcheck: passou
- bash -n: passou
- py_compile: passou
- ruff: passou
- ty: passou
- pytest focado build/import/derivadas/startup: 237 passed, 1 skipped
- pytest extra path/import/rescan: 60 passed, 1 skipped
- smokes Windows AMD64: PyInstaller CLI, Nuitka CLI, PyOxidizer version passaram
- smokes Debian AMD64: PyInstaller CLI, Nuitka CLI, PyOxidizer version passaram
- release v4.37 verificada com 32 assets

## Bloqueios antes de merge/release final

A suite completa local ainda nao esta verde:

- 1466 passed, 2 skipped, 9 failed
- falhas atuais: permissoes POSIX em Windows, PIL ausente, contratos antigos de header/layout, newline CSV e launcher Linux

A tag/release `v4.37` ainda nao deve ser movida neste PR automaticamente.
Depois das correcoes e merge aprovados, moveremos `v4.37` para o commit final escolhido e rebuildaremos os artefatos que precisarem apontar para esse commit em `build_info.json`.

## Risco conhecido

Alguns artefatos publicados ja contem as correcoes operacionais, mas `config/build_info.json` de artefatos locais/publicados aponta para commits anteriores ao commit final de empacotamento. Para rastreabilidade perfeita, sera necessario rebuild completo apos o commit final.

## Summary by Sourcery

Integrar as correções de estabilidade da v4.37 em `main`, melhorando metadados de runtime congelado, segurança de importação externa, desempenho de derivadas SSA e empacotamento Debian para AMD64 e ARM64.

New Features:
- Adicionar Debian ARM64 como alvo de compilação e empacotamento de primeira classe em PyInstaller, Nuitka, PyOxidizer e scripts de distribuição.

Bug Fixes:
- Corrigir a resolução do guia de instalação e do `build_info.json` em runtimes congelados (PyInstaller, Nuitka, PyOxidizer) para que o guia seja aberto corretamente e os diálogos "Sobre" exibam metadados de build precisos.
- Permitir que arquivos externos selecionados explicitamente fora das raízes confiáveis sejam preparados (staged) e reanalisados com segurança sem quebrar o endurecimento de caminhos já existente.
- Reforçar os testes de preparação de importação no Windows, pulando casos que dependem da semântica de `os.replace` exclusiva de POSIX.
- Resolver builds Debian do Nuitka no WSL utilizando venvs nativos, instalação serializada do `patchelf` e diretórios de trabalho isolados para evitar problemas de permissão e cache.
- Garantir que builds Debian do PyOxidizer incorporem um `build_info.json` atualizado e consigam localizar o diretório de instalação de forma confiável tanto em amd64 quanto em arm64.

Enhancements:
- Acelerar as views detalhadas de derivadas SSA e a renderização de árvores, armazenando em cache relações de família e minimizando varreduras de dataframes por nó e construção de índices.
- Enriquecer o diálogo "Sobre" com metadados embutidos de `build_info` (commit, data/hora do build, versão do `uv`) e melhorar o logging quando a resolução da versão do `uv` falhar.
- Unificar a geração do `build_info.json` entre os pipelines do PyInstaller, Nuitka e PyOxidizer, e incluir o guia de migração e o `build_info` em todos os artefatos empacotados e distribuições ZIP.
- Ensinar o builder multiplataforma e scripts auxiliares a derivar plataformas suportadas dinamicamente, emitir `build_info.json` por build, incluir o guia de migração em bundles do PyInstaller e otimizar o cálculo de tamanho de diretórios de manifesto.
- Introduzir helpers compartilhados de empacotamento Debian que reforçam locais seguros de staging, removem dados locais dos pacotes e compartilham detecção de versão e arquitetura entre fluxos de `.deb` e AppImage.

Build:
- Estender os scripts de build Debian para suportar ARM64 para PyInstaller, Nuitka e PyOxidizer, incluindo requisitos por arquitetura, gerenciamento de venv, locais temporários cientes de WSL e logs específicos por plataforma.
- Atualizar os scripts de build do Nuitka e do PyOxidizer no Windows para gerar `build_info.json`, preparar o guia de migração e reforçar a descoberta do vinculador (linker) MSVC para builds mais confiáveis.
- Adaptar as configs `pyoxidizer.bzl` para incluir `build_info.json` e o guia de migração, ao mesmo tempo excluindo artefatos transitórios do launcher e venvs da imagem de instalação.

Documentation:
- Atualizar os guias de build e distribuição para documentar o suporte a Debian ARM64, fluxos manuais de `.deb`/AppImage para ambas as arquiteturas Debian e a presença esperada do guia de migração e do `build_info` nos artefatos.
- Registrar atualizações de recuperação/backlog para o ciclo v4.37, incluindo mitigação de rede WSL/VPN, ajustes nas barreiras de teste e correções de caminhos congelados para Windows 11.

Tests:
- Adicionar cobertura para uso de `build_info` embutido, caminhos internos do PyInstaller, resolução do guia de instalação empacotado e regressões de desempenho de derivadas SSA em testes de GUI.
- Estender as suítes de teste para scripts de build, builder multiplataforma, helpers de empacotamento Debian e criação de distribuição, para verificar a inclusão de docs e `build_info` e reforçar o comportamento ciente de arquitetura.
- Adicionar testes garantindo que o staging de importações externas e workers de reanálise aceitam arquivos selecionados explicitamente e preservam corretamente dados de origem e preparados em cenários de falha.

Chores:
- Introduzir scripts de orquestração de empacotamento Debian e helpers comuns para padronizar a geração de `.deb` e AppImage para amd64 e arm64, e adicionar configuração de plataforma e requisitos para Debian ARM64.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate v4.37 stability fixes into main, improving frozen runtime metadata, external import safety, SSA derivatives performance, and Debian packaging across AMD64 and ARM64.

New Features:
- Add Debian ARM64 as a first-class build and packaging target across PyInstaller, Nuitka, PyOxidizer, and distribution scripts.

Bug Fixes:
- Fix resolution of the installation guide and build_info.json in frozen runtimes (PyInstaller, Nuitka, PyOxidizer) so the guide opens correctly and about dialogs show accurate build metadata.
- Allow explicitly selected external files outside trusted roots to be staged and rescanned safely without breaking existing path hardening.
- Harden import staging tests on Windows by skipping cases that rely on POSIX-only os.replace semantics.
- Resolve Nuitka Debian builds on WSL by using native venvs, serialized patchelf installation, and isolated work directories to avoid permission and caching issues.
- Ensure Debian PyOxidizer builds embed fresh build_info.json and can locate the install directory reliably on both amd64 and arm64.

Enhancements:
- Speed up SSA derivatives detail views and tree rendering by caching family relationships and minimizing per-node dataframe scans and index construction.
- Enrich the About dialog with embedded build_info metadata (commit, build datetime, uv version) and improve logging when uv version resolution fails.
- Unify build_info.json generation across PyInstaller, Nuitka, and PyOxidizer pipelines, and include the migration guide and build_info in all packaged artifacts and ZIP distributions.
- Teach the multiplatform builder and helper scripts to derive supported platforms dynamically, emit per-build build_info.json, include the migration guide in PyInstaller bundles, and optimize manifest directory size calculations.
- Introduce shared Debian packaging helpers that enforce safe staging locations, strip local data from packages, and share version and architecture detection between .deb and AppImage flows.

Build:
- Extend Debian build scripts to support ARM64 for PyInstaller, Nuitka, and PyOxidizer, including per-arch requirements, venv management, WSL-aware temp locations, and platform-specific logs.
- Update Windows Nuitka and PyOxidizer build scripts to generate build_info.json, stage the migration guide, and enforce MSVC linker discovery for more reliable builds.
- Adapt pyoxidizer.bzl configs to include build_info.json and the migration guide while excluding transient launcher artifacts and venvs from the install image.

Documentation:
- Refresh build and distribution guides to document Debian ARM64 support, manual .deb/AppImage flows for both Debian architectures, and the expected presence of the migration guide and build_info in artifacts.
- Record recovery/backlog updates for the v4.37 cycle, including WSL/VPN networking mitigation, test gate adjustments, and frozen path fixes for Windows 11.

Tests:
- Add coverage for embedded build_info usage, PyInstaller internal paths, bundled installation guide resolution, and SSA derivatives performance regressions in GUI tests.
- Extend test suites for build scripts, multiplatform builder, Debian packaging helpers, and distribution creation to assert inclusion of docs and build_info and enforce architecture-aware behavior.
- Add tests ensuring external import staging and rescan workers accept explicitly selected files and preserve source and staged data correctly under failure scenarios.

Chores:
- Introduce Debian packaging orchestration scripts and common helpers to standardize .deb and AppImage generation for amd64 and arm64, and add Debian ARM64 platform config and requirements.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the v4.37 stability patch: safer external import/rescan, faster SSA derivatives and details, GUI adds “Situação da Parcial”, hardened About with embedded build info and safe `uv` resolution, Debian ARM64 builds and Debian packaging (.deb/AppImage), embedded build/version metadata, and deterministic Debian/Windows release orchestrators.

- **Bug Fixes**
  - External imports: allow explicitly selected files via `extra_allowed_files`; rescan worker accepts active DB `db_path`; staging and tests hardened on Windows/WSL.
  - GUI/data: macro filters wait for Apply; details view falls back to global index, preserves relation metadata, ignores invalid types; DB‑only derivadas progress shows “banco atual”.
  - About/paths: read embedded `build_info.json`; resolve `uv` via PATH with better logging; frozen guide/docs paths fixed across backends; CSV exports force LF via `lineterminator`; `.gitattributes` enforces LF for `.sh`, `.bash`, `.envrc`.
  - Test hygiene: optional `Pillow`, platform‑aware skips, safer typing/casts and private attr access; small DeepSource cleanups.

- **New Features**
  - Debian ARM64 support for `pyinstaller`, `nuitka`, and `pyoxidizer`; platform registry derives supported platforms; per‑arch requirements and venvs for deterministic builds.
  - Debian packaging engines for `.deb` and AppImage with AMD64/ARM64 wrappers, shared staging/validation, and exclusion of transient launcher/venv artifacts.
  - Deterministic Debian and Windows release orchestrators with interactive mode, environment preflight, sequential backend execution, artifact validation, and consolidated report (`release_debian_report.py`).
  - Ship `docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md` and `config/build_info.json` in all installers and ZIPs; builders embed build/version metadata across artifacts.

<sup>Written for commit b0b04fac6b7d99a28bdb2d08aad100779948fd8e. Summary will update on new commits. <a href="https://cubic.dev/pr/mauriciomenon/SSA_Consulta_Rapida/pull/56?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for building and releasing on Debian ARM64 platform.
  * Embedded build metadata (version, timestamp, commit info) into application releases.
  * Added new "Situacao da Parcial" field to GUI display options.

* **Bug Fixes**
  * Improved installation guide lookup to support multiple bundled locations.
  * Enhanced path validation and file permission security for staged imports.
  * Strengthened cache lock reliability with better error handling and cleanup.

* **Documentation**
  * Added comprehensive build and release runbooks for multi-platform workflows.
  * Updated distribution guides with platform-specific packaging instructions.

* **Chores**
  * Added build system infrastructure for deterministic Windows and Debian releases.
  * Expanded automated test coverage for packaging and build scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->