### PR TITLE
STABILITY_PATCH: align Actions hardening

### DIFF
--- a/.github/CODE_QUALITY.md
+++ b/.github/CODE_QUALITY.md
@@ -19,7 +19,7 @@ This repository separates blocking local/CI checks from external advisory servic
 
 - `.github/workflows/minimal-ci.yml`: Python import/lint/test gate for the supported project scope.
 - `.github/workflows/codeql.yml`: GitHub CodeQL security scan.
-- `.github/workflows/secret_scan.yml`: secret scan jobs configured as non-blocking with `continue-on-error`.
+- `.github/workflows/secret_scan.yml`: blocking workspace and PR diff secret scans; history scan is advisory and only runs on schedule/manual dispatch.
 - `.deepsource.toml`: local analyzer configuration only; it does not decide whether the GitHub App blocks a PR.
 
 ## External Advisory Services

--- a/.github/actions/configure-qwen-opencode/action.yml
+++ b/.github/actions/configure-qwen-opencode/action.yml
@@ -10,6 +10,7 @@ runs:
         QWEN_API_KEY: ${{ env.QWEN_API_KEY }}
       run: |
         set -euo pipefail
+        umask 077
         mkdir -p "${HOME}/.config/opencode"
         python - <<'PY'
         import json
@@ -46,3 +47,4 @@ runs:
         target = Path.home() / ".config" / "opencode" / "opencode.json"
         target.write_text(json.dumps(config, indent=2), encoding="utf-8")
         PY
+        chmod 600 "${HOME}/.config/opencode/opencode.json"

--- a/.github/actions/configure-qwen-opencode/action.yml
+++ b/.github/actions/configure-qwen-opencode/action.yml
@@ -1,0 +1,48 @@
+name: Configure Qwen opencode provider
+description: Write the opencode provider config for Qwen Coding Plan.
+
+runs:
+  using: composite
+  steps:
+    - name: Write Qwen provider config
+      shell: bash
+      env:
+        QWEN_API_KEY: ${{ env.QWEN_API_KEY }}
+      run: |
+        set -euo pipefail
+        mkdir -p "${HOME}/.config/opencode"
+        python - <<'PY'
+        import json
+        import os
+        from pathlib import Path
+
+        api_key = os.environ["QWEN_API_KEY"]
+        config = {
+            "$schema": "https://opencode.ai/config.json",
+            "provider": {
+                "qwen-cloud-coding-plan": {
+                    "npm": "@ai-sdk/anthropic",
+                    "name": "Qwen Cloud Coding Plan",
+                    "options": {
+                        "baseURL": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1",
+                        "apiKey": api_key,
+                    },
+                    "models": {
+                        "qwen3-coder-plus": {
+                            "name": "Qwen3 Coder Plus",
+                            "modalities": {
+                                "input": ["text"],
+                                "output": ["text"],
+                            },
+                            "limit": {
+                                "context": 1000000,
+                                "output": 65536,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        target = Path.home() / ".config" / "opencode" / "opencode.json"
+        target.write_text(json.dumps(config, indent=2), encoding="utf-8")
+        PY

--- a/.github/actions/opencode-github/action.yml
+++ b/.github/actions/opencode-github/action.yml
@@ -53,6 +53,12 @@ runs:
       shell: bash
       run: echo "$HOME/.opencode/npm/bin" >> "${GITHUB_PATH}"
 
+    - name: Configure Git identity
+      shell: bash
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
     - name: Run opencode
       shell: bash
       id: run_opencode

--- a/.github/actions/opencode-github/action.yml
+++ b/.github/actions/opencode-github/action.yml
@@ -17,7 +17,7 @@ inputs:
   use_github_token:
     description: Use GITHUB_TOKEN directly instead of OpenCode App token exchange.
     required: false
-    default: "false"
+    default: "true"
   mentions:
     description: Comma-separated list of trigger phrases.
     required: false
@@ -63,6 +63,7 @@ runs:
         SHARE: ${{ inputs.share }}
         PROMPT: ${{ inputs.prompt }}
         USE_GITHUB_TOKEN: ${{ inputs.use_github_token }}
+        GITHUB_TOKEN: ${{ github.token }}
         MENTIONS: ${{ inputs.mentions }}
         VARIANT: ${{ inputs.variant }}
         OIDC_BASE_URL: ${{ inputs.oidc_base_url }}

--- a/.github/actions/opencode-github/action.yml
+++ b/.github/actions/opencode-github/action.yml
@@ -53,16 +53,10 @@ runs:
       shell: bash
       run: echo "$HOME/.opencode/npm/bin" >> "${GITHUB_PATH}"
 
-    - name: Configure Git identity
-      shell: bash
-      run: |
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-    - name: Run opencode
+    - name: Run opencode review
       shell: bash
       id: run_opencode
-      run: opencode github run
+      run: python scripts/ci/opencode_pr_review.py
       env:
         MODEL: ${{ inputs.model }}
         AGENT: ${{ inputs.agent }}
@@ -70,6 +64,7 @@ runs:
         PROMPT: ${{ inputs.prompt }}
         USE_GITHUB_TOKEN: ${{ inputs.use_github_token }}
         GITHUB_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ github.token }}
         MENTIONS: ${{ inputs.mentions }}
         VARIANT: ${{ inputs.variant }}
         OIDC_BASE_URL: ${{ inputs.oidc_base_url }}

--- a/.github/actions/opencode-github/action.yml
+++ b/.github/actions/opencode-github/action.yml
@@ -1,0 +1,68 @@
+name: opencode GitHub Action
+description: Run opencode in GitHub Actions workflows with pinned nested actions.
+
+inputs:
+  model:
+    description: Model to use.
+    required: true
+  agent:
+    description: Agent to use.
+    required: false
+  share:
+    description: Share the opencode session.
+    required: false
+  prompt:
+    description: Custom prompt to override the default prompt.
+    required: false
+  use_github_token:
+    description: Use GITHUB_TOKEN directly instead of OpenCode App token exchange.
+    required: false
+    default: "false"
+  mentions:
+    description: Comma-separated list of trigger phrases.
+    required: false
+  variant:
+    description: Model variant for provider-specific reasoning effort.
+    required: false
+  oidc_base_url:
+    description: Base URL for OIDC token exchange API.
+    required: false
+  opencode_version:
+    description: Pinned opencode-ai npm package version to install.
+    required: false
+    default: "1.14.33"
+
+runs:
+  using: composite
+  steps:
+    - name: Cache opencode
+      id: cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.opencode/npm
+        key: opencode-${{ runner.os }}-${{ runner.arch }}-${{ inputs.opencode_version }}
+
+    - name: Install opencode
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        npm install --global --prefix "$HOME/.opencode/npm" "opencode-ai@${{ inputs.opencode_version }}" --no-audit --no-fund
+
+    - name: Add opencode to PATH
+      shell: bash
+      run: echo "$HOME/.opencode/npm/bin" >> "${GITHUB_PATH}"
+
+    - name: Run opencode
+      shell: bash
+      id: run_opencode
+      run: opencode github run
+      env:
+        MODEL: ${{ inputs.model }}
+        AGENT: ${{ inputs.agent }}
+        SHARE: ${{ inputs.share }}
+        PROMPT: ${{ inputs.prompt }}
+        USE_GITHUB_TOKEN: ${{ inputs.use_github_token }}
+        MENTIONS: ${{ inputs.mentions }}
+        VARIANT: ${{ inputs.variant }}
+        OIDC_BASE_URL: ${{ inputs.oidc_base_url }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,6 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 jobs:
   precheck-default-setup:
@@ -66,6 +65,10 @@ jobs:
     if: ${{ needs.precheck-default-setup.outputs.run_advanced == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -78,6 +81,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,12 @@ jobs:
             "${API_URL}" || true)"
 
           if [ "${HTTP_CODE}" = "200" ]; then
-            STATE="$(jq -r '.state // .status // "unknown"' default_setup.json)"
+            if STATE="$(jq -r '.state // .status // "unknown"' default_setup.json 2>/dev/null)"; then
+              :
+            else
+              STATE="unknown"
+              echo "Could not parse CodeQL default setup response; running advanced scan." >&2
+            fi
             if [ "${STATE}" = "configured" ] || [ "${STATE}" = "enabled" ]; then
               RUN_ADVANCED="false"
               REASON="default_setup_active"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,8 +33,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          RUN_ADVANCED="false"
-          REASON="default_setup_unverified"
+          RUN_ADVANCED="true"
+          REASON="advanced_allowed_default_setup_unverified"
           API_URL="https://api.github.com/repos/${REPO}/code-scanning/default-setup"
           HTTP_CODE="$(curl -sS --connect-timeout 5 --max-time 10 -o default_setup.json -w "%{http_code}" \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
@@ -54,8 +54,8 @@ jobs:
               exit 1
             fi
           else
-            echo "Could not verify CodeQL default setup state: HTTP ${HTTP_CODE}" >&2
-            exit 1
+            echo "Could not verify CodeQL default setup state: HTTP ${HTTP_CODE}; running advanced scan." >&2
+            REASON="advanced_allowed_default_setup_unverified_http_${HTTP_CODE}"
           fi
 
           echo "run_advanced=${RUN_ADVANCED}" >> "${GITHUB_OUTPUT}"
@@ -92,7 +92,7 @@ jobs:
         with:
           category: "/language:${{ matrix.language }}"
 
-  default-setup-note:
+  default-setup-skip-note:
     needs: precheck-default-setup
     if: ${{ needs.precheck-default-setup.outputs.run_advanced != 'true' }}
     runs-on: ubuntu-latest
@@ -102,10 +102,10 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Skip advanced scan due to default setup
+      - name: Report default setup skip
         env:
           CODEQL_SKIP_REASON: ${{ needs.precheck-default-setup.outputs.reason }}
         run: |
           set -euo pipefail
-          echo "CodeQL advanced workflow skipped because default setup is active or verification could not be completed."
+          echo "CodeQL advanced workflow skipped because default setup is active."
           echo "Reason: ${CODEQL_SKIP_REASON}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   actions: read
   contents: read
+  security-events: read
 
 jobs:
   precheck-default-setup:
@@ -49,10 +50,14 @@ jobs:
               RUN_ADVANCED="true"
               REASON="advanced_allowed"
             else
-              echo "Unsupported CodeQL default setup state: ${STATE}" >&2
-              exit 1
+              echo "Unsupported CodeQL default setup state: ${STATE}; running advanced scan." >&2
+              SAFE_STATE="$(printf '%s' "${STATE}" | tr -c 'A-Za-z0-9_-' '_')"
+              REASON="advanced_allowed_default_setup_unknown_state_${SAFE_STATE}"
             fi
           else
+            if [ -z "${HTTP_CODE}" ]; then
+              HTTP_CODE="000"
+            fi
             echo "Could not verify CodeQL default setup state: HTTP ${HTTP_CODE}; running advanced scan." >&2
             REASON="advanced_allowed_default_setup_unverified_http_${HTTP_CODE}"
           fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,12 +30,13 @@ jobs:
         id: detect
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           RUN_ADVANCED="false"
           REASON="default_setup_unverified"
-          API_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/code-scanning/default-setup"
-          HTTP_CODE="$(curl -sS -o default_setup.json -w "%{http_code}" \
+          API_URL="https://api.github.com/repos/${REPO}/code-scanning/default-setup"
+          HTTP_CODE="$(curl -sS --connect-timeout 5 --max-time 10 -o default_setup.json -w "%{http_code}" \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "${API_URL}" || true)"
@@ -43,15 +44,18 @@ jobs:
           if [ "${HTTP_CODE}" = "200" ]; then
             STATE="$(jq -r '.state // .status // "unknown"' default_setup.json)"
             if [ "${STATE}" = "configured" ] || [ "${STATE}" = "enabled" ]; then
+              RUN_ADVANCED="false"
               REASON="default_setup_active"
             elif [ "${STATE}" = "not-configured" ] || [ "${STATE}" = "not_configured" ] || [ "${STATE}" = "disabled" ]; then
               RUN_ADVANCED="true"
               REASON="advanced_allowed"
             else
-              REASON="default_setup_state_unknown"
+              echo "Unsupported CodeQL default setup state: ${STATE}" >&2
+              exit 1
             fi
           else
-            REASON="default_setup_unverified_http_${HTTP_CODE}"
+            echo "Could not verify CodeQL default setup state: HTTP ${HTTP_CODE}" >&2
+            exit 1
           fi
 
           echo "run_advanced=${RUN_ADVANCED}" >> "${GITHUB_OUTPUT}"
@@ -99,7 +103,9 @@ jobs:
           egress-policy: audit
 
       - name: Skip advanced scan due to default setup
+        env:
+          CODEQL_SKIP_REASON: ${{ needs.precheck-default-setup.outputs.reason }}
         run: |
           set -euo pipefail
           echo "CodeQL advanced workflow skipped because default setup is active or verification could not be completed."
-          echo "Reason: ${{ needs.precheck-default-setup.outputs.reason }}"
+          echo "Reason: ${CODEQL_SKIP_REASON}"

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -7,14 +7,14 @@ on:
       - "**/*.py"
       - "pyproject.toml"
       - "requirements*.txt"
-      - ".github/workflows/minimal-ci.yml"
+      - ".github/workflows/*.yml"
   pull_request:
     branches: [main, dev]
     paths:
       - "**/*.py"
       - "pyproject.toml"
       - "requirements*.txt"
-      - ".github/workflows/minimal-ci.yml"
+      - ".github/workflows/*.yml"
 
 permissions:
   contents: read
@@ -62,18 +62,23 @@ jobs:
           uv sync --extra dev
 
       - name: Detect changed Python files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           ZERO_SHA="0000000000000000000000000000000000000000"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            BASE_SHA="${PR_BASE_SHA}"
           else
-            BASE_SHA="${{ github.event.before }}"
+            BASE_SHA="${BEFORE_SHA}"
           fi
           if [ "$BASE_SHA" = "$ZERO_SHA" ]; then
             git ls-files "*.py" > .changed_python_files
           else
-            git diff --name-only -z "$BASE_SHA" "${{ github.sha }}" -- "*.py" \
+            git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" -- "*.py" \
               | while IFS= read -r -d '' file_path; do
                   if [ -f "$file_path" ]; then
                     printf '%s\n' "$file_path"

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Python

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,6 +1,10 @@
 name: opencode
 
 on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -10,12 +14,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: opencode-${{ github.event.comment.id }}
+  group: opencode-${{ github.event_name }}-${{ github.event.comment.id || github.event.pull_request.number || github.sha }}
   cancel-in-progress: false
 
 jobs:
   noop:
     if: |
+      (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
       !(
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
         (
@@ -49,6 +54,151 @@ jobs:
     steps:
       - name: No opencode command
         run: echo "No opencode command in comment; skipping."
+
+  opencode-pr-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    environment: SECRETS
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Configure Qwen provider
+        env:
+          QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${HOME}/.config/opencode"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          api_key = os.environ["QWEN_API_KEY"]
+          config = {
+              "$schema": "https://opencode.ai/config.json",
+              "provider": {
+                  "qwen-cloud-coding-plan": {
+                      "npm": "@ai-sdk/anthropic",
+                      "name": "Qwen Cloud Coding Plan",
+                      "options": {
+                          "baseURL": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1",
+                          "apiKey": api_key,
+                      },
+                      "models": {
+                          "qwen3-coder-plus": {
+                              "name": "Qwen3 Coder Plus",
+                              "modalities": {
+                                  "input": ["text"],
+                                  "output": ["text"],
+                              },
+                              "limit": {
+                                  "context": 1000000,
+                                  "output": 65536,
+                              },
+                          },
+                      },
+                  },
+              },
+          }
+          target = Path.home() / ".config" / "opencode" / "opencode.json"
+          target.write_text(json.dumps(config, indent=2), encoding="utf-8")
+          PY
+
+      - name: Run automatic PR review
+        uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
+        with:
+          model: qwen-cloud-coding-plan/qwen3-coder-plus
+          prompt: |
+            Review this pull request for concrete bugs, security risks, CI/CD regressions, path/quoting problems, and release/build reproducibility issues.
+            Comment only on actionable findings. Do not repeat successful checks. Do not suggest broad refactors unless they block safety.
+
+  opencode-push-review:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    environment: SECRETS
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Configure Qwen provider
+        env:
+          QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${HOME}/.config/opencode"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          api_key = os.environ["QWEN_API_KEY"]
+          config = {
+              "$schema": "https://opencode.ai/config.json",
+              "provider": {
+                  "qwen-cloud-coding-plan": {
+                      "npm": "@ai-sdk/anthropic",
+                      "name": "Qwen Cloud Coding Plan",
+                      "options": {
+                          "baseURL": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1",
+                          "apiKey": api_key,
+                      },
+                      "models": {
+                          "qwen3-coder-plus": {
+                              "name": "Qwen3 Coder Plus",
+                              "modalities": {
+                                  "input": ["text"],
+                                  "output": ["text"],
+                              },
+                              "limit": {
+                                  "context": 1000000,
+                                  "output": 65536,
+                              },
+                          },
+                      },
+                  },
+              },
+          }
+          target = Path.home() / ".config" / "opencode" / "opencode.json"
+          target.write_text(json.dumps(config, indent=2), encoding="utf-8")
+          PY
+
+      - name: Run automatic push review
+        uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
+        with:
+          model: qwen-cloud-coding-plan/qwen3-coder-plus
+          prompt: |
+            Review the pushed commit range for concrete bugs, security risks, CI/CD regressions, path/quoting problems, and release/build reproducibility issues.
+            Report only actionable findings. Do not make code changes.
 
   opencode:
     if: |

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -92,6 +92,7 @@ jobs:
   opencode:
     if: |
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      (github.event_name == 'pull_request_review_comment' || github.event.issue.pull_request) &&
       (
         github.event.comment.body == '/oc' ||
         startsWith(github.event.comment.body, '/oc ') ||
@@ -128,6 +129,7 @@ jobs:
   opencode-glm:
     if: |
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      (github.event_name == 'pull_request_review_comment' || github.event.issue.pull_request) &&
       (
         github.event.comment.body == '/oc-glm' ||
         startsWith(github.event.comment.body, '/oc-glm ') ||
@@ -166,6 +168,7 @@ jobs:
   opencode-qwen:
     if: |
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      (github.event_name == 'pull_request_review_comment' || github.event.issue.pull_request) &&
       (
         github.event.comment.body == '/oc-qwen' ||
         startsWith(github.event.comment.body, '/oc-qwen ') ||

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -76,46 +76,9 @@ jobs:
           persist-credentials: false
 
       - name: Configure Qwen provider
+        uses: ./.github/actions/configure-qwen-opencode
         env:
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
-        run: |
-          set -euo pipefail
-          mkdir -p "${HOME}/.config/opencode"
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          api_key = os.environ["QWEN_API_KEY"]
-          config = {
-              "$schema": "https://opencode.ai/config.json",
-              "provider": {
-                  "qwen-cloud-coding-plan": {
-                      "npm": "@ai-sdk/anthropic",
-                      "name": "Qwen Cloud Coding Plan",
-                      "options": {
-                          "baseURL": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1",
-                          "apiKey": api_key,
-                      },
-                      "models": {
-                          "qwen3-coder-plus": {
-                              "name": "Qwen3 Coder Plus",
-                              "modalities": {
-                                  "input": ["text"],
-                                  "output": ["text"],
-                              },
-                              "limit": {
-                                  "context": 1000000,
-                                  "output": 65536,
-                              },
-                          },
-                      },
-                  },
-              },
-          }
-          target = Path.home() / ".config" / "opencode" / "opencode.json"
-          target.write_text(json.dumps(config, indent=2), encoding="utf-8")
-          PY
 
       - name: Run automatic PR review
         uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde
@@ -148,46 +111,9 @@ jobs:
           persist-credentials: false
 
       - name: Configure Qwen provider
+        uses: ./.github/actions/configure-qwen-opencode
         env:
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
-        run: |
-          set -euo pipefail
-          mkdir -p "${HOME}/.config/opencode"
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          api_key = os.environ["QWEN_API_KEY"]
-          config = {
-              "$schema": "https://opencode.ai/config.json",
-              "provider": {
-                  "qwen-cloud-coding-plan": {
-                      "npm": "@ai-sdk/anthropic",
-                      "name": "Qwen Cloud Coding Plan",
-                      "options": {
-                          "baseURL": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1",
-                          "apiKey": api_key,
-                      },
-                      "models": {
-                          "qwen3-coder-plus": {
-                              "name": "Qwen3 Coder Plus",
-                              "modalities": {
-                                  "input": ["text"],
-                                  "output": ["text"],
-                              },
-                              "limit": {
-                                  "context": 1000000,
-                                  "output": 65536,
-                              },
-                          },
-                      },
-                  },
-              },
-          }
-          target = Path.home() / ".config" / "opencode" / "opencode.json"
-          target.write_text(json.dumps(config, indent=2), encoding="utf-8")
-          PY
 
       - name: Run automatic push review
         uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde
@@ -301,47 +227,9 @@ jobs:
           persist-credentials: false
 
       - name: Configure Qwen provider
+        uses: ./.github/actions/configure-qwen-opencode
         env:
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
-        run: |
-          set -euo pipefail
-          mkdir -p "${HOME}/.config/opencode"
-          # Qwen Coding Plan is exposed through an Anthropic-compatible adapter.
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          api_key = os.environ["QWEN_API_KEY"]
-          config = {
-              "$schema": "https://opencode.ai/config.json",
-              "provider": {
-                  "qwen-cloud-coding-plan": {
-                      "npm": "@ai-sdk/anthropic",
-                      "name": "Qwen Cloud Coding Plan",
-                      "options": {
-                          "baseURL": "https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1",
-                          "apiKey": api_key,
-                      },
-                      "models": {
-                          "qwen3-coder-plus": {
-                              "name": "Qwen3 Coder Plus",
-                              "modalities": {
-                                  "input": ["text"],
-                                  "output": ["text"],
-                              },
-                              "limit": {
-                                  "context": 1000000,
-                                  "output": 65536,
-                              },
-                          },
-                      },
-                  },
-              },
-          }
-          target = Path.home() / ".config" / "opencode" / "opencode.json"
-          target.write_text(json.dumps(config, indent=2), encoding="utf-8")
-          PY
 
       - name: Run opencode with Qwen
         uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -158,7 +158,7 @@ jobs:
           PY
 
       - name: Run opencode with Qwen
-        uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a
+        uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -54,7 +54,7 @@ jobs:
         run: echo "No opencode command in comment; skipping."
 
   opencode-pr-review:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 25
     environment: SECRETS

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -14,6 +14,42 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  noop:
+    if: |
+      !(
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+        (
+          github.event.comment.body == '/oc' ||
+          startsWith(github.event.comment.body, '/oc ') ||
+          contains(github.event.comment.body, ' /oc ') ||
+          github.event.comment.body == '/opencode' ||
+          startsWith(github.event.comment.body, '/opencode ') ||
+          contains(github.event.comment.body, ' /opencode ') ||
+          github.event.comment.body == '/oc-glm' ||
+          startsWith(github.event.comment.body, '/oc-glm ') ||
+          contains(github.event.comment.body, ' /oc-glm ') ||
+          github.event.comment.body == '/glm-review' ||
+          startsWith(github.event.comment.body, '/glm-review ') ||
+          contains(github.event.comment.body, ' /glm-review ') ||
+          github.event.comment.body == '/zhipu-review' ||
+          startsWith(github.event.comment.body, '/zhipu-review ') ||
+          contains(github.event.comment.body, ' /zhipu-review ') ||
+          github.event.comment.body == '/oc-qwen' ||
+          startsWith(github.event.comment.body, '/oc-qwen ') ||
+          contains(github.event.comment.body, ' /oc-qwen ') ||
+          github.event.comment.body == '/qwen-review' ||
+          startsWith(github.event.comment.body, '/qwen-review ') ||
+          contains(github.event.comment.body, ' /qwen-review ')
+        )
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+      - name: No opencode command
+        run: echo "No opencode command in comment; skipping."
+
   opencode:
     if: |
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,8 +1,6 @@
 name: opencode
 
 on:
-  push:
-    branches: [main, dev]
   pull_request:
     branches: [main, dev]
   issue_comment:
@@ -90,41 +88,6 @@ jobs:
           prompt: |
             Review this pull request for concrete bugs, security risks, CI/CD regressions, path/quoting problems, and release/build reproducibility issues.
             Comment only on actionable findings. Do not repeat successful checks. Do not suggest broad refactors unless they block safety.
-
-  opencode-push-review:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    environment: SECRETS
-    permissions:
-      contents: read
-      issues: write
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Configure Qwen provider
-        uses: ./.github/actions/configure-qwen-opencode
-        env:
-          QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
-
-      - name: Run automatic push review
-        uses: ./.github/actions/opencode-github
-        env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
-        with:
-          model: qwen-cloud-coding-plan/qwen3-coder-plus
-          prompt: |
-            Review the pushed commit range for concrete bugs, security risks, CI/CD regressions, path/quoting problems, and release/build reproducibility issues.
-            Report only actionable findings. Do not make code changes.
 
   opencode:
     if: |

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -81,7 +81,7 @@ jobs:
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
 
       - name: Run automatic PR review
-        uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde
+        uses: ./.github/actions/opencode-github
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
@@ -116,7 +116,7 @@ jobs:
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
 
       - name: Run automatic push review
-        uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde
+        uses: ./.github/actions/opencode-github
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
@@ -156,7 +156,7 @@ jobs:
           persist-credentials: false
 
       - name: Run opencode
-        uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde
+        uses: ./.github/actions/opencode-github
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
@@ -192,7 +192,7 @@ jobs:
           persist-credentials: false
 
       - name: Run opencode with GLM
-        uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde
+        uses: ./.github/actions/opencode-github
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           ZAI_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
@@ -232,7 +232,7 @@ jobs:
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
 
       - name: Run opencode with Qwen
-        uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde
+        uses: ./.github/actions/opencode-github
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -13,9 +13,6 @@ concurrency:
   group: opencode-${{ github.event.comment.id }}
   cancel-in-progress: false
 
-env:
-  COMMENT_BODY: ${{ github.event.comment.body }}
-
 jobs:
   opencode:
     if: |
@@ -30,8 +27,8 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment: SECRETS
     permissions: &opencode_permissions
-      id-token: write
       contents: read
       pull-requests: write
       issues: write
@@ -123,6 +120,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${HOME}/.config/opencode"
+          # Qwen Coding Plan is exposed through an Anthropic-compatible adapter.
           python - <<'PY'
           import json
           import os

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Run opencode
-        uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a
+        uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
@@ -80,7 +80,7 @@ jobs:
           persist-credentials: false
 
       - name: Run opencode with GLM
-        uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a
+        uses: anomalyco/opencode/github@80f1f1b5b8535b6008af54621665738115346cde
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           ZAI_API_KEY: ${{ secrets.ZHIPU_API_KEY }}

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main, dev ]
   pull_request:
     branches: [ main, dev ]
+  schedule:
+    - cron: "30 3 * * 0"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,8 +19,6 @@ jobs:
       contents: read
       actions: read
     runs-on: ubuntu-latest
-    env:
-      SENSITIVE_PATTERN: 'sk-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|[A-Z_]+API_KEY=[A-Za-z0-9]{16,}'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -28,56 +29,17 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-          fetch-depth: 0  # precisamos do histórico para grep opcional
+          fetch-depth: 0  # required for PR and history scans
 
       - name: Filtered workspace scan
-        run: |
-          set -euo pipefail
-          echo '[INFO] Scanning for sensitive patterns'
-
-          # Scan with exclusions
-          if grep -R -E -q "$SENSITIVE_PATTERN" . \
-             --exclude-dir=.git \
-             --exclude-dir=dist \
-             --exclude-dir=build \
-             --exclude-dir=logs \
-             --exclude-dir=__pycache__ \
-             --exclude-dir=.pytest_cache \
-             --exclude-dir=.mypy_cache \
-             --exclude-dir=node_modules \
-             --exclude='*.pyc' \
-             --exclude='*.so' \
-             --exclude='*.md'; then
-            echo '[ERROR] Sensitive patterns found'
-            exit 1
-          else
-            echo '[OK] No sensitive patterns detected'
-          fi
+        run: bash scripts/security/scan_secrets.sh workspace
 
       - name: PR diff scan
         if: ${{ github.event_name == 'pull_request' }}
         env:
           BASE_REF: ${{ github.base_ref }}
-        run: |
-          set -euo pipefail
-          echo '[INFO] Scanning PR diff'
-          git fetch origin "$BASE_REF"
-
-          if git diff --unified=0 "origin/${BASE_REF}...HEAD" | grep -E '^\+[^+]' | sed 's/^+//' | grep -E -q "$SENSITIVE_PATTERN" 2>/dev/null; then
-            echo '[ERROR] Possible secret in diff'
-            exit 1
-          else
-            echo '[OK] No sensitive patterns in diff'
-          fi
+        run: bash scripts/security/scan_secrets.sh pr-diff "$BASE_REF"
 
       - name: Advisory historic scan for legacy secrets
-        run: |
-          set -euo pipefail
-          echo '[INFO] Sampling recent commits'
-
-          if git log --max-count=20 -E -G "$SENSITIVE_PATTERN" --format='%H' HEAD | grep -q .; then
-            echo '[INFO] Historical pattern found in recent commits'
-            echo '[INFO] Advisory only: current tree and PR diff scans are blocking'
-          else
-            echo '[OK] Recent history sample clean'
-          fi
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        run: bash scripts/security/scan_secrets.sh history

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -37,8 +37,8 @@ jobs:
       - name: PR diff scan
         if: ${{ github.event_name == 'pull_request' }}
         env:
-          BASE_REF: ${{ github.base_ref }}
-        run: bash scripts/security/scan_secrets.sh pr-diff "$BASE_REF"
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: bash scripts/security/scan_secrets.sh pr-diff "$BASE_SHA"
 
       - name: Advisory historic scan for legacy secrets
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -16,6 +16,8 @@ jobs:
       contents: read
       actions: read
     runs-on: ubuntu-latest
+    env:
+      SENSITIVE_PATTERN: 'sk-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|[A-Z_]+API_KEY=[A-Za-z0-9]{16,}'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -25,58 +27,55 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           fetch-depth: 0  # precisamos do histórico para grep opcional
 
-      - name: Recursive workspace scan
+      - name: Filtered workspace scan
         run: |
           set -euo pipefail
           echo '[INFO] Scanning for sensitive patterns'
-          PATTERN='sk-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|[A-Z_]+API_KEY=[A-Za-z0-9]{16,}'
 
           # Scan with exclusions
-          if grep -R -E "$PATTERN" . \
-             --exclude-dir={launchers,.git,dist,build,logs,.github,__pycache__,.pytest_cache,.mypy_cache,node_modules} \
+          if grep -R -E -q "$SENSITIVE_PATTERN" . \
+             --exclude-dir=.git \
+             --exclude-dir=dist \
+             --exclude-dir=build \
+             --exclude-dir=logs \
+             --exclude-dir=__pycache__ \
+             --exclude-dir=.pytest_cache \
+             --exclude-dir=.mypy_cache \
+             --exclude-dir=node_modules \
              --exclude='*.pyc' \
              --exclude='*.so' \
-             --exclude='*.md' \
-             --exclude='.gitleaks.toml' \
-             --exclude='test_keys.txt' \
-             --exclude='replacements.txt' 2>/dev/null; then
+             --exclude='*.md'; then
             echo '[ERROR] Sensitive patterns found'
             exit 1
           else
             echo '[OK] No sensitive patterns detected'
           fi
 
-      - name: Staged-like diff scan (PR only)
+      - name: PR diff scan
         if: ${{ github.event_name == 'pull_request' }}
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
           echo '[INFO] Scanning PR diff'
-          git fetch origin "$BASE_REF" --depth=1 || true
-          DIFF=$(git diff --unified=0 "origin/${BASE_REF}...HEAD" 2>/dev/null || true)
+          git fetch origin "$BASE_REF"
 
-          if [ -n "$DIFF" ]; then
-            ADDITIONS=$(echo "$DIFF" | grep -E '^\+' | grep -vE '^\+\+\+' || true)
-            if [ -n "$ADDITIONS" ] && echo "$ADDITIONS" | grep -E -q 'sk-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|[A-Z_]+API_KEY=' 2>/dev/null; then
-              echo '[ERROR] Possible secret in diff'
-              exit 1
-            else
-              echo '[OK] No sensitive patterns in diff'
-            fi
+          if git diff --unified=0 "origin/${BASE_REF}...HEAD" | grep -E '^\+[^+]' | sed 's/^+//' | grep -E -q "$SENSITIVE_PATTERN" 2>/dev/null; then
+            echo '[ERROR] Possible secret in diff'
+            exit 1
           else
-            echo '[INFO] No diff to scan'
+            echo '[OK] No sensitive patterns in diff'
           fi
 
       - name: Advisory historic scan for legacy secrets
         run: |
           set -euo pipefail
           echo '[INFO] Sampling recent commits'
-          PATTERN='sk-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}'
 
-          if git log --max-count=20 -E -G "$PATTERN" --format='%H' HEAD | grep -q .; then
+          if git log --max-count=20 -E -G "$SENSITIVE_PATTERN" --format='%H' HEAD | grep -q .; then
             echo '[INFO] Historical pattern found in recent commits'
             echo '[INFO] Advisory only: current tree and PR diff scans are blocking'
           else

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -2,9 +2,9 @@ name: Secret Scan
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 permissions:
   contents: read
@@ -27,8 +27,7 @@ jobs:
         with:
           fetch-depth: 0  # precisamos do histórico para grep opcional
 
-      - name: Quick working tree scan
-        continue-on-error: true
+      - name: Recursive workspace scan
         run: |
           set -euo pipefail
           echo '[INFO] Scanning for sensitive patterns'
@@ -43,14 +42,14 @@ jobs:
              --exclude='.gitleaks.toml' \
              --exclude='test_keys.txt' \
              --exclude='replacements.txt' 2>/dev/null; then
-            echo '[WARN] Sensitive patterns found - review manually'
+            echo '[ERROR] Sensitive patterns found'
+            exit 1
           else
             echo '[OK] No sensitive patterns detected'
           fi
 
       - name: Staged-like diff scan (PR only)
         if: ${{ github.event_name == 'pull_request' }}
-        continue-on-error: true
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
@@ -61,8 +60,9 @@ jobs:
 
           if [ -n "$DIFF" ]; then
             ADDITIONS=$(echo "$DIFF" | grep -E '^\+' | grep -vE '^\+\+\+' || true)
-            if echo "$ADDITIONS" | grep -E -q 'sk-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|[A-Z_]+API_KEY=' 2>/dev/null; then
-              echo '[WARN] Possible secret in diff - review manually'
+            if [ -n "$ADDITIONS" ] && echo "$ADDITIONS" | grep -E -q 'sk-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|[A-Z_]+API_KEY=' 2>/dev/null; then
+              echo '[ERROR] Possible secret in diff'
+              exit 1
             else
               echo '[OK] No sensitive patterns in diff'
             fi
@@ -70,27 +70,15 @@ jobs:
             echo '[INFO] No diff to scan'
           fi
 
-      - name: Historic scan for legacy secrets (sample)
-        continue-on-error: true
+      - name: Advisory historic scan for legacy secrets
         run: |
           set -euo pipefail
           echo '[INFO] Sampling recent commits'
-          SAMPLE=$(git rev-list --max-count=20 HEAD 2>/dev/null || echo "")
+          PATTERN='sk-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}'
 
-          if [ -n "$SAMPLE" ]; then
-            FOUND=0
-            for c in $SAMPLE; do
-              if git --no-pager grep -E 'sk-[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}' $c >/dev/null 2>&1; then
-                echo "[INFO] Pattern found in commit $c (may be historical)"
-                FOUND=1
-              fi
-            done
-
-            if [ $FOUND -eq 1 ]; then
-              echo '[INFO] Historical findings may already be rotated'
-            else
-              echo '[OK] Sample clean'
-            fi
+          if git log --max-count=20 -E -G "$PATTERN" --format='%H' HEAD | grep -q .; then
+            echo '[INFO] Historical pattern found in recent commits'
+            echo '[INFO] Advisory only: current tree and PR diff scans are blocking'
           else
-            echo '[INFO] No commits to scan'
+            echo '[OK] Recent history sample clean'
           fi

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -2,9 +2,9 @@ name: Secret Scan
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [main, dev]
   pull_request:
-    branches: [ main, dev ]
+    branches: [main, dev]
   schedule:
     - cron: "30 3 * * 0"
   workflow_dispatch:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,4 +8,4 @@ description = "Allow detect-secrets baseline hash metadata only"
 condition = "AND"
 regexTarget = "line"
 paths = ['''^\.secrets\.baseline$''']
-regexes = ['''"hashed_secret": "[a-f0-9]{40}"''']
+regexes = ['''^\s*"hashed_secret": "[a-f0-9]{40}",?\s*$''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+title = "SSA Consulta Rapida Gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Allow detect-secrets baseline hash metadata only"
+condition = "AND"
+regexTarget = "line"
+paths = ['''^\.secrets\.baseline$''']
+regexes = ['''"hashed_secret": "[a-f0-9]{40}"''']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,62 +127,62 @@
     }
   ],
   "results": {
-    ".github\\workflows\\opencode.yml": [
+    ".github/workflows/opencode.yml": [
       {
         "type": "Secret Keyword",
-        "filename": ".github\\workflows\\opencode.yml",
+        "filename": ".github/workflows/opencode.yml",
         "hashed_secret": "248a3d2f04326fd36fdf74e6940d104b9aa88c27",
         "is_verified": false,
         "line_number": 120
       }
     ],
-    "config\\llm_providers\\README.md": [
+    "config/llm_providers/README.md": [
       {
         "type": "Secret Keyword",
-        "filename": "config\\llm_providers\\README.md",
+        "filename": "config/llm_providers/README.md",
         "hashed_secret": "0a3bc45f9330c1abb577d7e21b5c509d542b18bf",
         "is_verified": false,
         "line_number": 43
       }
     ],
-    "docs\\CCR_LLM_PROVIDERS_SETUP.md": [
+    "docs/CCR_LLM_PROVIDERS_SETUP.md": [
       {
         "type": "Secret Keyword",
-        "filename": "docs\\CCR_LLM_PROVIDERS_SETUP.md",
+        "filename": "docs/CCR_LLM_PROVIDERS_SETUP.md",
         "hashed_secret": "c11332d165f7ca754e4a06fbebfec731b3f912b9",
         "is_verified": false,
         "line_number": 183
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs\\CCR_LLM_PROVIDERS_SETUP.md",
+        "filename": "docs/CCR_LLM_PROVIDERS_SETUP.md",
         "hashed_secret": "f705ab416f2965b4b5b2a001f5aed18782b644a8",
         "is_verified": false,
         "line_number": 311
       }
     ],
-    "docs\\OHMYOPENCODE_MANUAL.md": [
+    "docs/OHMYOPENCODE_MANUAL.md": [
       {
         "type": "Secret Keyword",
-        "filename": "docs\\OHMYOPENCODE_MANUAL.md",
+        "filename": "docs/OHMYOPENCODE_MANUAL.md",
         "hashed_secret": "ee7570d2dc51c5918da259c27c29dc65299d5d7f",
         "is_verified": false,
         "line_number": 76
       }
     ],
-    "tests\\test_config_manager_atomic_save.py": [
+    "tests/test_config_manager_atomic_save.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_config_manager_atomic_save.py",
+        "filename": "tests/test_config_manager_atomic_save.py",
         "hashed_secret": "939bb46a04c3640c8c427e92b1b557e882e2d2a0",
         "is_verified": false,
         "line_number": 126
       }
     ],
-    "tests\\test_release_docs_contract.py": [
+    "tests/test_release_docs_contract.py": [
       {
         "type": "Hex High Entropy String",
-        "filename": "tests\\test_release_docs_contract.py",
+        "filename": "tests/test_release_docs_contract.py",
         "hashed_secret": "ccd5dc95a55de8b3ea3ebe87736411971be7f344",
         "is_verified": false,
         "line_number": 42

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,14 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -119,49 +127,67 @@
     }
   ],
   "results": {
-    "config/llm_providers/README.md": [
+    ".github\\workflows\\opencode.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "config/llm_providers/README.md",
+        "filename": ".github\\workflows\\opencode.yml",
+        "hashed_secret": "248a3d2f04326fd36fdf74e6940d104b9aa88c27",
+        "is_verified": false,
+        "line_number": 120
+      }
+    ],
+    "config\\llm_providers\\README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "config\\llm_providers\\README.md",
         "hashed_secret": "0a3bc45f9330c1abb577d7e21b5c509d542b18bf",
         "is_verified": false,
         "line_number": 43
       }
     ],
-    "docs/CCR_LLM_PROVIDERS_SETUP.md": [
+    "docs\\CCR_LLM_PROVIDERS_SETUP.md": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/CCR_LLM_PROVIDERS_SETUP.md",
+        "filename": "docs\\CCR_LLM_PROVIDERS_SETUP.md",
         "hashed_secret": "c11332d165f7ca754e4a06fbebfec731b3f912b9",
         "is_verified": false,
         "line_number": 183
       },
       {
         "type": "Secret Keyword",
-        "filename": "docs/CCR_LLM_PROVIDERS_SETUP.md",
+        "filename": "docs\\CCR_LLM_PROVIDERS_SETUP.md",
         "hashed_secret": "f705ab416f2965b4b5b2a001f5aed18782b644a8",
         "is_verified": false,
         "line_number": 311
       }
     ],
-    "docs/OHMYOPENCODE_MANUAL.md": [
+    "docs\\OHMYOPENCODE_MANUAL.md": [
       {
         "type": "Secret Keyword",
-        "filename": "docs/OHMYOPENCODE_MANUAL.md",
+        "filename": "docs\\OHMYOPENCODE_MANUAL.md",
         "hashed_secret": "ee7570d2dc51c5918da259c27c29dc65299d5d7f",
         "is_verified": false,
         "line_number": 76
       }
     ],
-    "docs/WORKERS_API_DOCUMENTATION.md": [
+    "tests\\test_config_manager_atomic_save.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests\\test_config_manager_atomic_save.py",
+        "hashed_secret": "939bb46a04c3640c8c427e92b1b557e882e2d2a0",
+        "is_verified": false,
+        "line_number": 126
+      }
+    ],
+    "tests\\test_release_docs_contract.py": [
       {
         "type": "Hex High Entropy String",
-        "filename": "docs/WORKERS_API_DOCUMENTATION.md",
-        "hashed_secret": "7a6c978d9933c67178dbf5d4a0280764647fe4cf",
+        "filename": "tests\\test_release_docs_contract.py",
+        "hashed_secret": "ccd5dc95a55de8b3ea3ebe87736411971be7f344",
         "is_verified": false,
-        "line_number": 274
+        "line_number": 42
       }
     ]
   },
-  "generated_at": "2026-04-11T17:59:26Z"
+  "generated_at": "2026-05-03T13:51:19Z"
 }

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ As notas antigas permanecem abaixo para referencia e auditoria tecnica.
 - **Estrutura de Requirements (Otimizada):**
   - **requirements.txt** - Dependências de runtime essenciais (PyQt6, pandas, openpyxl, tabulate)
   - **requirements_dev.txt** - Ferramentas de desenvolvimento (pytest, flake8, black, mypy, pre-commit)
-  - **requirements_build.txt** - Ferramentas de build (pyinstaller, pillow, cairosvg, pywin32, upx4py)
+  - **requirements_build.txt** - Ferramentas de build (pyinstaller, pillow, cairosvg, pywin32)
   - **requirements_ci.txt** - Ferramentas de CI/CD (pytest, flake8, black, mypy, pre-commit, pyinstaller)
   - **requirements_clean.txt** - Arquivo documental (não utilizado para instalação)
 
@@ -556,11 +556,11 @@ Tip: The repository contains a `.gitattributes` entry that enforces LF for `.env
 **Windows + direnv (scoop):** se `direnv exec` nao achar o binario, aponte `DIRENV_BIN` para o caminho retornado por `where direnv` (converta para formato WSL com `cygpath -u` se estiver dentro do bash). Evite hardcode de usuario/caminho; ajuste tambem `XDG_*` se necessario. Em caso de duvida, ative o ambiente manualmente com `.venv\\Scripts\\Activate.ps1`.
 
 
-Para build Windows com compressao UPX (reducao de tamanho), instale tambem:
+Para build Windows com compressao UPX (reducao de tamanho), instale o binario `upx` pelo gerenciador do sistema.
 ```pwsh
-uv pip install --python 3.13 -r launchers/platforms/windows_amd64/requirements_windows_build.txt
+scoop install upx
 ```
-Esse arquivo separado evita alerta de dependencia ausente em ambientes macOS/Linux onde `upx4py` nao e necessario.
+O build continua sem compressao se `upx` nao estiver disponivel no `PATH`.
 
 ## Inicializacao automatica de diretorios
 Na primeira execucao o sistema garante a criacao idempotente dos diretorios essenciais (ex.: `data/`, `data/historico_backups/`, `logs/`, `reports/`, `extracao/`, `exportacao/`).

--- a/README.md
+++ b/README.md
@@ -557,9 +557,11 @@ Tip: The repository contains a `.gitattributes` entry that enforces LF for `.env
 
 
 Para build Windows com compressao UPX (reducao de tamanho), instale o binario `upx` pelo gerenciador do sistema.
+
 ```pwsh
 scoop install upx
 ```
+
 O build continua sem compressao se `upx` nao estiver disponivel no `PATH`.
 
 ## Inicializacao automatica de diretorios

--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -37,3 +37,12 @@
 - Kluster CLI deep on `docs/RECOVERY_BACKLOG.md`: timed out after 60s (`kluster review file docs/RECOVERY_BACKLOG.md --mode deep`).
 - Fallback planned: rerun Kluster in instant mode for documentation/status files and keep deep mode for code/workflow files when it completes inside the local 60s window.
 - Codex security preflight: timed out after 60s while running broad `gitleaks` (`C:\Users\mauri\.codex\scripts\security-preflight.ps1 -RepoPath C:\Users\mauri\git\SSA_Consulta_Rapida -Mode manual`).
+
+## 2026-05-03T02:30:00-03:00 Nuitka runtime source-path slice
+
+- Scope: corrigir entrypoints Nuitka para nao usar caminho do repo de build como fallback de runtime.
+- Evidencia: smoke isolado do executavel Nuitka CLI carregou 70.954 SSAs mesmo com `APPDATA`, `LOCALAPPDATA` e `SSA_*` limpos; o entrypoint `launchers/cli_entry.py` so tratava `sys.frozen`, mas Nuitka expõe `__compiled__`.
+- Kluster MCP/tool discovery: `tool_search` nao expôs ferramenta Kluster callable nesta sessao.
+- Kluster CLI fallback: `pnpm.CMD dlx kluster-verify --help` falhou com `ERR_PNPM_FETCH_404` para `https://registry.npmjs.org/kluster-verify`.
+- Validacao classica focada: `py_compile`, `ruff`, `ty` e `pytest` focado passaram antes do commit.
+- Observacao operacional: hooks locais de commit ainda executam Kluster quando disponiveis no fluxo de commit.

--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -68,3 +68,11 @@
 - Scope: extracted `.github/workflows/secret_scan.yml` shell logic into `scripts/security/scan_secrets.sh`.
 - TruffleHog historical scan: timed out after 240s (`trufflehog git file://C:/Users/mauri/git/SSA_Consulta_Rapida --json --no-verification --no-update --results=verified,unknown`).
 - TruffleHog partial redacted parse: 4 JSON lines, 0 findings, 2 scanner errors before timeout.
+
+## 2026-05-03T10:55:00-03:00 gitleaks baseline review slice
+
+- Scope: reviewed `.secrets.baseline` and added focused Gitleaks config for detect-secrets hash metadata.
+- Full workspace Gitleaks scan: timed out after 180s (`gitleaks detect --config .gitleaks.toml --no-git --source . --redact --exit-code 1`).
+- Focused substitute: `uvx pre-commit run gitleaks --files .secrets.baseline` passed.
+- Focused substitute: `gitleaks detect --config .gitleaks.toml --no-git --source .secrets.baseline --redact --exit-code 1` passed.
+- Focused substitute: `trufflehog filesystem .gitleaks.toml .secrets.baseline docs/RECOVERY_BACKLOG.md --no-update --no-verification --results=verified,unknown --json` found 0 verified or unknown secrets.

--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -93,3 +93,13 @@
 - Kluster CLI fallback: `C:\Users\mauri\.pnpm\bin\pnpm.CMD dlx kluster-verify --help` failed with `ERR_PNPM_FETCH_404` for `https://registry.npmjs.org/kluster-verify`.
 - Local config evidence: `C:\Users\mauri\.config\opencode\opencode.json` points to MCP package `@klusterai/kluster-verify-code-mcp@latest` with `--server=https://api.kluster.ai`, not to a standalone `kluster-verify` CLI package.
 - Status: external Kluster verification blocked by MCP transport failure; classic validation remains mandatory before commit.
+
+## 2026-05-03T22:31:00-03:00 PR58 launcher and secret scan follow-up slice
+
+- Scope: launcher bundle-root handling, runtime test environment cleanup, secret scan fallback/preflight, and Debian release report missing package-dir contract.
+- Kluster MCP auto review attempt 1: `kluster_code_review_auto` failed with `Transport closed`.
+- Kluster MCP auto review attempt 2: `kluster_code_review_auto` failed with `Transport closed`.
+- Kluster MCP auto review attempt 3: `kluster_code_review_auto` failed with `Transport closed`.
+- Kluster MCP auto review attempt 4: `kluster_code_review_auto` failed with `Transport closed`.
+- Kluster MCP auto review attempt 5: `kluster_code_review_auto` failed with `Transport closed`.
+- Status: external Kluster MCP remains blocked by transport failure; commit/push hooks and classic validation remain mandatory before commit.

--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -102,4 +102,5 @@
 - Kluster MCP auto review attempt 3: `kluster_code_review_auto` failed with `Transport closed`.
 - Kluster MCP auto review attempt 4: `kluster_code_review_auto` failed with `Transport closed`.
 - Kluster MCP auto review attempt 5: `kluster_code_review_auto` failed with `Transport closed`.
+- Kluster MCP auto review attempt 6: `kluster_code_review_auto` failed with `Transport closed`.
 - Status: external Kluster MCP remains blocked by transport failure; commit/push hooks and classic validation remain mandatory before commit.

--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -55,3 +55,10 @@
 - Kluster MCP/tool discovery: `tool_search` nao expos ferramenta Kluster callable nesta sessao.
 - Kluster CLI fallback: `C:\Users\mauri\.pnpm\bin\pnpm.CMD dlx kluster-verify --help` falhou com `ERR_PNPM_FETCH_404` para `https://registry.npmjs.org/kluster-verify`.
 - Validacao classica focada antes do commit: `py_compile`, `ruff`, `ty` e `pytest` focado passaram.
+
+## 2026-05-03T03:50:00-03:00 Windows release smoke isolation slice
+
+- Scope: impedir que o smoke do orquestrador Windows use `APPDATA`, `LOCALAPPDATA`, `USERPROFILE`, cwd ou `SSA_*` do usuario.
+- Evidencia: `builds/reports/release_report_windows_amd64.json` gerado para `da964144a82b7e93a3f46ccf239949fc23318547` registrou `DADOS CARREGADOS: 70,954 SSAs` no smoke, enquanto o smoke manual isolado do mesmo executavel retornou sem dados carregados.
+- Causa: `Invoke-Smoke` em `dev_env/build/release_windows.ps1` usava `Start-Process` sem ambiente isolado.
+- Kluster CLI fallback: `C:\Users\mauri\.pnpm\bin\pnpm.CMD dlx kluster-verify --help` falhou com `ERR_PNPM_FETCH_404` para `https://registry.npmjs.org/kluster-verify`.

--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -76,3 +76,10 @@
 - Focused substitute: `uvx pre-commit run gitleaks --files .secrets.baseline` passed.
 - Focused substitute: `gitleaks detect --config .gitleaks.toml --no-git --source .secrets.baseline --redact --exit-code 1` passed.
 - Focused substitute: `trufflehog filesystem .gitleaks.toml .secrets.baseline docs/RECOVERY_BACKLOG.md --no-update --no-verification --results=verified,unknown --json` found 0 verified or unknown secrets.
+
+## 2026-05-03T17:40:00-03:00 PR58 CI security follow-up slice
+
+- Scope: CodeQL precheck fail-open behavior, secret scan script robustness, and detect-secrets baseline path portability.
+- Kluster MCP auto review: `kluster_code_review_auto` failed with `Transport closed`.
+- Kluster CLI fallback: `C:\Users\mauri\.pnpm\bin\pnpm.CMD dlx kluster-verify --help` failed with `ERR_PNPM_FETCH_404` for `https://registry.npmjs.org/kluster-verify`.
+- Status: external Kluster verification blocked by environment/tool availability; classic validation still required before commit.

--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -46,3 +46,12 @@
 - Kluster CLI fallback: `pnpm.CMD dlx kluster-verify --help` falhou com `ERR_PNPM_FETCH_404` para `https://registry.npmjs.org/kluster-verify`.
 - Validacao classica focada: `py_compile`, `ruff`, `ty` e `pytest` focado passaram antes do commit.
 - Observacao operacional: hooks locais de commit ainda executam Kluster quando disponiveis no fluxo de commit.
+
+## 2026-05-03T03:12:00-03:00 Nuitka parent-data isolation slice
+
+- Scope: impedir que entrypoints Nuitka copiem `data/ssas.db` de diretorio pai do `.dist`.
+- Evidencia: smoke isolado do Windows Nuitka CLI criou runtime temporario e copiou `builds/nuitka/windows_amd64/data/ssas.db` com 70.954 SSAs para `APPDATA` temporario.
+- Causa: `_find_bundled_dir` e `_find_bundled_data_dir` aceitavam `exe_path.parent.parent / "data"`, que no layout local aponta para `builds/nuitka/windows_amd64/data`.
+- Kluster MCP/tool discovery: `tool_search` nao expos ferramenta Kluster callable nesta sessao.
+- Kluster CLI fallback: `C:\Users\mauri\.pnpm\bin\pnpm.CMD dlx kluster-verify --help` falhou com `ERR_PNPM_FETCH_404` para `https://registry.npmjs.org/kluster-verify`.
+- Validacao classica focada antes do commit: `py_compile`, `ruff`, `ty` e `pytest` focado passaram.

--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -30,3 +30,10 @@
 - Kluster CLI instant successful run after status update: review `69f39d18295e5d0b624eac55`.
 - Kluster final remaining items: structural import orchestrator refactor, filter/search performance and parser documentation, duplicated emoji definitions, local lazy imports in rescan worker, and filter-search cache performance.
 - Status: classic validation passed; Kluster backend was unstable and final remaining items are deferred as non-blocking or performance-slice items.
+
+## 2026-05-03T00:45:00-03:00 security workflow slice
+
+- Scope: GitHub Actions hardening, vulnerable requirements scan cleanup, and secret scan workflow tightening.
+- Kluster CLI deep on `docs/RECOVERY_BACKLOG.md`: timed out after 60s (`kluster review file docs/RECOVERY_BACKLOG.md --mode deep`).
+- Fallback planned: rerun Kluster in instant mode for documentation/status files and keep deep mode for code/workflow files when it completes inside the local 60s window.
+- Codex security preflight: timed out after 60s while running broad `gitleaks` (`C:\Users\mauri\.codex\scripts\security-preflight.ps1 -RepoPath C:\Users\mauri\git\SSA_Consulta_Rapida -Mode manual`).

--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -83,3 +83,13 @@
 - Kluster MCP auto review: `kluster_code_review_auto` failed with `Transport closed`.
 - Kluster CLI fallback: `C:\Users\mauri\.pnpm\bin\pnpm.CMD dlx kluster-verify --help` failed with `ERR_PNPM_FETCH_404` for `https://registry.npmjs.org/kluster-verify`.
 - Status: external Kluster verification blocked by environment/tool availability; classic validation still required before commit.
+
+## 2026-05-03T22:06:00-03:00 PR58 remaining review hardening slice
+
+- Scope: remaining valid PR review comments for workflow hardening, secret scan robustness, opencode review wrapper, Windows smoke process cleanup, and release report CSV normalization.
+- Kluster MCP auto review attempt 1: `kluster_code_review_auto` failed with `Transport closed`.
+- Kluster MCP auto review attempt 2: `kluster_code_review_auto` failed with `Transport closed`.
+- Kluster CLI local command check: no `kluster-verify` executable was found by `Get-Command`.
+- Kluster CLI fallback: `C:\Users\mauri\.pnpm\bin\pnpm.CMD dlx kluster-verify --help` failed with `ERR_PNPM_FETCH_404` for `https://registry.npmjs.org/kluster-verify`.
+- Local config evidence: `C:\Users\mauri\.config\opencode\opencode.json` points to MCP package `@klusterai/kluster-verify-code-mcp@latest` with `--server=https://api.kluster.ai`, not to a standalone `kluster-verify` CLI package.
+- Status: external Kluster verification blocked by MCP transport failure; classic validation remains mandatory before commit.

--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -62,3 +62,9 @@
 - Evidencia: `builds/reports/release_report_windows_amd64.json` gerado para `da964144a82b7e93a3f46ccf239949fc23318547` registrou `DADOS CARREGADOS: 70,954 SSAs` no smoke, enquanto o smoke manual isolado do mesmo executavel retornou sem dados carregados.
 - Causa: `Invoke-Smoke` em `dev_env/build/release_windows.ps1` usava `Start-Process` sem ambiente isolado.
 - Kluster CLI fallback: `C:\Users\mauri\.pnpm\bin\pnpm.CMD dlx kluster-verify --help` falhou com `ERR_PNPM_FETCH_404` para `https://registry.npmjs.org/kluster-verify`.
+
+## 2026-05-03T10:04:00-03:00 secret scan extraction slice
+
+- Scope: extracted `.github/workflows/secret_scan.yml` shell logic into `scripts/security/scan_secrets.sh`.
+- TruffleHog historical scan: timed out after 240s (`trufflehog git file://C:/Users/mauri/git/SSA_Consulta_Rapida --json --no-verification --no-update --results=verified,unknown`).
+- TruffleHog partial redacted parse: 4 JSON lines, 0 findings, 2 scanner errors before timeout.

--- a/dev_env/build/build_nuitka_clean.bat
+++ b/dev_env/build/build_nuitka_clean.bat
@@ -34,7 +34,7 @@ if not defined FILE_VERSION set "FILE_VERSION=0.0.0.0"
 set "BUILD_METADATA_DIR=%REPO_ROOT%\builds\metadata"
 if not exist "%BUILD_METADATA_DIR%" mkdir "%BUILD_METADATA_DIR%"
 set "BUILD_INFO_FILE=%BUILD_METADATA_DIR%\build_info_windows_amd64_nuitka.json"
-uv run --python 3.13 python -c "import datetime,json,os,pathlib,subprocess; root=pathlib.Path(os.environ['REPO_ROOT']); run=lambda args: subprocess.run(args,cwd=str(root),text=True,capture_output=True,check=False).stdout.strip(); commit=run(['git','rev-parse','HEAD']); payload={'app_version':os.environ.get('APP_VERSION',''),'build_datetime':datetime.datetime.now().astimezone().isoformat(timespec='seconds'),'build_system':'nuitka','git_commit':commit,'git_commit_datetime':run(['git','log','-1','--format=%%cI']),'git_commit_short':commit[:7] if commit else '','git_commit_title':run(['git','log','-1','--format=%%s']),'platform':'windows_amd64','uv_version':run(['uv','--version'])}; pathlib.Path(os.environ['BUILD_INFO_FILE']).write_text(json.dumps(payload,ensure_ascii=True,indent=2,sort_keys=True)+'\n',encoding='utf-8')"
+uv run --python 3.13 "%REPO_ROOT%\dev_env\build\write_build_info.py" --repo-root "%REPO_ROOT%" --output "%BUILD_INFO_FILE%" --build-system nuitka --platform windows_amd64 --app-version "%APP_VERSION%"
 if errorlevel 1 (
     echo Erro ao gerar build_info.json.
     exit /b 1

--- a/dev_env/build/build_nuitka_debian.sh
+++ b/dev_env/build/build_nuitka_debian.sh
@@ -128,7 +128,6 @@ if [[ ! -s "${BUILD_INFO_FILE}" ]]; then
   echo "Erro: falha ao gerar build_info_debian_amd64_nuitka.json" >&2
   exit 1
 fi
-
 GUI_DIST="${FINAL_BUILD_DIR}/gui_entry.dist"
 CLI_DIST="${FINAL_BUILD_DIR}/cli_entry.dist"
 rm -rf "${GUI_DIST}" "${CLI_DIST}"

--- a/dev_env/build/build_nuitka_debian.sh
+++ b/dev_env/build/build_nuitka_debian.sh
@@ -93,7 +93,7 @@ if [[ ! -f "${VERSION_FILE}" ]]; then
   echo "Erro: version.json nao encontrado: ${VERSION_FILE}"
   exit 1
 fi
-APP_VERSION="$(
+if ! APP_VERSION="$(
   uv run --python 3.13 python - "${VERSION_FILE}" <<'PY_VERSION'
 import json
 import pathlib
@@ -106,7 +106,14 @@ if not version:
     raise SystemExit("version_short ausente em config/version.json")
 print(version)
 PY_VERSION
-)"
+)"; then
+  echo "Erro: falha ao extrair version_short de config/version.json" >&2
+  exit 1
+fi
+if [[ -z "${APP_VERSION}" ]]; then
+  echo "Erro: version_short vazio em config/version.json" >&2
+  exit 1
+fi
 
 BUILD_INFO_FILE="${REPO_ROOT}/builds/metadata/build_info_debian_amd64_nuitka.json"
 mkdir -p "$(dirname "${BUILD_INFO_FILE}")"
@@ -117,6 +124,10 @@ uv run --python 3.13 "${REPO_ROOT}/dev_env/build/write_build_info.py" \
   --build-system nuitka \
   --platform debian_amd64 \
   --app-version "${APP_VERSION}"
+if [[ ! -s "${BUILD_INFO_FILE}" ]]; then
+  echo "Erro: falha ao gerar build_info_debian_amd64_nuitka.json" >&2
+  exit 1
+fi
 
 GUI_DIST="${FINAL_BUILD_DIR}/gui_entry.dist"
 CLI_DIST="${FINAL_BUILD_DIR}/cli_entry.dist"

--- a/dev_env/build/build_nuitka_debian.sh
+++ b/dev_env/build/build_nuitka_debian.sh
@@ -111,37 +111,12 @@ PY_VERSION
 BUILD_INFO_FILE="${REPO_ROOT}/builds/metadata/build_info_debian_amd64_nuitka.json"
 mkdir -p "$(dirname "${BUILD_INFO_FILE}")"
 LAST_STEP="write_build_info"
-uv run --python 3.13 python - "${REPO_ROOT}" "${BUILD_INFO_FILE}" "nuitka" "debian_amd64" "${APP_VERSION}" <<'PY_BUILD_INFO'
-import datetime
-import json
-import pathlib
-import subprocess
-import sys
-
-root = pathlib.Path(sys.argv[1])
-output = pathlib.Path(sys.argv[2])
-build_system = sys.argv[3]
-platform_name = sys.argv[4]
-app_version = sys.argv[5]
-
-def run(args):
-    result = subprocess.run(args, cwd=str(root), text=True, capture_output=True, check=False)
-    return (result.stdout or "").strip() if result.returncode == 0 else ""
-
-commit = run(["git", "rev-parse", "HEAD"])
-payload = {
-    "app_version": app_version,
-    "build_datetime": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
-    "build_system": build_system,
-    "git_commit": commit,
-    "git_commit_datetime": run(["git", "log", "-1", "--format=%cI"]),
-    "git_commit_short": commit[:7] if commit else "",
-    "git_commit_title": run(["git", "log", "-1", "--format=%s"]),
-    "platform": platform_name,
-    "uv_version": run(["uv", "--version"]),
-}
-output.write_text(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY_BUILD_INFO
+uv run --python 3.13 "${REPO_ROOT}/dev_env/build/write_build_info.py" \
+  --repo-root "${REPO_ROOT}" \
+  --output "${BUILD_INFO_FILE}" \
+  --build-system nuitka \
+  --platform debian_amd64 \
+  --app-version "${APP_VERSION}"
 
 GUI_DIST="${FINAL_BUILD_DIR}/gui_entry.dist"
 CLI_DIST="${FINAL_BUILD_DIR}/cli_entry.dist"

--- a/dev_env/build/build_nuitka_debian_arm64.sh
+++ b/dev_env/build/build_nuitka_debian_arm64.sh
@@ -128,7 +128,6 @@ if [[ ! -s "${BUILD_INFO_FILE}" ]]; then
   echo "Erro: falha ao gerar build_info_debian_arm64_nuitka.json" >&2
   exit 1
 fi
-
 GUI_DIST="${FINAL_BUILD_DIR}/gui_entry.dist"
 CLI_DIST="${FINAL_BUILD_DIR}/cli_entry.dist"
 rm -rf "${GUI_DIST}" "${CLI_DIST}"

--- a/dev_env/build/build_nuitka_debian_arm64.sh
+++ b/dev_env/build/build_nuitka_debian_arm64.sh
@@ -111,37 +111,12 @@ PY_VERSION
 BUILD_INFO_FILE="${REPO_ROOT}/builds/metadata/build_info_debian_arm64_nuitka.json"
 mkdir -p "$(dirname "${BUILD_INFO_FILE}")"
 LAST_STEP="write_build_info"
-uv run --python 3.13 python - "${REPO_ROOT}" "${BUILD_INFO_FILE}" "nuitka" "debian_arm64" "${APP_VERSION}" <<'PY_BUILD_INFO'
-import datetime
-import json
-import pathlib
-import subprocess
-import sys
-
-root = pathlib.Path(sys.argv[1])
-output = pathlib.Path(sys.argv[2])
-build_system = sys.argv[3]
-platform_name = sys.argv[4]
-app_version = sys.argv[5]
-
-def run(args):
-    result = subprocess.run(args, cwd=str(root), text=True, capture_output=True, check=False)
-    return (result.stdout or "").strip() if result.returncode == 0 else ""
-
-commit = run(["git", "rev-parse", "HEAD"])
-payload = {
-    "app_version": app_version,
-    "build_datetime": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
-    "build_system": build_system,
-    "git_commit": commit,
-    "git_commit_datetime": run(["git", "log", "-1", "--format=%cI"]),
-    "git_commit_short": commit[:7] if commit else "",
-    "git_commit_title": run(["git", "log", "-1", "--format=%s"]),
-    "platform": platform_name,
-    "uv_version": run(["uv", "--version"]),
-}
-output.write_text(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY_BUILD_INFO
+uv run --python 3.13 "${REPO_ROOT}/dev_env/build/write_build_info.py" \
+  --repo-root "${REPO_ROOT}" \
+  --output "${BUILD_INFO_FILE}" \
+  --build-system nuitka \
+  --platform debian_arm64 \
+  --app-version "${APP_VERSION}"
 
 GUI_DIST="${FINAL_BUILD_DIR}/gui_entry.dist"
 CLI_DIST="${FINAL_BUILD_DIR}/cli_entry.dist"

--- a/dev_env/build/build_nuitka_debian_arm64.sh
+++ b/dev_env/build/build_nuitka_debian_arm64.sh
@@ -93,7 +93,7 @@ if [[ ! -f "${VERSION_FILE}" ]]; then
   echo "Erro: version.json nao encontrado: ${VERSION_FILE}"
   exit 1
 fi
-APP_VERSION="$(
+if ! APP_VERSION="$(
   uv run --python 3.13 python - "${VERSION_FILE}" <<'PY_VERSION'
 import json
 import pathlib
@@ -106,7 +106,14 @@ if not version:
     raise SystemExit("version_short ausente em config/version.json")
 print(version)
 PY_VERSION
-)"
+)"; then
+  echo "Erro: falha ao extrair version_short de config/version.json" >&2
+  exit 1
+fi
+if [[ -z "${APP_VERSION}" ]]; then
+  echo "Erro: version_short vazio em config/version.json" >&2
+  exit 1
+fi
 
 BUILD_INFO_FILE="${REPO_ROOT}/builds/metadata/build_info_debian_arm64_nuitka.json"
 mkdir -p "$(dirname "${BUILD_INFO_FILE}")"
@@ -117,6 +124,10 @@ uv run --python 3.13 "${REPO_ROOT}/dev_env/build/write_build_info.py" \
   --build-system nuitka \
   --platform debian_arm64 \
   --app-version "${APP_VERSION}"
+if [[ ! -s "${BUILD_INFO_FILE}" ]]; then
+  echo "Erro: falha ao gerar build_info_debian_arm64_nuitka.json" >&2
+  exit 1
+fi
 
 GUI_DIST="${FINAL_BUILD_DIR}/gui_entry.dist"
 CLI_DIST="${FINAL_BUILD_DIR}/cli_entry.dist"

--- a/dev_env/build/build_pyoxidizer.bat
+++ b/dev_env/build/build_pyoxidizer.bat
@@ -167,7 +167,7 @@ if errorlevel 1 (
 )
 if not exist "%STAGE_DIR%\config" mkdir "%STAGE_DIR%\config"
 set "BUILD_INFO_FILE=%STAGE_DIR%\config\build_info.json"
-uv run --python 3.13 python -c "import datetime,json,os,pathlib,subprocess; root=pathlib.Path(os.environ['REPO_ROOT']); run=lambda args: subprocess.run(args,cwd=str(root),text=True,capture_output=True,check=False).stdout.strip(); commit=run(['git','rev-parse','HEAD']); payload={'app_version':os.environ.get('APP_VERSION',''),'build_datetime':datetime.datetime.now().astimezone().isoformat(timespec='seconds'),'build_system':'pyoxidizer','git_commit':commit,'git_commit_datetime':run(['git','log','-1','--format=%%cI']),'git_commit_short':commit[:7] if commit else '','git_commit_title':run(['git','log','-1','--format=%%s']),'platform':'windows_amd64','uv_version':run(['uv','--version'])}; pathlib.Path(os.environ['BUILD_INFO_FILE']).write_text(json.dumps(payload,ensure_ascii=True,indent=2,sort_keys=True)+'\n',encoding='utf-8')"
+uv run --python 3.13 "%REPO_ROOT%\dev_env\build\write_build_info.py" --repo-root "%REPO_ROOT%" --output "%BUILD_INFO_FILE%" --build-system pyoxidizer --platform windows_amd64 --app-version "%APP_VERSION%"
 if errorlevel 1 (
     echo Erro ao gerar build_info.json para staging.
     exit /b 1

--- a/dev_env/build/build_pyoxidizer_debian.sh
+++ b/dev_env/build/build_pyoxidizer_debian.sh
@@ -42,8 +42,12 @@ fi
 BUILD_INFO_FILE="${REPO_ROOT}/config/build_info.json"
 BUILD_INFO_BACKUP=""
 if [[ -f "${BUILD_INFO_FILE}" ]]; then
-  BUILD_INFO_BACKUP_CANDIDATE="${BUILD_INFO_FILE}.$$.$RANDOM.bak"
-  cp -p "${BUILD_INFO_FILE}" "${BUILD_INFO_BACKUP_CANDIDATE}"
+  BUILD_INFO_BACKUP_CANDIDATE="$(mktemp "${BUILD_INFO_FILE}.XXXXXX")"
+  if ! cp -p "${BUILD_INFO_FILE}" "${BUILD_INFO_BACKUP_CANDIDATE}"; then
+    rm -f "${BUILD_INFO_BACKUP_CANDIDATE}"
+    echo "Erro: falha ao criar backup temporario de ${BUILD_INFO_FILE}" >&2
+    exit 1
+  fi
   BUILD_INFO_BACKUP="${BUILD_INFO_BACKUP_CANDIDATE}"
 fi
 

--- a/dev_env/build/build_pyoxidizer_debian.sh
+++ b/dev_env/build/build_pyoxidizer_debian.sh
@@ -91,7 +91,6 @@ if [[ ! -s "${BUILD_INFO_FILE}" ]]; then
   echo "Erro: falha ao gerar build_info.json para PyOxidizer debian_amd64" >&2
   exit 1
 fi
-
 PYOX_CMD=(
   uv tool run --python 3.13 --from pyoxidizer pyoxidizer build
   --release

--- a/dev_env/build/build_pyoxidizer_debian.sh
+++ b/dev_env/build/build_pyoxidizer_debian.sh
@@ -42,8 +42,9 @@ fi
 BUILD_INFO_FILE="${REPO_ROOT}/config/build_info.json"
 BUILD_INFO_BACKUP=""
 if [[ -f "${BUILD_INFO_FILE}" ]]; then
-  BUILD_INFO_BACKUP="${BUILD_INFO_FILE}.$$.bak"
-  cp -p "${BUILD_INFO_FILE}" "${BUILD_INFO_BACKUP}"
+  BUILD_INFO_BACKUP_CANDIDATE="${BUILD_INFO_FILE}.$$.$RANDOM.bak"
+  cp -p "${BUILD_INFO_FILE}" "${BUILD_INFO_BACKUP_CANDIDATE}"
+  BUILD_INFO_BACKUP="${BUILD_INFO_BACKUP_CANDIDATE}"
 fi
 
 cleanup_build_info() {
@@ -55,7 +56,7 @@ cleanup_build_info() {
 }
 trap cleanup_build_info EXIT
 
-APP_VERSION="$(
+if ! APP_VERSION="$(
   uv run --python 3.13 python - "${VERSION_FILE}" <<'PY_VERSION'
 import json
 import pathlib
@@ -68,13 +69,24 @@ if not version:
     raise SystemExit("version_short ausente em config/version.json")
 print(version)
 PY_VERSION
-)"
+)"; then
+  echo "Erro: falha ao extrair version_short de config/version.json" >&2
+  exit 1
+fi
+if [[ -z "${APP_VERSION}" ]]; then
+  echo "Erro: version_short vazio em config/version.json" >&2
+  exit 1
+fi
 uv run --python 3.13 "${REPO_ROOT}/dev_env/build/write_build_info.py" \
   --repo-root "${REPO_ROOT}" \
   --output "${BUILD_INFO_FILE}" \
   --build-system pyoxidizer \
   --platform debian_amd64 \
   --app-version "${APP_VERSION}"
+if [[ ! -s "${BUILD_INFO_FILE}" ]]; then
+  echo "Erro: falha ao gerar build_info.json para PyOxidizer debian_amd64" >&2
+  exit 1
+fi
 
 PYOX_CMD=(
   uv tool run --python 3.13 --from pyoxidizer pyoxidizer build

--- a/dev_env/build/build_pyoxidizer_debian.sh
+++ b/dev_env/build/build_pyoxidizer_debian.sh
@@ -55,42 +55,26 @@ cleanup_build_info() {
 }
 trap cleanup_build_info EXIT
 
-uv run --python 3.13 python - "${REPO_ROOT}" "${VERSION_FILE}" "${BUILD_INFO_FILE}" "pyoxidizer" "debian_amd64" <<'PY_BUILD_INFO'
-import datetime
+APP_VERSION="$(
+  uv run --python 3.13 python - "${VERSION_FILE}" <<'PY_VERSION'
 import json
 import pathlib
-import subprocess
 import sys
 
-root = pathlib.Path(sys.argv[1])
-version_file = pathlib.Path(sys.argv[2])
-output = pathlib.Path(sys.argv[3])
-build_system = sys.argv[4]
-platform_name = sys.argv[5]
-
-version_payload = json.loads(version_file.read_text(encoding="utf-8"))
-app_version = str(version_payload.get("version_short") or "").strip()
-if not app_version:
+version_file = pathlib.Path(sys.argv[1])
+payload = json.loads(version_file.read_text(encoding="utf-8"))
+version = str(payload.get("version_short") or "").strip()
+if not version:
     raise SystemExit("version_short ausente em config/version.json")
-
-def run(args):
-    result = subprocess.run(args, cwd=str(root), text=True, capture_output=True, check=False)
-    return (result.stdout or "").strip() if result.returncode == 0 else ""
-
-commit = run(["git", "rev-parse", "HEAD"])
-payload = {
-    "app_version": app_version,
-    "build_datetime": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
-    "build_system": build_system,
-    "git_commit": commit,
-    "git_commit_datetime": run(["git", "log", "-1", "--format=%cI"]),
-    "git_commit_short": commit[:7] if commit else "",
-    "git_commit_title": run(["git", "log", "-1", "--format=%s"]),
-    "platform": platform_name,
-    "uv_version": run(["uv", "--version"]),
-}
-output.write_text(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY_BUILD_INFO
+print(version)
+PY_VERSION
+)"
+uv run --python 3.13 "${REPO_ROOT}/dev_env/build/write_build_info.py" \
+  --repo-root "${REPO_ROOT}" \
+  --output "${BUILD_INFO_FILE}" \
+  --build-system pyoxidizer \
+  --platform debian_amd64 \
+  --app-version "${APP_VERSION}"
 
 PYOX_CMD=(
   uv tool run --python 3.13 --from pyoxidizer pyoxidizer build

--- a/dev_env/build/build_pyoxidizer_debian_arm64.sh
+++ b/dev_env/build/build_pyoxidizer_debian_arm64.sh
@@ -42,8 +42,12 @@ fi
 BUILD_INFO_FILE="${REPO_ROOT}/config/build_info.json"
 BUILD_INFO_BACKUP=""
 if [[ -f "${BUILD_INFO_FILE}" ]]; then
-  BUILD_INFO_BACKUP_CANDIDATE="${BUILD_INFO_FILE}.$$.$RANDOM.bak"
-  cp -p "${BUILD_INFO_FILE}" "${BUILD_INFO_BACKUP_CANDIDATE}"
+  BUILD_INFO_BACKUP_CANDIDATE="$(mktemp "${BUILD_INFO_FILE}.XXXXXX")"
+  if ! cp -p "${BUILD_INFO_FILE}" "${BUILD_INFO_BACKUP_CANDIDATE}"; then
+    rm -f "${BUILD_INFO_BACKUP_CANDIDATE}"
+    echo "Erro: falha ao criar backup temporario de ${BUILD_INFO_FILE}" >&2
+    exit 1
+  fi
   BUILD_INFO_BACKUP="${BUILD_INFO_BACKUP_CANDIDATE}"
 fi
 

--- a/dev_env/build/build_pyoxidizer_debian_arm64.sh
+++ b/dev_env/build/build_pyoxidizer_debian_arm64.sh
@@ -42,8 +42,9 @@ fi
 BUILD_INFO_FILE="${REPO_ROOT}/config/build_info.json"
 BUILD_INFO_BACKUP=""
 if [[ -f "${BUILD_INFO_FILE}" ]]; then
-  BUILD_INFO_BACKUP="${BUILD_INFO_FILE}.$$.bak"
-  cp -p "${BUILD_INFO_FILE}" "${BUILD_INFO_BACKUP}"
+  BUILD_INFO_BACKUP_CANDIDATE="${BUILD_INFO_FILE}.$$.$RANDOM.bak"
+  cp -p "${BUILD_INFO_FILE}" "${BUILD_INFO_BACKUP_CANDIDATE}"
+  BUILD_INFO_BACKUP="${BUILD_INFO_BACKUP_CANDIDATE}"
 fi
 
 cleanup_build_info() {
@@ -55,7 +56,7 @@ cleanup_build_info() {
 }
 trap cleanup_build_info EXIT
 
-APP_VERSION="$(
+if ! APP_VERSION="$(
   uv run --python 3.13 python - "${VERSION_FILE}" <<'PY_VERSION'
 import json
 import pathlib
@@ -68,13 +69,24 @@ if not version:
     raise SystemExit("version_short ausente em config/version.json")
 print(version)
 PY_VERSION
-)"
+)"; then
+  echo "Erro: falha ao extrair version_short de config/version.json" >&2
+  exit 1
+fi
+if [[ -z "${APP_VERSION}" ]]; then
+  echo "Erro: version_short vazio em config/version.json" >&2
+  exit 1
+fi
 uv run --python 3.13 "${REPO_ROOT}/dev_env/build/write_build_info.py" \
   --repo-root "${REPO_ROOT}" \
   --output "${BUILD_INFO_FILE}" \
   --build-system pyoxidizer \
   --platform debian_arm64 \
   --app-version "${APP_VERSION}"
+if [[ ! -s "${BUILD_INFO_FILE}" ]]; then
+  echo "Erro: falha ao gerar build_info.json para PyOxidizer debian_arm64" >&2
+  exit 1
+fi
 
 PYOX_CMD=(
   uv tool run --python 3.13 --from pyoxidizer pyoxidizer build

--- a/dev_env/build/build_pyoxidizer_debian_arm64.sh
+++ b/dev_env/build/build_pyoxidizer_debian_arm64.sh
@@ -91,7 +91,6 @@ if [[ ! -s "${BUILD_INFO_FILE}" ]]; then
   echo "Erro: falha ao gerar build_info.json para PyOxidizer debian_arm64" >&2
   exit 1
 fi
-
 PYOX_CMD=(
   uv tool run --python 3.13 --from pyoxidizer pyoxidizer build
   --release

--- a/dev_env/build/build_pyoxidizer_debian_arm64.sh
+++ b/dev_env/build/build_pyoxidizer_debian_arm64.sh
@@ -55,42 +55,26 @@ cleanup_build_info() {
 }
 trap cleanup_build_info EXIT
 
-uv run --python 3.13 python - "${REPO_ROOT}" "${VERSION_FILE}" "${BUILD_INFO_FILE}" "pyoxidizer" "debian_arm64" <<'PY_BUILD_INFO'
-import datetime
+APP_VERSION="$(
+  uv run --python 3.13 python - "${VERSION_FILE}" <<'PY_VERSION'
 import json
 import pathlib
-import subprocess
 import sys
 
-root = pathlib.Path(sys.argv[1])
-version_file = pathlib.Path(sys.argv[2])
-output = pathlib.Path(sys.argv[3])
-build_system = sys.argv[4]
-platform_name = sys.argv[5]
-
-version_payload = json.loads(version_file.read_text(encoding="utf-8"))
-app_version = str(version_payload.get("version_short") or "").strip()
-if not app_version:
+version_file = pathlib.Path(sys.argv[1])
+payload = json.loads(version_file.read_text(encoding="utf-8"))
+version = str(payload.get("version_short") or "").strip()
+if not version:
     raise SystemExit("version_short ausente em config/version.json")
-
-def run(args):
-    result = subprocess.run(args, cwd=str(root), text=True, capture_output=True, check=False)
-    return (result.stdout or "").strip() if result.returncode == 0 else ""
-
-commit = run(["git", "rev-parse", "HEAD"])
-payload = {
-    "app_version": app_version,
-    "build_datetime": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
-    "build_system": build_system,
-    "git_commit": commit,
-    "git_commit_datetime": run(["git", "log", "-1", "--format=%cI"]),
-    "git_commit_short": commit[:7] if commit else "",
-    "git_commit_title": run(["git", "log", "-1", "--format=%s"]),
-    "platform": platform_name,
-    "uv_version": run(["uv", "--version"]),
-}
-output.write_text(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY_BUILD_INFO
+print(version)
+PY_VERSION
+)"
+uv run --python 3.13 "${REPO_ROOT}/dev_env/build/write_build_info.py" \
+  --repo-root "${REPO_ROOT}" \
+  --output "${BUILD_INFO_FILE}" \
+  --build-system pyoxidizer \
+  --platform debian_arm64 \
+  --app-version "${APP_VERSION}"
 
 PYOX_CMD=(
   uv tool run --python 3.13 --from pyoxidizer pyoxidizer build

--- a/dev_env/build/release_platform_report.py
+++ b/dev_env/build/release_platform_report.py
@@ -299,6 +299,45 @@ def _asset_payload(path: pathlib.Path) -> dict[str, object]:
         raise ReleaseReportError(f"falha lendo asset {path}: {exc}") from exc
 
 
+def _expected_debian_asset_names(
+    backends: list[str],
+    packages: list[str],
+    app_version: str,
+) -> set[str]:
+    names: set[str] = set()
+    for backend in backends:
+        if "deb" in packages:
+            names.add(f"ssa-consulta-rapida-{backend}-amd64_{app_version}_amd64.deb")
+        if "appimage" in packages and backend != "pyoxidizer":
+            names.add(
+                f"SSA_Consulta_Rapida_v{app_version}_debian_amd64_{backend}.AppImage"
+            )
+        if "tar" in packages:
+            if backend in {"pyinstaller", "nuitka"}:
+                names.add(
+                    f"SSA_Consulta_Rapida_v{app_version}_debian_amd64_{backend}_cli.tar.gz"
+                )
+                names.add(
+                    f"SSA_Consulta_Rapida_v{app_version}_debian_amd64_{backend}_gui.tar.gz"
+                )
+            else:
+                names.add(
+                    f"SSA_Consulta_Rapida_v{app_version}_debian_amd64_{backend}.tar.gz"
+                )
+    return names
+
+
+def _expected_asset_names(
+    platform_name: str,
+    backends: list[str],
+    packages: list[str],
+    app_version: str,
+) -> set[str] | None:
+    if platform_name == "debian_amd64":
+        return _expected_debian_asset_names(backends, packages, app_version)
+    return None
+
+
 def cmd_print_app_version(args: argparse.Namespace) -> int:
     payload = _read_json(args.version_file)
     version = str(payload.get("version_short") or "").strip()
@@ -354,22 +393,29 @@ def _asset_suffixes_for_platform(platform_name: str) -> tuple[str, ...]:
 
 
 def write_report(args: argparse.Namespace) -> int:
+    backends = [item for item in args.backends.split(",") if item]
+    packages = [item for item in args.packages.split(",") if item]
     package_dir = args.repo_root / "builds" / "packages" / args.platform
     assets = []
     if package_dir.is_dir():
         asset_suffixes = _asset_suffixes_for_platform(args.platform)
+        expected_asset_names = _expected_asset_names(
+            args.platform,
+            backends,
+            packages,
+            args.app_version,
+        )
         asset_paths = [
             path
             for path in sorted(package_dir.iterdir())
             if path.is_file() and path.name.lower().endswith(asset_suffixes)
+            and (expected_asset_names is None or path.name in expected_asset_names)
         ]
         if asset_paths:
             workers = min(4, len(asset_paths))
             with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
                 assets = list(executor.map(_asset_payload, asset_paths))
 
-    backends = [item for item in args.backends.split(",") if item]
-    packages = [item for item in args.packages.split(",") if item]
     scorecards = _load_scorecards()
     unknown_backends = [backend for backend in backends if backend not in scorecards]
     if unknown_backends:

--- a/dev_env/build/release_platform_report.py
+++ b/dev_env/build/release_platform_report.py
@@ -408,24 +408,26 @@ def write_report(args: argparse.Namespace) -> int:
     packages = _split_csv(args.packages)
     package_dir = args.repo_root / "builds" / "packages" / args.platform
     assets = []
-    if package_dir.is_dir():
-        asset_suffixes = _asset_suffixes_for_packages(packages)
-        expected_asset_names = _expected_asset_names(
-            args.platform,
-            backends,
-            packages,
-            args.app_version,
-        )
-        asset_paths = [
-            path
-            for path in sorted(package_dir.iterdir())
-            if path.is_file() and path.name.lower().endswith(asset_suffixes)
-            and (expected_asset_names is None or path.name in expected_asset_names)
-        ]
-        if asset_paths:
-            workers = min(4, len(asset_paths))
-            with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-                assets = list(executor.map(_asset_payload, asset_paths))
+    if not package_dir.is_dir():
+        raise ReleaseReportError(f"diretorio de pacotes ausente: {package_dir}")
+
+    asset_suffixes = _asset_suffixes_for_packages(packages)
+    expected_asset_names = _expected_asset_names(
+        args.platform,
+        backends,
+        packages,
+        args.app_version,
+    )
+    asset_paths = [
+        path
+        for path in sorted(package_dir.iterdir())
+        if path.is_file() and path.name.lower().endswith(asset_suffixes)
+        and (expected_asset_names is None or path.name in expected_asset_names)
+    ]
+    if asset_paths:
+        workers = min(4, len(asset_paths))
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            assets = list(executor.map(_asset_payload, asset_paths))
 
     scorecards = _load_scorecards()
     unknown_backends = [backend for backend in backends if backend not in scorecards]

--- a/dev_env/build/release_platform_report.py
+++ b/dev_env/build/release_platform_report.py
@@ -392,13 +392,24 @@ def _asset_suffixes_for_platform(platform_name: str) -> tuple[str, ...]:
     return tuple(suffix.lower() for suffix in suffixes)
 
 
+def _split_csv(value: str) -> list[str]:
+    return [item.strip().lower() for item in value.split(",") if item.strip()]
+
+
+def _asset_suffixes_for_packages(packages: list[str]) -> tuple[str, ...]:
+    suffixes: list[str] = []
+    for package in packages:
+        suffixes.extend(PACKAGE_ASSET_SUFFIXES.get(package, (f".{package}",)))
+    return tuple(suffix.lower() for suffix in suffixes)
+
+
 def write_report(args: argparse.Namespace) -> int:
-    backends = [item for item in args.backends.split(",") if item]
-    packages = [item for item in args.packages.split(",") if item]
+    backends = _split_csv(args.backends)
+    packages = _split_csv(args.packages)
     package_dir = args.repo_root / "builds" / "packages" / args.platform
     assets = []
     if package_dir.is_dir():
-        asset_suffixes = _asset_suffixes_for_platform(args.platform)
+        asset_suffixes = _asset_suffixes_for_packages(packages)
         expected_asset_names = _expected_asset_names(
             args.platform,
             backends,

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -402,35 +402,29 @@ function Invoke-Smoke {
         )
         Set-Content -LiteralPath $wrapperPath -Value $wrapperLines -Encoding ASCII
 
-        $process = Start-Process `
-            -FilePath $env:ComSpec `
-            -ArgumentList @("/d", "/c", "`"$wrapperPath`"") `
-            -RedirectStandardInput $stdinPath `
-            -RedirectStandardOutput $stdoutPath `
-            -RedirectStandardError $stderrPath `
-            -NoNewWindow `
-            -PassThru
         $smokeTimeoutSeconds = 60
-        $deadline = (Get-Date).AddSeconds($smokeTimeoutSeconds)
-        while (-not $process.HasExited -and (Get-Date) -lt $deadline) {
-            Start-Sleep -Milliseconds 200
-            $process.Refresh()
+        $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+        $startInfo.FileName = $env:ComSpec
+        $startInfo.Arguments = "/d /c `"`"$wrapperPath`" < `"$stdinPath`" > `"$stdoutPath`" 2> `"$stderrPath`"`""
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+
+        $process = New-Object System.Diagnostics.Process
+        $process.StartInfo = $startInfo
+        if (-not $process.Start()) {
+            throw "Smoke CLI falhou para ${BackendName}. Processo nao iniciou."
         }
-        $timedOut = -not $process.HasExited
+        $completed = $process.WaitForExit($smokeTimeoutSeconds * 1000)
+        $timedOut = -not $completed
         if ($timedOut) {
             if (-not $process.HasExited) {
-                Stop-Process -Id $process.Id -Force
+                $process.Kill()
                 [void]$process.WaitForExit(10000)
             }
             $process.Refresh()
         }
         $exitCode = 1
         if (-not $timedOut) {
-            [void]$process.WaitForExit()
-            $process.Refresh()
-            if ($null -eq $process.ExitCode) {
-                throw "Smoke CLI falhou para ${BackendName}. ExitCode indisponivel."
-            }
             $exitCode = $process.ExitCode
         }
         $stderrText = ""

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -413,13 +413,13 @@ function Invoke-Smoke {
             -PassThru
         $stderrText = ""
         if (Test-Path $stderrPath) {
-            $stderrText = (Get-Content -LiteralPath $stderrPath -Raw -ErrorAction SilentlyContinue).Trim()
+            $stderrText = ([string] (Get-Content -LiteralPath $stderrPath -Raw -ErrorAction SilentlyContinue)).Trim()
         }
         if ($process.ExitCode -ne 0) {
             throw "Smoke CLI falhou para ${BackendName}. ExitCode=$($process.ExitCode). $stderrText"
         }
         if (Test-Path $stdoutPath) {
-            $smokeOutput = (Get-Content -LiteralPath $stdoutPath -Raw -ErrorAction SilentlyContinue).Trim()
+            $smokeOutput = ([string] (Get-Content -LiteralPath $stdoutPath -Raw -ErrorAction SilentlyContinue)).Trim()
         }
         if ($smokeOutput -match "DADOS CARREGADOS:\s+[1-9][0-9.,]*\s+SSAs") {
             throw "Smoke CLI contaminado por dados locais para ${BackendName}."

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -381,28 +381,45 @@ function Invoke-Smoke {
     $smokeDir = Join-Path ([System.IO.Path]::GetTempPath()) ("ssa_release_smoke_" + [guid]::NewGuid().ToString("N"))
     New-Item -ItemType Directory -Force $smokeDir | Out-Null
     try {
-        $stdinPath = Join-Path $smokeDir "stdin.txt"
-        $stdoutPath = Join-Path $smokeDir "stdout.txt"
-        $stderrPath = Join-Path $smokeDir "stderr.txt"
-        Set-Content -LiteralPath $stdinPath -Value "q`n" -NoNewline -Encoding ASCII
-        $process = Start-Process `
-            -FilePath (Resolve-Path $Config.cli_exe).Path `
-            -ArgumentList "--skip-import" `
-            -RedirectStandardInput $stdinPath `
-            -RedirectStandardOutput $stdoutPath `
-            -RedirectStandardError $stderrPath `
-            -NoNewWindow `
-            -Wait `
-            -PassThru
+        $appDataDir = Join-Path $smokeDir "appdata"
+        $localAppDataDir = Join-Path $smokeDir "localappdata"
+        $userProfileDir = Join-Path $smokeDir "userprofile"
+        New-Item -ItemType Directory -Force $appDataDir, $localAppDataDir, $userProfileDir | Out-Null
+
+        $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+        $processInfo.FileName = (Resolve-Path $Config.cli_exe).Path
+        $processInfo.Arguments = "--skip-import"
+        $processInfo.WorkingDirectory = $smokeDir
+        $processInfo.UseShellExecute = $false
+        $processInfo.RedirectStandardInput = $true
+        $processInfo.RedirectStandardOutput = $true
+        $processInfo.RedirectStandardError = $true
+        $processInfo.EnvironmentVariables["APPDATA"] = $appDataDir
+        $processInfo.EnvironmentVariables["LOCALAPPDATA"] = $localAppDataDir
+        $processInfo.EnvironmentVariables["USERPROFILE"] = $userProfileDir
+        foreach ($key in @($processInfo.EnvironmentVariables.Keys | Where-Object { $_ -like "SSA_*" })) {
+            $processInfo.EnvironmentVariables.Remove($key)
+        }
+
+        $process = New-Object System.Diagnostics.Process
+        $process.StartInfo = $processInfo
+        if (-not $process.Start()) {
+            throw "Smoke CLI nao iniciou para ${BackendName}."
+        }
+        $process.StandardInput.WriteLine("q")
+        $process.StandardInput.Close()
+        $stdoutText = $process.StandardOutput.ReadToEnd()
+        $stderrText = $process.StandardError.ReadToEnd()
+        if (-not $process.WaitForExit(60000)) {
+            $process.Kill()
+            throw "Smoke CLI timeout para ${BackendName}."
+        }
         if ($process.ExitCode -ne 0) {
-            $stderrText = ""
-            if (Test-Path $stderrPath) {
-                $stderrText = (Get-Content -LiteralPath $stderrPath -Raw -ErrorAction SilentlyContinue).Trim()
-            }
             throw "Smoke CLI falhou para ${BackendName}. ExitCode=$($process.ExitCode). $stderrText"
         }
-        if (Test-Path $stdoutPath) {
-            $smokeOutput = (Get-Content -LiteralPath $stdoutPath -Raw -ErrorAction SilentlyContinue).Trim()
+        $smokeOutput = $stdoutText.Trim()
+        if ($smokeOutput -match "DADOS CARREGADOS:\s+[1-9][0-9.,]*\s+SSAs") {
+            throw "Smoke CLI contaminado por dados locais para ${BackendName}."
         }
     } finally {
         if (Test-Path $smokeDir) {

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -386,38 +386,41 @@ function Invoke-Smoke {
         $userProfileDir = Join-Path $smokeDir "userprofile"
         New-Item -ItemType Directory -Force $appDataDir, $localAppDataDir, $userProfileDir | Out-Null
 
-        $processInfo = New-Object System.Diagnostics.ProcessStartInfo
-        $processInfo.FileName = (Resolve-Path $Config.cli_exe).Path
-        $processInfo.Arguments = "--skip-import"
-        $processInfo.WorkingDirectory = $smokeDir
-        $processInfo.UseShellExecute = $false
-        $processInfo.RedirectStandardInput = $true
-        $processInfo.RedirectStandardOutput = $true
-        $processInfo.RedirectStandardError = $true
-        $processInfo.EnvironmentVariables["APPDATA"] = $appDataDir
-        $processInfo.EnvironmentVariables["LOCALAPPDATA"] = $localAppDataDir
-        $processInfo.EnvironmentVariables["USERPROFILE"] = $userProfileDir
-        foreach ($key in @($processInfo.EnvironmentVariables.Keys | Where-Object { $_ -like "SSA_*" })) {
-            $processInfo.EnvironmentVariables.Remove($key)
-        }
+        $stdinPath = Join-Path $smokeDir "stdin.txt"
+        $stdoutPath = Join-Path $smokeDir "stdout.txt"
+        $stderrPath = Join-Path $smokeDir "stderr.txt"
+        $wrapperPath = Join-Path $smokeDir "smoke.cmd"
+        Set-Content -LiteralPath $stdinPath -Value "q`n" -NoNewline -Encoding ASCII
+        $wrapperLines = @(
+            "@echo off",
+            "set `"APPDATA=$appDataDir`"",
+            "set `"LOCALAPPDATA=$localAppDataDir`"",
+            "set `"USERPROFILE=$userProfileDir`"",
+            "for /f `"tokens=1 delims==`" %%A in ('set SSA_ 2^>nul') do set `"%%A=`"",
+            "cd /d `"$smokeDir`"",
+            "`"$((Resolve-Path $Config.cli_exe).Path)`" --skip-import"
+        )
+        Set-Content -LiteralPath $wrapperPath -Value $wrapperLines -Encoding ASCII
 
-        $process = New-Object System.Diagnostics.Process
-        $process.StartInfo = $processInfo
-        if (-not $process.Start()) {
-            throw "Smoke CLI nao iniciou para ${BackendName}."
-        }
-        $process.StandardInput.WriteLine("q")
-        $process.StandardInput.Close()
-        $stdoutText = $process.StandardOutput.ReadToEnd()
-        $stderrText = $process.StandardError.ReadToEnd()
-        if (-not $process.WaitForExit(60000)) {
-            $process.Kill()
-            throw "Smoke CLI timeout para ${BackendName}."
+        $process = Start-Process `
+            -FilePath $env:ComSpec `
+            -ArgumentList @("/d", "/c", "`"$wrapperPath`"") `
+            -RedirectStandardInput $stdinPath `
+            -RedirectStandardOutput $stdoutPath `
+            -RedirectStandardError $stderrPath `
+            -NoNewWindow `
+            -Wait `
+            -PassThru
+        $stderrText = ""
+        if (Test-Path $stderrPath) {
+            $stderrText = (Get-Content -LiteralPath $stderrPath -Raw -ErrorAction SilentlyContinue).Trim()
         }
         if ($process.ExitCode -ne 0) {
             throw "Smoke CLI falhou para ${BackendName}. ExitCode=$($process.ExitCode). $stderrText"
         }
-        $smokeOutput = $stdoutText.Trim()
+        if (Test-Path $stdoutPath) {
+            $smokeOutput = (Get-Content -LiteralPath $stdoutPath -Raw -ErrorAction SilentlyContinue).Trim()
+        }
         if ($smokeOutput -match "DADOS CARREGADOS:\s+[1-9][0-9.,]*\s+SSAs") {
             throw "Smoke CLI contaminado por dados locais para ${BackendName}."
         }

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -426,7 +426,11 @@ function Invoke-Smoke {
         }
         $exitCode = 1
         if (-not $timedOut) {
+            [void]$process.WaitForExit()
             $process.Refresh()
+            if ($null -eq $process.ExitCode) {
+                throw "Smoke CLI falhou para ${BackendName}. ExitCode indisponivel."
+            }
             $exitCode = $process.ExitCode
         }
         $stderrText = ""

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -413,13 +413,19 @@ function Invoke-Smoke {
             -PassThru
         $stderrText = ""
         if (Test-Path $stderrPath) {
-            $stderrText = ([string] (Get-Content -LiteralPath $stderrPath -Raw -ErrorAction SilentlyContinue)).Trim()
+            $stderrRaw = Get-Content -LiteralPath $stderrPath -Raw -ErrorAction SilentlyContinue
+            if ($null -ne $stderrRaw) {
+                $stderrText = $stderrRaw.Trim()
+            }
         }
         if ($process.ExitCode -ne 0) {
             throw "Smoke CLI falhou para ${BackendName}. ExitCode=$($process.ExitCode). $stderrText"
         }
         if (Test-Path $stdoutPath) {
-            $smokeOutput = ([string] (Get-Content -LiteralPath $stdoutPath -Raw -ErrorAction SilentlyContinue)).Trim()
+            $stdoutRaw = Get-Content -LiteralPath $stdoutPath -Raw -ErrorAction SilentlyContinue
+            if ($null -ne $stdoutRaw) {
+                $smokeOutput = $stdoutRaw.Trim()
+            }
         }
         if ($smokeOutput -match "DADOS CARREGADOS:\s+[1-9][0-9.,]*\s+SSAs") {
             throw "Smoke CLI contaminado por dados locais para ${BackendName}."

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -543,6 +543,7 @@ function Get-ArtifactHash {
         }
         else {
             $stream = [System.IO.File]::OpenRead($path)
+            $sha256 = $null
             try {
                 $sha256 = [System.Security.Cryptography.SHA256]::Create()
                 $hashBytes = $sha256.ComputeHash($stream)

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -409,8 +409,26 @@ function Invoke-Smoke {
             -RedirectStandardOutput $stdoutPath `
             -RedirectStandardError $stderrPath `
             -NoNewWindow `
-            -Wait `
             -PassThru
+        $smokeTimeoutSeconds = 60
+        $deadline = (Get-Date).AddSeconds($smokeTimeoutSeconds)
+        while (-not $process.HasExited -and (Get-Date) -lt $deadline) {
+            Start-Sleep -Milliseconds 200
+            $process.Refresh()
+        }
+        $timedOut = -not $process.HasExited
+        if ($timedOut) {
+            if (-not $process.HasExited) {
+                Stop-Process -Id $process.Id -Force
+                [void]$process.WaitForExit(10000)
+            }
+            $process.Refresh()
+        }
+        $exitCode = 1
+        if (-not $timedOut) {
+            $process.Refresh()
+            $exitCode = $process.ExitCode
+        }
         $stderrText = ""
         if (Test-Path $stderrPath) {
             $stderrRaw = Get-Content -LiteralPath $stderrPath -Raw -ErrorAction SilentlyContinue
@@ -418,8 +436,11 @@ function Invoke-Smoke {
                 $stderrText = $stderrRaw.Trim()
             }
         }
-        if ($process.ExitCode -ne 0) {
-            throw "Smoke CLI falhou para ${BackendName}. ExitCode=$($process.ExitCode). $stderrText"
+        if ($timedOut) {
+            throw "Smoke CLI timeout para ${BackendName} depois de ${smokeTimeoutSeconds}s. $stderrText"
+        }
+        if ($exitCode -ne 0) {
+            throw "Smoke CLI falhou para ${BackendName}. ExitCode=${exitCode}. $stderrText"
         }
         if (Test-Path $stdoutPath) {
             $stdoutRaw = Get-Content -LiteralPath $stdoutPath -Raw -ErrorAction SilentlyContinue

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -556,9 +556,9 @@ function Get-ArtifactHash {
     param([Parameter(Mandatory = $true)] [string[]] $Paths)
 
     $records = @()
+    $hashCommand = Get-Command -Name "Get-FileHash" -ErrorAction SilentlyContinue
     foreach ($path in $Paths) {
         Assert-ExistingFile $path
-        $hashCommand = Get-Command -Name "Get-FileHash" -ErrorAction SilentlyContinue
         if ($hashCommand) {
             $hash = & $hashCommand -Algorithm SHA256 -LiteralPath $path
             $hashPath = $hash.Path

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -509,10 +509,30 @@ function Get-ArtifactHash {
     $records = @()
     foreach ($path in $Paths) {
         Assert-ExistingFile $path
-        $hash = Get-FileHash -Algorithm SHA256 -LiteralPath $path
+        $hashCommand = Get-Command -Name "Get-FileHash" -ErrorAction SilentlyContinue
+        if ($hashCommand) {
+            $hash = & $hashCommand -Algorithm SHA256 -LiteralPath $path
+            $hashPath = $hash.Path
+            $hashValue = $hash.Hash
+        }
+        else {
+            $stream = [System.IO.File]::OpenRead($path)
+            try {
+                $sha256 = [System.Security.Cryptography.SHA256]::Create()
+                $hashBytes = $sha256.ComputeHash($stream)
+                $hashValue = ([System.BitConverter]::ToString($hashBytes) -replace "-", "").ToUpperInvariant()
+            }
+            finally {
+                if ($sha256) {
+                    $sha256.Dispose()
+                }
+                $stream.Dispose()
+            }
+            $hashPath = (Resolve-Path -LiteralPath $path).Path
+        }
         $records += [ordered]@{
-            path = $hash.Path
-            sha256 = $hash.Hash
+            path = $hashPath
+            sha256 = $hashValue
             length = (Get-Item -LiteralPath $path).Length
         }
     }

--- a/dev_env/build/release_windows.ps1
+++ b/dev_env/build/release_windows.ps1
@@ -400,7 +400,8 @@ function Invoke-Smoke {
             "cd /d `"$smokeDir`"",
             "`"$((Resolve-Path $Config.cli_exe).Path)`" --skip-import"
         )
-        Set-Content -LiteralPath $wrapperPath -Value $wrapperLines -Encoding ASCII
+        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllLines($wrapperPath, $wrapperLines, $utf8NoBom)
 
         $smokeTimeoutSeconds = 60
         $startInfo = New-Object System.Diagnostics.ProcessStartInfo
@@ -418,7 +419,10 @@ function Invoke-Smoke {
         $timedOut = -not $completed
         if ($timedOut) {
             if (-not $process.HasExited) {
-                $process.Kill()
+                & taskkill.exe /PID $process.Id /T /F | Out-Null
+                if ($LASTEXITCODE -ne 0 -and -not $process.HasExited) {
+                    $process.Kill()
+                }
                 [void]$process.WaitForExit(10000)
             }
             $process.Refresh()

--- a/dev_env/build/write_build_info.py
+++ b/dev_env/build/write_build_info.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import pathlib
+import subprocess
+
+
+def _run_output(args: list[str], cwd: pathlib.Path, *, require_success: bool) -> str:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=str(cwd),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if require_success and result.returncode != 0:
+        return ""
+    return "\n".join(
+        part.strip() for part in (result.stdout, result.stderr) if part and part.strip()
+    ).strip()
+
+
+def _first_line(text: str) -> str:
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return ""
+
+
+def _first_tool_version(commands: tuple[list[str], ...], cwd: pathlib.Path) -> str:
+    for command in commands:
+        output = _run_output(command, cwd, require_success=False)
+        if output:
+            return _first_line(output)
+    return ""
+
+
+def _c_compiler_version(cwd: pathlib.Path) -> str:
+    cc_env = os.environ.get("CC", "").strip()
+    commands: list[list[str]] = []
+    if cc_env:
+        commands.append([cc_env, "--version"])
+    commands.extend(
+        (
+            ["cc", "--version"],
+            ["gcc", "--version"],
+            ["clang", "--version"],
+            ["cl"],
+        )
+    )
+    version = _first_tool_version(tuple(commands), cwd)
+    if version:
+        return version
+    msvc_version = os.environ.get("VCToolsVersion", "").strip()
+    if msvc_version:
+        return f"MSVC {msvc_version}"
+    return ""
+
+
+def build_payload(
+    repo_root: pathlib.Path,
+    build_system: str,
+    platform_name: str,
+    app_version: str,
+) -> dict[str, str]:
+    commit = _run_output(["git", "rev-parse", "HEAD"], repo_root, require_success=True)
+    return {
+        "app_version": app_version,
+        "build_datetime": datetime.datetime.now()
+        .astimezone()
+        .isoformat(timespec="seconds"),
+        "build_system": build_system,
+        "c_compiler_version": _c_compiler_version(repo_root),
+        "git_commit": commit,
+        "git_commit_datetime": _run_output(
+            ["git", "log", "-1", "--format=%cI"],
+            repo_root,
+            require_success=True,
+        ),
+        "git_commit_short": commit[:7] if commit else "",
+        "git_commit_title": _run_output(
+            ["git", "log", "-1", "--format=%s"],
+            repo_root,
+            require_success=True,
+        ),
+        "platform": platform_name,
+        "rustc_version": _first_tool_version((["rustc", "--version"],), repo_root),
+        "uv_version": _run_output(["uv", "--version"], repo_root, require_success=True),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=pathlib.Path, required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--build-system", required=True)
+    parser.add_argument("--platform", required=True)
+    parser.add_argument("--app-version", required=True)
+    args = parser.parse_args()
+
+    payload = build_payload(
+        args.repo_root,
+        args.build_system,
+        args.platform,
+        args.app_version,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev_env/build/write_build_info.py
+++ b/dev_env/build/write_build_info.py
@@ -6,6 +6,7 @@ import json
 import os
 import pathlib
 import subprocess
+import sys
 
 
 def _run_output(args: list[str], cwd: pathlib.Path, *, require_success: bool) -> str:
@@ -112,11 +113,15 @@ def main() -> int:
         args.platform,
         args.app_version,
     )
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(
-        json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    try:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        print(f"Failed to write build info: {exc}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/dev_env/build/write_build_info.py
+++ b/dev_env/build/write_build_info.py
@@ -19,10 +19,24 @@ def _run_output(args: list[str], cwd: pathlib.Path, *, require_success: bool) ->
             check=False,
             timeout=20,
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except OSError as exc:
+        if require_success:
+            print(f"Metadata command failed ({' '.join(args)}): {exc}", file=sys.stderr)
         return ""
-    if require_success and result.returncode != 0:
+    except subprocess.TimeoutExpired as exc:
+        if require_success:
+            print(f"Metadata command timed out ({' '.join(args)}): {exc}", file=sys.stderr)
         return ""
+    if result.returncode != 0:
+        if require_success:
+            print(
+                "Metadata command failed "
+                f"({' '.join(args)}): exit {result.returncode}; "
+                f"stdout={result.stdout.strip()!r}; stderr={result.stderr.strip()!r}",
+                file=sys.stderr,
+            )
+            return ""
+        return result.stdout.strip()
     return "\n".join(
         part.strip() for part in (result.stdout, result.stderr) if part and part.strip()
     ).strip()
@@ -115,10 +129,9 @@ def main() -> int:
     )
     try:
         args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(
-            json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
+        serialized = json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True)
+        json.loads(serialized)
+        args.output.write_text(serialized + "\n", encoding="utf-8")
     except OSError as exc:
         print(f"Failed to write build info: {exc}", file=sys.stderr)
         return 1

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -34,11 +34,15 @@ Escopo deste slice:
 4. endurecer `secret_scan.yml` sem imprimir segredo em logs.
 
 Pendente nao bloqueante:
-1. extrair a logica shell de `.github/workflows/secret_scan.yml` para script versionado ou composite action, para reduzir duplicacao entre scan de workspace, PR diff e historico.
-2. avaliar scan historico completo com TruffleHog fora do limite padrao de 60s, porque o scan local de historico excedeu a janela nesta rodada.
-3. revisar achados antigos do `gitleaks` em `.secrets.baseline` e artefatos ignorados, sem imprimir valores sensiveis.
-4. avaliar limite de escopo/profundidade no scan recursivo do `secret_scan.yml` se o tempo de CI crescer.
-5. centralizar constantes de versao usadas por `tests/test_shell_ci_contracts.py` e scripts de ambiente, para evitar drift em proximo bump.
+1. avaliar scan historico completo com TruffleHog fora do limite padrao de 60s, porque o scan local de historico excedeu a janela nesta rodada.
+2. revisar achados antigos do `gitleaks` em `.secrets.baseline` e artefatos ignorados, sem imprimir valores sensiveis.
+3. avaliar limite de escopo/profundidade no scan recursivo do `secret_scan.yml` se o tempo de CI crescer.
+4. centralizar constantes de versao usadas por `tests/test_shell_ci_contracts.py` e scripts de ambiente, para evitar drift em proximo bump.
+
+Feito em 2026-05-03:
+1. `.github/workflows/secret_scan.yml` passou a chamar `scripts/security/scan_secrets.sh`.
+2. o script versionado centraliza os modos `workspace`, `pr-diff` e `history`.
+3. `tests/test_shell_ci_contracts.py` cobre sintaxe e smoke local do script.
 
 ## Update 2026-04-29 20:35 - Debian release orchestrator
 

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -35,14 +35,15 @@ Escopo deste slice:
 
 Pendente nao bloqueante:
 1. avaliar scan historico completo com TruffleHog fora do limite padrao de 60s, porque o scan local de historico excedeu a janela nesta rodada.
-2. revisar achados antigos do `gitleaks` em `.secrets.baseline` e artefatos ignorados, sem imprimir valores sensiveis.
-3. avaliar limite de escopo/profundidade no scan recursivo do `secret_scan.yml` se o tempo de CI crescer.
-4. centralizar constantes de versao usadas por `tests/test_shell_ci_contracts.py` e scripts de ambiente, para evitar drift em proximo bump.
+2. avaliar limite de escopo/profundidade no scan recursivo do `secret_scan.yml` se o tempo de CI crescer.
+3. centralizar constantes de versao usadas por `tests/test_shell_ci_contracts.py` e scripts de ambiente, para evitar drift em proximo bump.
 
 Feito em 2026-05-03:
 1. `.github/workflows/secret_scan.yml` passou a chamar `scripts/security/scan_secrets.sh`.
 2. o script versionado centraliza os modos `workspace`, `pr-diff` e `history`.
 3. `tests/test_shell_ci_contracts.py` cobre sintaxe e smoke local do script.
+4. `.secrets.baseline` foi revisada sem imprimir valores sensiveis; os achados remanescentes eram hashes e referencias sem valor em claro.
+5. `.gitleaks.toml` passou a estender regras padrao e permitir apenas linhas `hashed_secret` da baseline.
 
 ## Update 2026-04-29 20:35 - Debian release orchestrator
 

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -25,6 +25,21 @@ O escopo fica dividido por prioridade para manter a entrega segura e incremental
 
 ## ACTIVE PRIORITIES
 
+## Update 2026-05-03 - security scan follow-ups
+
+Escopo deste slice:
+1. corrigir permissoes e persistencia de credenciais em workflows GitHub Actions.
+2. corrigir marcadores de ambiente em requirements para evitar falso positivo de OSV.
+3. atualizar `black` para versao sem `GHSA-3936-cmfr-pm3m`.
+4. endurecer `secret_scan.yml` sem imprimir segredo em logs.
+
+Pendente nao bloqueante:
+1. extrair a logica shell de `.github/workflows/secret_scan.yml` para script versionado ou composite action, para reduzir duplicacao entre scan de workspace, PR diff e historico.
+2. avaliar scan historico completo com TruffleHog fora do limite padrao de 60s, porque o scan local de historico excedeu a janela nesta rodada.
+3. revisar achados antigos do `gitleaks` em `.secrets.baseline` e artefatos ignorados, sem imprimir valores sensiveis.
+4. avaliar limite de escopo/profundidade no scan recursivo do `secret_scan.yml` se o tempo de CI crescer.
+5. centralizar constantes de versao usadas por `tests/test_shell_ci_contracts.py` e scripts de ambiente, para evitar drift em proximo bump.
+
 ## Update 2026-04-29 20:35 - Debian release orchestrator
 
 Escopo desta atualizacao:

--- a/gui/gui_ssa.py
+++ b/gui/gui_ssa.py
@@ -1195,6 +1195,12 @@ def build_about_message(app_version: str) -> str:
     build_datetime = str(build_info.get("build_datetime") or "").strip()
     if build_datetime:
         lines.append(f"Build: {build_datetime}")
+    c_compiler_version = str(build_info.get("c_compiler_version") or "").strip()
+    if c_compiler_version:
+        lines.append(f"C/C++: {c_compiler_version}")
+    rustc_version = str(build_info.get("rustc_version") or "").strip()
+    if rustc_version:
+        lines.append(f"Rust: {rustc_version}")
     return "\n".join(lines)
 
 

--- a/launchers/README.md
+++ b/launchers/README.md
@@ -61,10 +61,10 @@ launchers/
 Para compressao opcional no Windows:
 
 ```bash
-uv pip install --python 3.13 -r launchers/platforms/windows_amd64/requirements_windows_build.txt
+scoop install upx
 ```
 
-Se `upx4py` nao estiver instalado, o build continua sem compressao.
+Se `upx` nao estiver no `PATH`, o build continua sem compressao.
 
 ## Troubleshooting
 
@@ -92,4 +92,3 @@ uv run --python 3.13 launchers/build_multiplatform.py --clean-all
 - Estado oficial de runtime/build para este ciclo e v4.33.
 
 <!-- DOC_SYNC_MAC: 2026-03-29 host-agnostic paths, continue from repo root on macOS -->
-

--- a/launchers/build_multiplatform.py
+++ b/launchers/build_multiplatform.py
@@ -26,6 +26,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 robust_logging = importlib.import_module("utils.robust_logging")
 logger = robust_logging.get_robust_logger().get_logger(__name__, "maintenance")
+write_build_info = importlib.import_module("dev_env.build.write_build_info")
 
 
 class MultiPlatformBuilder:
@@ -135,21 +136,12 @@ class MultiPlatformBuilder:
         return str(result.stdout or "").strip()
 
     def _build_info_payload(self, build_system: str, platform_name: str) -> dict:
-        git_commit = self._command_stdout(["git", "rev-parse", "HEAD"])
-        git_commit_datetime = self._command_stdout(["git", "log", "-1", "--format=%cI"])
-        git_commit_title = self._command_stdout(["git", "log", "-1", "--format=%s"])
-        uv_version = self._command_stdout([self.uv_cmd, "--version"])
-        return {
-            "app_version": self.version,
-            "build_datetime": datetime.now().astimezone().isoformat(timespec="seconds"),
-            "build_system": build_system,
-            "git_commit": git_commit,
-            "git_commit_datetime": git_commit_datetime,
-            "git_commit_short": git_commit[:7] if git_commit else "",
-            "git_commit_title": git_commit_title,
-            "platform": platform_name,
-            "uv_version": uv_version,
-        }
+        return write_build_info.build_payload(
+            self.base_dir,
+            build_system,
+            platform_name,
+            self.version,
+        )
 
     def _write_build_info_file(self, build_system: str, platform_name: str) -> Path:
         metadata_dir = self.platforms_dir / platform_name / "temp"

--- a/launchers/build_multiplatform.py
+++ b/launchers/build_multiplatform.py
@@ -467,17 +467,11 @@ VSVersionInfo(
         app_config = config[f"{app_type}_config"]
         pyinstaller_args = config["pyinstaller_args"]
 
-        # Aviso amigavel sobre compressao UPX opcional (nao bloqueante)
         if platform_name.startswith("windows"):
-            # Heuristica: se config pyinstaller_args contiver algo indicando compressao futura
-            # (ex.: flag custom que adicionaremos no futuro) ou simplesmente sempre avisar se upx ausente
-            try:
-                __import__("upx4py")  # noqa: F401
-            except Exception:
+            if not shutil.which("upx"):
                 logger.warning(
-                    "UPX nao detectado (pacote 'upx4py' ausente). Build seguira sem compressao. "
-                    "Para habilitar instale: uv pip install --python %s -r launchers/platforms/windows_amd64/requirements_windows_build.txt",
-                    str(python_exe),
+                    "UPX nao detectado no PATH. Build seguira sem compressao. "
+                    "Para habilitar, instale o binario UPX pelo gerenciador do sistema."
                 )
 
         # Comando base

--- a/launchers/build_multiplatform.py
+++ b/launchers/build_multiplatform.py
@@ -467,13 +467,6 @@ VSVersionInfo(
         app_config = config[f"{app_type}_config"]
         pyinstaller_args = config["pyinstaller_args"]
 
-        if platform_name.startswith("windows"):
-            if not shutil.which("upx"):
-                logger.warning(
-                    "UPX nao detectado no PATH. Build seguira sem compressao. "
-                    "Para habilitar, instale o binario UPX pelo gerenciador do sistema."
-                )
-
         # Comando base
         cmd = [
             self.uv_cmd,

--- a/launchers/build_multiplatform.py
+++ b/launchers/build_multiplatform.py
@@ -147,16 +147,20 @@ class MultiPlatformBuilder:
         metadata_dir = self.platforms_dir / platform_name / "temp"
         metadata_dir.mkdir(parents=True, exist_ok=True)
         build_info_path = metadata_dir / "build_info.json"
-        build_info_path.write_text(
-            json.dumps(
-                self._build_info_payload(build_system, platform_name),
-                ensure_ascii=True,
-                indent=2,
-                sort_keys=True,
+        try:
+            build_info_path.write_text(
+                json.dumps(
+                    self._build_info_payload(build_system, platform_name),
+                    ensure_ascii=True,
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
             )
-            + "\n",
-            encoding="utf-8",
-        )
+        except OSError:
+            logger.error("Failed to write build info to %s", build_info_path)
+            raise
         return build_info_path
 
     @staticmethod

--- a/launchers/cli_entry.py
+++ b/launchers/cli_entry.py
@@ -63,6 +63,17 @@ def _find_bundled_dir(app_dir: str, folder_name: str) -> Path | None:
     return None
 
 
+def _copy_missing_tree(source_dir: Path, target_dir: Path) -> None:
+    for source in source_dir.rglob("*"):
+        relative = source.relative_to(source_dir)
+        target = target_dir / relative
+        if source.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+        elif source.is_file() and not target.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+
+
 def _seed_runtime_config(runtime_dir: Path, bundled_config: Path | None) -> Path:
     """Inicializa config de runtime com defaults do bundle."""
     runtime_config = runtime_dir / "config"
@@ -74,11 +85,8 @@ def _seed_runtime_config(runtime_dir: Path, bundled_config: Path | None) -> Path
         for source in bundled_config.iterdir():
             target = runtime_config / source.name
             if source.is_dir():
-                try:
-                    shutil.copytree(source, target, dirs_exist_ok=True)
-                except TypeError:
-                    if not target.exists():
-                        shutil.copytree(source, target)
+                target.mkdir(parents=True, exist_ok=True)
+                _copy_missing_tree(source, target)
             elif source.is_file() and not target.exists():
                 shutil.copy2(source, target)
     except Exception:

--- a/launchers/cli_entry.py
+++ b/launchers/cli_entry.py
@@ -36,12 +36,13 @@ def _find_bundled_dir(app_dir: str, folder_name: str) -> Path | None:
     """Localiza pasta embutida em layouts de empacotamento comuns."""
     exe_path = Path(sys.executable).resolve()
     app_path = Path(app_dir)
-    candidates = (
+    candidates = [
         app_path / folder_name,
         app_path / "_internal" / folder_name,
         exe_path.parent.parent / "Resources" / folder_name,
-        exe_path.parent.parent / folder_name,
-    )
+    ]
+    if folder_name != "data":
+        candidates.append(exe_path.parent.parent / folder_name)
     for candidate in candidates:
         if candidate.is_dir():
             return candidate

--- a/launchers/cli_entry.py
+++ b/launchers/cli_entry.py
@@ -32,9 +32,23 @@ def _resolve_runtime_home() -> Path:
     return runtime_dir
 
 
+def _resolve_executable_path() -> Path:
+    executable = str(getattr(sys, "executable", "") or "").strip()
+    if executable:
+        return Path(executable).resolve()
+    return Path(__file__).resolve()
+
+
+def _resolve_bundle_root() -> Path:
+    meipass = str(getattr(sys, "_MEIPASS", "") or "").strip()
+    if meipass:
+        return Path(meipass).resolve()
+    return _resolve_executable_path().parent
+
+
 def _find_bundled_dir(app_dir: str, folder_name: str) -> Path | None:
     """Localiza pasta embutida em layouts de empacotamento comuns."""
-    exe_path = Path(sys.executable).resolve()
+    exe_path = _resolve_executable_path()
     app_path = Path(app_dir)
     candidates = [
         app_path / folder_name,
@@ -144,7 +158,7 @@ def _prepare_frozen_runtime(app_dir: str) -> Path:
 
 
 # Adicionar diretorio raiz ao path CORRETAMENTE
-exe_path = Path(sys.executable)
+exe_path = _resolve_executable_path()
 is_frozen_runtime = bool(
     getattr(sys, "frozen", False)
     or getattr(sys, "oxidized", False)
@@ -154,11 +168,7 @@ is_frozen_runtime = bool(
 )
 if is_frozen_runtime:
     # Executavel empacotado - buscar na raiz dos dados empacotados.
-    if hasattr(sys, "_MEIPASS"):
-        # PyInstaller - usar diretorio do executavel, NAO _MEIPASS (pasta temporaria)
-        app_dir = os.path.dirname(os.path.abspath(sys.executable))
-    else:
-        app_dir = os.path.dirname(os.path.abspath(sys.executable))
+    app_dir = str(_resolve_bundle_root())
     _prepare_frozen_runtime(app_dir)
 else:
     # Script Python normal

--- a/launchers/cli_entry.py
+++ b/launchers/cli_entry.py
@@ -143,13 +143,18 @@ def _prepare_frozen_runtime(app_dir: str) -> Path:
 
 
 # Adicionar diretorio raiz ao path CORRETAMENTE
-if getattr(sys, "frozen", False):
-    # Executavel PyInstaller - buscar na raiz dos dados empacotados
+is_frozen_runtime = bool(
+    getattr(sys, "frozen", False)
+    or getattr(sys, "oxidized", False)
+    or "__compiled__" in globals()
+)
+if is_frozen_runtime:
+    # Executavel empacotado - buscar na raiz dos dados empacotados.
     if hasattr(sys, "_MEIPASS"):
         # PyInstaller - usar diretorio do executavel, NAO _MEIPASS (pasta temporaria)
         app_dir = os.path.dirname(os.path.abspath(sys.executable))
     else:
-        app_dir = os.path.dirname(sys.executable)
+        app_dir = os.path.dirname(os.path.abspath(sys.executable))
     _prepare_frozen_runtime(app_dir)
 else:
     # Script Python normal

--- a/launchers/cli_entry.py
+++ b/launchers/cli_entry.py
@@ -143,10 +143,13 @@ def _prepare_frozen_runtime(app_dir: str) -> Path:
 
 
 # Adicionar diretorio raiz ao path CORRETAMENTE
+exe_path = Path(sys.executable)
 is_frozen_runtime = bool(
     getattr(sys, "frozen", False)
     or getattr(sys, "oxidized", False)
     or "__compiled__" in globals()
+    or exe_path.parent.name.endswith(".dist")
+    or exe_path.name.startswith(("SSA_CLI_", "SSA_Consulta_Rapida"))
 )
 if is_frozen_runtime:
     # Executavel empacotado - buscar na raiz dos dados empacotados.

--- a/launchers/gui_entry.py
+++ b/launchers/gui_entry.py
@@ -195,10 +195,13 @@ def _prepare_frozen_runtime(app_dir: str) -> Path:
 
 
 # Adicionar diretorio raiz ao path CORRETAMENTE
+exe_path = Path(sys.executable)
 is_frozen_runtime = bool(
     getattr(sys, "frozen", False)
     or getattr(sys, "oxidized", False)
     or "__compiled__" in globals()
+    or exe_path.parent.name.endswith(".dist")
+    or exe_path.name.startswith(("SSA_GUI_", "SSA_Consulta_Rapida"))
 )
 if is_frozen_runtime:
     # Executavel empacotado - buscar na raiz dos dados empacotados.

--- a/launchers/gui_entry.py
+++ b/launchers/gui_entry.py
@@ -54,7 +54,6 @@ def _find_bundled_data_dir(app_dir: str) -> Path | None:
         app_path / "data",
         app_path / "_internal" / "data",
         exe_path.parent.parent / "Resources" / "data",
-        exe_path.parent.parent / "data",
     )
     for candidate in candidates:
         if candidate.is_dir():

--- a/launchers/gui_entry.py
+++ b/launchers/gui_entry.py
@@ -91,6 +91,17 @@ def _find_bundled_resources_dir(app_dir: str) -> Path | None:
     return None
 
 
+def _copy_missing_tree(source_dir: Path, target_dir: Path) -> None:
+    for source in source_dir.rglob("*"):
+        relative = source.relative_to(source_dir)
+        target = target_dir / relative
+        if source.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+        elif source.is_file() and not target.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+
+
 def _seed_runtime_config(runtime_dir: Path, bundled_config: Path | None) -> Path:
     """Inicializa config de runtime do usuario com defaults empacotados."""
     runtime_config = runtime_dir / "config"
@@ -101,11 +112,8 @@ def _seed_runtime_config(runtime_dir: Path, bundled_config: Path | None) -> Path
         for source in bundled_config.iterdir():
             target = runtime_config / source.name
             if source.is_dir():
-                try:
-                    shutil.copytree(source, target, dirs_exist_ok=True)
-                except TypeError:
-                    if not target.exists():
-                        shutil.copytree(source, target)
+                target.mkdir(parents=True, exist_ok=True)
+                _copy_missing_tree(source, target)
             elif source.is_file() and not target.exists():
                 shutil.copy2(source, target)
     except Exception:
@@ -142,11 +150,8 @@ def _seed_runtime_resources(runtime_dir: Path, bundled_resources: Path | None) -
         for source in bundled_resources.iterdir():
             target = runtime_resources / source.name
             if source.is_dir():
-                try:
-                    shutil.copytree(source, target, dirs_exist_ok=True)
-                except TypeError:
-                    if not target.exists():
-                        shutil.copytree(source, target)
+                target.mkdir(parents=True, exist_ok=True)
+                _copy_missing_tree(source, target)
             elif source.is_file() and not target.exists():
                 shutil.copy2(source, target)
     except Exception:

--- a/launchers/gui_entry.py
+++ b/launchers/gui_entry.py
@@ -30,9 +30,23 @@ def _resolve_runtime_home() -> Path:
     return runtime_dir
 
 
+def _resolve_executable_path() -> Path:
+    executable = str(getattr(sys, "executable", "") or "").strip()
+    if executable:
+        return Path(executable).resolve()
+    return Path(__file__).resolve()
+
+
+def _resolve_bundle_root() -> Path:
+    meipass = str(getattr(sys, "_MEIPASS", "") or "").strip()
+    if meipass:
+        return Path(meipass).resolve()
+    return _resolve_executable_path().parent
+
+
 def _find_bundled_config_dir(app_dir: str) -> Path | None:
     """Localiza config embutida em diferentes layouts de empacotamento."""
-    exe_path = Path(sys.executable).resolve()
+    exe_path = _resolve_executable_path()
     app_path = Path(app_dir)
     candidates = (
         app_path / "config",
@@ -48,7 +62,7 @@ def _find_bundled_config_dir(app_dir: str) -> Path | None:
 
 def _find_bundled_data_dir(app_dir: str) -> Path | None:
     """Localiza data embutida em diferentes layouts de empacotamento."""
-    exe_path = Path(sys.executable).resolve()
+    exe_path = _resolve_executable_path()
     app_path = Path(app_dir)
     candidates = (
         app_path / "data",
@@ -63,7 +77,7 @@ def _find_bundled_data_dir(app_dir: str) -> Path | None:
 
 def _find_bundled_resources_dir(app_dir: str) -> Path | None:
     """Localiza resources embutido em diferentes layouts de empacotamento."""
-    exe_path = Path(sys.executable).resolve()
+    exe_path = _resolve_executable_path()
     app_path = Path(app_dir)
     candidates = (
         app_path / "resources",
@@ -194,7 +208,7 @@ def _prepare_frozen_runtime(app_dir: str) -> Path:
 
 
 # Adicionar diretorio raiz ao path CORRETAMENTE
-exe_path = Path(sys.executable)
+exe_path = _resolve_executable_path()
 is_frozen_runtime = bool(
     getattr(sys, "frozen", False)
     or getattr(sys, "oxidized", False)
@@ -204,11 +218,7 @@ is_frozen_runtime = bool(
 )
 if is_frozen_runtime:
     # Executavel empacotado - buscar na raiz dos dados empacotados.
-    if hasattr(sys, "_MEIPASS"):
-        # PyInstaller - usar diretorio do executavel, NAO _MEIPASS (pasta temporaria)
-        app_dir = os.path.dirname(os.path.abspath(sys.executable))
-    else:
-        app_dir = os.path.dirname(os.path.abspath(sys.executable))
+    app_dir = str(_resolve_bundle_root())
     _prepare_frozen_runtime(app_dir)
 else:
     # Script Python normal

--- a/launchers/gui_entry.py
+++ b/launchers/gui_entry.py
@@ -195,13 +195,18 @@ def _prepare_frozen_runtime(app_dir: str) -> Path:
 
 
 # Adicionar diretorio raiz ao path CORRETAMENTE
-if getattr(sys, "frozen", False):
-    # Executavel PyInstaller - buscar na raiz dos dados empacotados
+is_frozen_runtime = bool(
+    getattr(sys, "frozen", False)
+    or getattr(sys, "oxidized", False)
+    or "__compiled__" in globals()
+)
+if is_frozen_runtime:
+    # Executavel empacotado - buscar na raiz dos dados empacotados.
     if hasattr(sys, "_MEIPASS"):
         # PyInstaller - usar diretorio do executavel, NAO _MEIPASS (pasta temporaria)
         app_dir = os.path.dirname(os.path.abspath(sys.executable))
     else:
-        app_dir = os.path.dirname(sys.executable)
+        app_dir = os.path.dirname(os.path.abspath(sys.executable))
     _prepare_frozen_runtime(app_dir)
 else:
     # Script Python normal

--- a/launchers/platforms/debian_amd64/requirements.txt
+++ b/launchers/platforms/debian_amd64/requirements.txt
@@ -13,4 +13,4 @@ pillow>=12.2.0
 cairosvg>=2.9.0
 
 # Linux especifico para AppImage
-patchelf>=0.17.0; platform_system=="Linux"
+patchelf>=0.17.0 ; platform_system=="Linux"

--- a/launchers/platforms/debian_arm64/requirements.txt
+++ b/launchers/platforms/debian_arm64/requirements.txt
@@ -13,4 +13,4 @@ pillow>=12.2.0
 cairosvg>=2.9.0
 
 # Linux especifico para AppImage
-patchelf>=0.17.0; platform_system=="Linux"
+patchelf>=0.17.0 ; platform_system=="Linux"

--- a/launchers/platforms/windows_amd64/requirements.txt
+++ b/launchers/platforms/windows_amd64/requirements.txt
@@ -14,4 +14,4 @@ cairosvg>=2.9.0
 # Para compressao UPX opcional use tambem: requirements_windows_build.txt
 
 # Windows especifico
-pywin32>=306; platform_system=="Windows"
+pywin32>=306 ; platform_system=="Windows"

--- a/launchers/platforms/windows_amd64/requirements_windows_build.txt
+++ b/launchers/platforms/windows_amd64/requirements_windows_build.txt
@@ -1,5 +1,4 @@
-# Dependencias adicionais para build/empacotamento Windows com compressao UPX
-# Instale ALEM de requirements.txt quando quiser reduzir tamanho dos executaveis.
-
+# Subset especifico para build/empacotamento Windows com compressao UPX.
+# Use quando quiser instalar apenas as dependencias opcionais de compactacao.
 # Compactacao (opcional)
 upx4py>=0.1.0

--- a/launchers/platforms/windows_amd64/requirements_windows_build.txt
+++ b/launchers/platforms/windows_amd64/requirements_windows_build.txt
@@ -1,4 +1,2 @@
-# Subset especifico para build/empacotamento Windows com compressao UPX.
-# Use quando quiser instalar apenas as dependencias opcionais de compactacao.
-# Compactacao (opcional)
-upx4py>=0.1.0
+# Dependencias Python opcionais de build Windows.
+# UPX e um binario externo; instale pelo gerenciador do sistema, nao via pip.

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -7,10 +7,10 @@ pillow>=12.2.0
 cairosvg>=2.9.0
 
 # Especificos por plataforma
-pywin32>=307; platform_system=="Windows"
+pywin32>=307 ; platform_system=="Windows"
 upx4py>=0.1.0; platform_system=="Windows"
 
 # Changelog:
 # [2025-12-10] - Atualizado para versoes com security patches
 dmgbuild>=1.6.7; platform_system=="Darwin"
-patchelf>=0.18.0; platform_system=="Linux"
+patchelf>=0.18.0 ; platform_system=="Linux"

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -8,7 +8,6 @@ cairosvg>=2.9.0
 
 # Especificos por plataforma
 pywin32>=307 ; platform_system=="Windows"
-upx4py>=0.1.0 ; platform_system=="Windows"
 
 # Changelog:
 # [2025-12-10] - Atualizado para versoes com security patches

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -8,7 +8,7 @@ cairosvg>=2.9.0
 
 # Especificos por plataforma
 pywin32>=307 ; platform_system=="Windows"
-upx4py>=0.1.0; platform_system=="Windows"
+upx4py>=0.1.0 ; platform_system=="Windows"
 
 # Changelog:
 # [2025-12-10] - Atualizado para versoes com security patches

--- a/requirements_ci.txt
+++ b/requirements_ci.txt
@@ -2,7 +2,7 @@
 pytest>=9.0.3
 flake8>=7.1.1
 isort>=5.13.2
-black>=24.8.0
+black>=26.3.1
 mypy>=1.11.2
 pytest-cov>=5.0.0
 pre-commit>=4.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@
 pytest>=9.0.3
 flake8>=7.1.1
 isort>=5.13.2
-black>=24.8.0
+black>=26.3.1
 mypy>=1.11.2
 pytest-cov>=5.0.0
 pre-commit>=4.0.1

--- a/scripts/ci/opencode_pr_review.py
+++ b/scripts/ci/opencode_pr_review.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import codecs
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+DIFF_LIMIT_BYTES = 200_000
+DEFAULT_PROMPT = (
+    "Review this pull request for concrete bugs, security risks, CI/CD regressions, "
+    "path/quoting problems, and release/build reproducibility issues. Comment only "
+    "on actionable findings. If there are no actionable findings, say that explicitly. "
+    "Do not make code changes."
+)
+LFS_POINTER_MARKER = "git-lfs.github.com/spec"
+
+
+def extract_pr_number(event: dict[str, Any]) -> int:
+    if "pull_request" in event:
+        return int(event["pull_request"]["number"])
+    issue = event.get("issue")
+    if isinstance(issue, dict) and issue.get("pull_request") and issue.get("number") is not None:
+        return int(issue["number"])
+    raise ValueError("opencode review requires a pull request event or PR comment")
+
+
+def truncate_diff(path: Path, output_path: Path | None = None, limit: int = DIFF_LIMIT_BYTES) -> tuple[str, bool]:
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    notice = f"\n\n[diff truncated at {limit} bytes]\n"
+    notice_size = len(notice.encode("utf-8"))
+    payload_limit = max(1, limit - notice_size)
+    if path.stat().st_size <= limit:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if output_path is not None:
+            output_path.write_text(text, encoding="utf-8", newline="\n")
+        return text, False
+    with path.open("rb") as source:
+        data = source.read(payload_limit)
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+    text = decoder.decode(data, final=False)
+    newline = text.rfind("\n")
+    if newline > 0:
+        text = text[:newline]
+    text = text + notice
+    if output_path is not None:
+        output_path.write_text(text, encoding="utf-8", newline="\n")
+    return text, True
+
+
+def run_checked(command: list[str], *, stdout_path: Path | None = None, timeout: int | None = None) -> None:
+    if stdout_path is None:
+        subprocess.run(command, check=True, text=True, timeout=timeout)
+        return
+    result = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+    )
+    stdout_path.parent.mkdir(parents=True, exist_ok=True)
+    stdout_path.write_text(result.stdout or "", encoding="utf-8", newline="\n")
+    if result.returncode != 0:
+        print(result.stdout or "", end="")
+        print(result.stderr or "", end="")
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            command,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
+
+
+def build_prompt(base_prompt: str, diff_text: str) -> str:
+    if LFS_POINTER_MARKER not in diff_text:
+        return base_prompt
+    return (
+        base_prompt
+        + "\n\nThe diff contains Git LFS pointer content. Call out that affected "
+        "LFS-backed files need manual review because pointer text is not the real file content."
+    )
+
+
+def fetch_pr_diff(pr_number: int, diff_file: Path) -> None:
+    run_checked(["gh", "pr", "diff", str(pr_number), "--patch"], stdout_path=diff_file)
+
+
+def run_opencode_review(model: str, agent: str, review_diff_file: Path, prompt: str, review_file: Path) -> None:
+    run_checked(
+        [
+            "opencode",
+            "run",
+            "--model",
+            model,
+            "--agent",
+            agent,
+            "--file",
+            str(review_diff_file),
+            "--format",
+            "default",
+            prompt,
+        ],
+        stdout_path=review_file,
+        timeout=1200,
+    )
+
+
+def write_comment_body(body_file: Path, *, model: str, workflow: str, job: str, review_text: str) -> None:
+    body_file.write_text(
+        "\n".join(
+            [
+                "### opencode review",
+                "",
+                f"- model: `{model}`",
+                "- mode: review-only",
+                f"- source: `{workflow}` / `{job}`",
+                "",
+                review_text,
+            ]
+        ),
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def post_pr_comment(pr_number: int, body_file: Path) -> None:
+    run_checked(["gh", "pr", "comment", str(pr_number), "--body-file", str(body_file)])
+
+
+def main() -> int:
+    event_path = Path(os.environ["GITHUB_EVENT_PATH"])
+    runner_temp = Path(os.environ["RUNNER_TEMP"])
+    model = os.environ["MODEL"]
+    agent = os.environ.get("AGENT") or "plan"
+    workflow = os.environ.get("GITHUB_WORKFLOW", "opencode")
+    job = os.environ.get("GITHUB_JOB", "opencode")
+    prompt = os.environ.get("PROMPT") or DEFAULT_PROMPT
+
+    event = json.loads(event_path.read_text(encoding="utf-8"))
+    pr_number = extract_pr_number(event)
+
+    diff_file = runner_temp / f"opencode-pr-{pr_number}.diff"
+    review_diff_file = runner_temp / f"opencode-pr-{pr_number}-review.diff"
+    review_file = runner_temp / f"opencode-review-{pr_number}.md"
+    body_file = runner_temp / f"opencode-comment-{pr_number}.md"
+
+    fetch_pr_diff(pr_number, diff_file)
+    diff_text, _ = truncate_diff(diff_file, output_path=review_diff_file)
+    prompt = build_prompt(prompt, diff_text)
+
+    run_opencode_review(model, agent, review_diff_file, prompt, review_file)
+    review_text = review_file.read_text(encoding="utf-8", errors="replace")
+    write_comment_body(body_file, model=model, workflow=workflow, job=job, review_text=review_text)
+    post_pr_comment(pr_number, body_file)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/opencode_pr_review.py
+++ b/scripts/ci/opencode_pr_review.py
@@ -65,8 +65,8 @@ def run_checked(command: list[str], *, stdout_path: Path | None = None, timeout:
     stdout_path.parent.mkdir(parents=True, exist_ok=True)
     stdout_path.write_text(result.stdout or "", encoding="utf-8", newline="\n")
     if result.returncode != 0:
-        print(result.stdout or "", end="")
-        print(result.stderr or "", end="")
+        print(f"Command failed with exit code {result.returncode}: {command[0]}")
+        print(f"stdout captured in: {stdout_path}")
         raise subprocess.CalledProcessError(
             result.returncode,
             command,
@@ -131,10 +131,17 @@ def post_pr_comment(pr_number: int, body_file: Path) -> None:
     run_checked(["gh", "pr", "comment", str(pr_number), "--body-file", str(body_file)])
 
 
+def required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Required environment variable is missing: {name}")
+    return value
+
+
 def main() -> int:
-    event_path = Path(os.environ["GITHUB_EVENT_PATH"])
-    runner_temp = Path(os.environ["RUNNER_TEMP"])
-    model = os.environ["MODEL"]
+    event_path = Path(required_env("GITHUB_EVENT_PATH"))
+    runner_temp = Path(required_env("RUNNER_TEMP"))
+    model = required_env("MODEL")
     agent = os.environ.get("AGENT") or "plan"
     workflow = os.environ.get("GITHUB_WORKFLOW", "opencode")
     job = os.environ.get("GITHUB_JOB", "opencode")

--- a/scripts/security/scan_secrets.sh
+++ b/scripts/security/scan_secrets.sh
@@ -130,7 +130,10 @@ scan_pr_diff() {
   append_git_pathspec_excludes
 
   local added_lines
-  added_lines="$(mktemp)"
+  if ! added_lines="$(mktemp)"; then
+    echo '[ERROR] Failed to create temporary file for PR diff scan' >&2
+    return 1
+  fi
   if ! git diff --unified=0 "${diff_base}...HEAD" "${pathspec_args[@]}" \
     | awk '/^\+\+\+ (b\/|\/dev\/null)/ { next } /^\+/ { sub(/^\+/, ""); print }' \
     >"$added_lines"; then

--- a/scripts/security/scan_secrets.sh
+++ b/scripts/security/scan_secrets.sh
@@ -35,6 +35,16 @@ Modes:
 EOF
 }
 
+require_commands() {
+  local command
+  for command in git grep awk mktemp; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+      echo "[ERROR] Required command not found: ${command}" >&2
+      return 127
+    fi
+  done
+}
+
 validate_pattern() {
   local status
   set +e
@@ -83,7 +93,7 @@ scan_workspace() {
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     git grep --untracked -I -E -l "$SENSITIVE_PATTERN" "${pathspec_args[@]}"
   else
-    grep -R -E -l "${grep_args[@]}" "$SENSITIVE_PATTERN" .
+    grep -r -E -l "${grep_args[@]}" "$SENSITIVE_PATTERN" .
   fi
   status=$?
   set -e
@@ -158,12 +168,15 @@ main() {
   local mode="${1:-}"
   case "$mode" in
     workspace)
+      require_commands
       scan_workspace
       ;;
     pr-diff)
+      require_commands
       scan_pr_diff "${2:-}"
       ;;
     history)
+      require_commands
       scan_history
       ;;
     -h|--help|help)

--- a/scripts/security/scan_secrets.sh
+++ b/scripts/security/scan_secrets.sh
@@ -45,6 +45,7 @@ validate_pattern() {
     echo '[ERROR] Invalid sensitive pattern' >&2
     return "$status"
   fi
+  return 0
 }
 
 append_grep_excludes() {
@@ -82,7 +83,7 @@ scan_workspace() {
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     git grep -I -E -l "$SENSITIVE_PATTERN" "${pathspec_args[@]}"
   else
-    grep -R -E -l "$SENSITIVE_PATTERN" . "${grep_args[@]}"
+    grep -R -E -l "${grep_args[@]}" "$SENSITIVE_PATTERN" .
   fi
   status=$?
   set -e
@@ -114,15 +115,24 @@ scan_pr_diff() {
   local pathspec_args=(-- .)
   append_git_pathspec_excludes
 
-  if git diff --unified=0 FETCH_HEAD...HEAD "${pathspec_args[@]}" \
+  local added_lines
+  added_lines="$(mktemp)"
+  trap 'rm -f "${added_lines:-}"' RETURN
+  git diff --unified=0 FETCH_HEAD...HEAD "${pathspec_args[@]}" \
     | awk '/^\+\+\+ (b\/|\/dev\/null)/ { next } /^\+/ { sub(/^\+/, ""); print }' \
-    | grep -E -q "$SENSITIVE_PATTERN"; then
+    >"$added_lines"
+
+  if grep -E -q "$SENSITIVE_PATTERN" "$added_lines"; then
     echo '[ERROR] Possible secret in diff'
     echo '[INFO] Changed files in scanned diff:'
     git diff --name-only FETCH_HEAD...HEAD "${pathspec_args[@]}" | sed 's/^/[INFO] /'
+    rm -f "$added_lines"
+    trap - RETURN
     return 1
   fi
 
+  rm -f "$added_lines"
+  trap - RETURN
   echo '[OK] No sensitive patterns in diff'
 }
 

--- a/scripts/security/scan_secrets.sh
+++ b/scripts/security/scan_secrets.sh
@@ -26,11 +26,11 @@ readonly EXCLUDED_FILES=(
 
 usage() {
   cat >&2 <<'EOF'
-Usage: scan_secrets.sh <workspace|pr-diff|history> [base-ref]
+Usage: scan_secrets.sh <workspace|pr-diff|history> [base-commit-or-ref]
 
 Modes:
   workspace        Scan the checked-out workspace, excluding generated caches.
-  pr-diff BASE_REF Scan added lines in the PR diff against BASE_REF.
+  pr-diff BASE    Scan added lines in the PR diff against BASE.
   history          Advisory scan of recent Git history; never blocks.
 EOF
 }
@@ -103,21 +103,25 @@ scan_workspace() {
 scan_pr_diff() {
   local base_ref="${1:-}"
   if [[ -z "$base_ref" ]]; then
-    echo '[ERROR] pr-diff mode requires a base ref' >&2
+    echo '[ERROR] pr-diff mode requires a base commit or ref' >&2
     return 2
   fi
 
   validate_pattern
 
   echo '[INFO] Scanning PR diff'
-  git fetch --no-tags origin "$base_ref"
+  local diff_base="$base_ref"
+  if ! git cat-file -e "${diff_base}^{commit}" 2>/dev/null; then
+    git fetch --no-tags --depth=1 origin "$base_ref"
+    diff_base="FETCH_HEAD"
+  fi
 
   local pathspec_args=(-- .)
   append_git_pathspec_excludes
 
   local added_lines
   added_lines="$(mktemp)"
-  if ! git diff --unified=0 FETCH_HEAD...HEAD "${pathspec_args[@]}" \
+  if ! git diff --unified=0 "${diff_base}...HEAD" "${pathspec_args[@]}" \
     | awk '/^\+\+\+ (b\/|\/dev\/null)/ { next } /^\+/ { sub(/^\+/, ""); print }' \
     >"$added_lines"; then
     echo '[ERROR] PR diff scan failed' >&2
@@ -128,7 +132,7 @@ scan_pr_diff() {
   if grep -E -q "$SENSITIVE_PATTERN" "$added_lines"; then
     echo '[ERROR] Possible secret in diff'
     echo '[INFO] Changed files in scanned diff:'
-    git diff --name-only FETCH_HEAD...HEAD "${pathspec_args[@]}" | sed 's/^/[INFO] /'
+    git diff --name-only "${diff_base}...HEAD" "${pathspec_args[@]}" | sed 's/^/[INFO] /'
     rm -f "$added_lines"
     return 1
   fi

--- a/scripts/security/scan_secrets.sh
+++ b/scripts/security/scan_secrets.sh
@@ -117,22 +117,23 @@ scan_pr_diff() {
 
   local added_lines
   added_lines="$(mktemp)"
-  trap 'rm -f "${added_lines:-}"' RETURN
-  git diff --unified=0 FETCH_HEAD...HEAD "${pathspec_args[@]}" \
+  if ! git diff --unified=0 FETCH_HEAD...HEAD "${pathspec_args[@]}" \
     | awk '/^\+\+\+ (b\/|\/dev\/null)/ { next } /^\+/ { sub(/^\+/, ""); print }' \
-    >"$added_lines"
+    >"$added_lines"; then
+    echo '[ERROR] PR diff scan failed' >&2
+    rm -f "$added_lines"
+    return 1
+  fi
 
   if grep -E -q "$SENSITIVE_PATTERN" "$added_lines"; then
     echo '[ERROR] Possible secret in diff'
     echo '[INFO] Changed files in scanned diff:'
     git diff --name-only FETCH_HEAD...HEAD "${pathspec_args[@]}" | sed 's/^/[INFO] /'
     rm -f "$added_lines"
-    trap - RETURN
     return 1
   fi
 
   rm -f "$added_lines"
-  trap - RETURN
   echo '[OK] No sensitive patterns in diff'
 }
 

--- a/scripts/security/scan_secrets.sh
+++ b/scripts/security/scan_secrets.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly TOKEN_CHARS='[A-Za-z0-9]'
+readonly API_KEY_VALUE_MIN="${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}"
+readonly PROVIDER_TOKEN_MIN="${API_KEY_VALUE_MIN}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}${TOKEN_CHARS}"
+readonly TOKEN_START='(^|[^A-Za-z0-9])'
+readonly TOKEN_END='([^A-Za-z0-9]|$)'
+readonly DEFAULT_SENSITIVE_PATTERN="${TOKEN_START}(sk-${PROVIDER_TOKEN_MIN}${TOKEN_CHARS}*|hf_${PROVIDER_TOKEN_MIN}${TOKEN_CHARS}*|[A-Z_]+API_KEY=${API_KEY_VALUE_MIN}${TOKEN_CHARS}*)${TOKEN_END}"
+readonly SENSITIVE_PATTERN="${SENSITIVE_PATTERN:-$DEFAULT_SENSITIVE_PATTERN}"
+readonly HISTORY_MAX_COUNT="${SECRET_SCAN_HISTORY_MAX_COUNT:-200}"
+readonly EXCLUDED_DIRS=(
+  .git
+  dist
+  build
+  logs
+  __pycache__
+  .pytest_cache
+  .mypy_cache
+  node_modules
+)
+readonly EXCLUDED_FILES=(
+  '*.pyc'
+  '*.so'
+)
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scan_secrets.sh <workspace|pr-diff|history> [base-ref]
+
+Modes:
+  workspace        Scan the checked-out workspace, excluding generated caches.
+  pr-diff BASE_REF Scan added lines in the PR diff against BASE_REF.
+  history          Advisory scan of recent Git history; never blocks.
+EOF
+}
+
+validate_pattern() {
+  local status
+  set +e
+  grep -E "$SENSITIVE_PATTERN" </dev/null >/dev/null
+  status=$?
+  set -e
+  if (( status > 1 )); then
+    echo '[ERROR] Invalid sensitive pattern' >&2
+    return "$status"
+  fi
+}
+
+append_grep_excludes() {
+  local item
+  for item in "${EXCLUDED_DIRS[@]}"; do
+    grep_args+=(--exclude-dir="$item")
+  done
+  for item in "${EXCLUDED_FILES[@]}"; do
+    grep_args+=(--exclude="$item")
+  done
+}
+
+append_git_pathspec_excludes() {
+  local item
+  for item in "${EXCLUDED_DIRS[@]}"; do
+    pathspec_args+=(":(exclude)$item/**")
+  done
+  for item in "${EXCLUDED_FILES[@]}"; do
+    pathspec_args+=(":(exclude)$item")
+  done
+}
+
+scan_workspace() {
+  echo '[INFO] Scanning workspace for sensitive patterns'
+  validate_pattern
+
+  local grep_args=(--binary-files=without-match)
+  append_grep_excludes
+
+  local pathspec_args=(-- .)
+  append_git_pathspec_excludes
+
+  local status
+  set +e
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git grep -I -E -l "$SENSITIVE_PATTERN" "${pathspec_args[@]}"
+  else
+    grep -R -E -l "$SENSITIVE_PATTERN" . "${grep_args[@]}"
+  fi
+  status=$?
+  set -e
+
+  if (( status == 0 )); then
+    echo '[ERROR] Sensitive patterns found'
+    return 1
+  fi
+  if (( status > 1 )); then
+    echo '[ERROR] Workspace scan failed' >&2
+    return "$status"
+  fi
+
+  echo '[OK] No sensitive patterns detected'
+}
+
+scan_pr_diff() {
+  local base_ref="${1:-}"
+  if [[ -z "$base_ref" ]]; then
+    echo '[ERROR] pr-diff mode requires a base ref' >&2
+    return 2
+  fi
+
+  validate_pattern
+
+  echo '[INFO] Scanning PR diff'
+  git fetch --no-tags origin "$base_ref"
+
+  local pathspec_args=(-- .)
+  append_git_pathspec_excludes
+
+  if git diff --unified=0 FETCH_HEAD...HEAD "${pathspec_args[@]}" \
+    | awk '/^\+\+\+ (b\/|\/dev\/null)/ { next } /^\+/ { sub(/^\+/, ""); print }' \
+    | grep -E -q "$SENSITIVE_PATTERN"; then
+    echo '[ERROR] Possible secret in diff'
+    echo '[INFO] Changed files in scanned diff:'
+    git diff --name-only FETCH_HEAD...HEAD "${pathspec_args[@]}" | sed 's/^/[INFO] /'
+    return 1
+  fi
+
+  echo '[OK] No sensitive patterns in diff'
+}
+
+scan_history() {
+  echo '[INFO] Sampling recent commits'
+  validate_pattern
+
+  if git log --max-count="$HISTORY_MAX_COUNT" -E -G "$SENSITIVE_PATTERN" --format='%H' HEAD | grep -q .; then
+    echo '[INFO] Historical pattern found in recent commits'
+    echo '[INFO] Advisory only: current tree and PR diff scans are blocking'
+    return 0
+  fi
+
+  echo '[OK] Recent history sample clean'
+}
+
+main() {
+  local mode="${1:-}"
+  case "$mode" in
+    workspace)
+      scan_workspace
+      ;;
+    pr-diff)
+      scan_pr_diff "${2:-}"
+      ;;
+    history)
+      scan_history
+      ;;
+    -h|--help|help)
+      usage
+      ;;
+    *)
+      usage
+      return 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/security/scan_secrets.sh
+++ b/scripts/security/scan_secrets.sh
@@ -37,7 +37,7 @@ EOF
 
 require_commands() {
   local command
-  for command in git grep awk mktemp; do
+  for command in git grep awk mktemp sed; do
     if ! command -v "$command" >/dev/null 2>&1; then
       echo "[ERROR] Required command not found: ${command}" >&2
       return 127
@@ -48,7 +48,7 @@ require_commands() {
 validate_pattern() {
   local status
   set +e
-  grep -E "$SENSITIVE_PATTERN" </dev/null >/dev/null
+  grep -E -- "$SENSITIVE_PATTERN" </dev/null >/dev/null
   status=$?
   set -e
   if (( status > 1 )); then
@@ -91,9 +91,9 @@ scan_workspace() {
   local status
   set +e
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git grep --untracked -I -E -l "$SENSITIVE_PATTERN" "${pathspec_args[@]}"
+    git grep --untracked -I -E -l -e "$SENSITIVE_PATTERN" "${pathspec_args[@]}"
   else
-    grep -r -E -l "${grep_args[@]}" "$SENSITIVE_PATTERN" .
+    grep -r -E -l "${grep_args[@]}" -- "$SENSITIVE_PATTERN" .
   fi
   status=$?
   set -e
@@ -139,7 +139,7 @@ scan_pr_diff() {
     return 1
   fi
 
-  if grep -E -q "$SENSITIVE_PATTERN" "$added_lines"; then
+  if grep -E -q -- "$SENSITIVE_PATTERN" "$added_lines"; then
     echo '[ERROR] Possible secret in diff'
     echo '[INFO] Changed files in scanned diff:'
     git diff --name-only "${diff_base}...HEAD" "${pathspec_args[@]}" | sed 's/^/[INFO] /'
@@ -155,7 +155,7 @@ scan_history() {
   echo '[INFO] Sampling recent commits'
   validate_pattern
 
-  if git log --max-count="$HISTORY_MAX_COUNT" -E -G "$SENSITIVE_PATTERN" --format='%H' HEAD | grep -q .; then
+  if git log --max-count="$HISTORY_MAX_COUNT" -E -G "$SENSITIVE_PATTERN" --format='%H' HEAD | grep -q -- .; then
     echo '[INFO] Historical pattern found in recent commits'
     echo '[INFO] Advisory only: current tree and PR diff scans are blocking'
     return 0

--- a/scripts/security/scan_secrets.sh
+++ b/scripts/security/scan_secrets.sh
@@ -81,7 +81,7 @@ scan_workspace() {
   local status
   set +e
   if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git grep -I -E -l "$SENSITIVE_PATTERN" "${pathspec_args[@]}"
+    git grep --untracked -I -E -l "$SENSITIVE_PATTERN" "${pathspec_args[@]}"
   else
     grep -R -E -l "${grep_args[@]}" "$SENSITIVE_PATTERN" .
   fi

--- a/tests/test_build_multiplatform_manifest.py
+++ b/tests/test_build_multiplatform_manifest.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from launchers.build_multiplatform import MultiPlatformBuilder
 from dev_env.build import write_build_info
 
@@ -103,6 +105,60 @@ def test_write_build_info_payload_includes_toolchain_versions(monkeypatch, tmp_p
 
     assert payload["c_compiler_version"] == "gcc 14.2.0"
     assert payload["rustc_version"] == "rustc 1.90.0"
+
+
+def test_write_build_info_main_reports_output_write_errors(
+    capsys,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    output_dir = tmp_path / "output-dir"
+    output_dir.mkdir()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "write_build_info.py",
+            "--repo-root",
+            str(tmp_path),
+            "--output",
+            str(output_dir),
+            "--build-system",
+            "nuitka",
+            "--platform",
+            "debian_amd64",
+            "--app-version",
+            "4.37",
+        ],
+    )
+    monkeypatch.setattr(
+        write_build_info,
+        "build_payload",
+        lambda *_args: {"app_version": "4.37"},
+    )
+
+    assert write_build_info.main() == 1
+    assert "Failed to write build info" in capsys.readouterr().err
+
+
+def test_pyinstaller_build_info_write_logs_before_raising(monkeypatch) -> None:
+    builder = MultiPlatformBuilder()
+    errors = []
+
+    def fail_write(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "write_text", fail_write)
+    monkeypatch.setattr(
+        "launchers.build_multiplatform.logger.error",
+        lambda *args, **_kwargs: errors.append(args),
+    )
+
+    with pytest.raises(OSError):
+        builder._write_build_info_file("pyinstaller", "windows_amd64")
+
+    assert errors
+    assert "Failed to write build info" in errors[0][0]
 
 
 def test_upx_contract_uses_system_binary_not_python_package():

--- a/tests/test_build_multiplatform_manifest.py
+++ b/tests/test_build_multiplatform_manifest.py
@@ -107,6 +107,50 @@ def test_write_build_info_payload_includes_toolchain_versions(monkeypatch, tmp_p
     assert payload["rustc_version"] == "rustc 1.90.0"
 
 
+def test_write_build_info_logs_required_metadata_command_failure(
+    capsys,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            ["git", "rev-parse", "HEAD"],
+            returncode=128,
+            stdout="",
+            stderr="not a git repo",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert write_build_info._run_output(
+        ["git", "rev-parse", "HEAD"],
+        tmp_path,
+        require_success=True,
+    ) == ""
+    assert "Metadata command failed" in capsys.readouterr().err
+
+
+def test_write_build_info_ignores_optional_command_stderr_on_failure(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    def fake_run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            ["cc", "--version"],
+            returncode=1,
+            stdout="",
+            stderr="compiler error detail",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert write_build_info._run_output(
+        ["cc", "--version"],
+        tmp_path,
+        require_success=False,
+    ) == ""
+
+
 def test_write_build_info_main_reports_output_write_errors(
     capsys,
     monkeypatch,
@@ -139,6 +183,35 @@ def test_write_build_info_main_reports_output_write_errors(
 
     assert write_build_info.main() == 1
     assert "Failed to write build info" in capsys.readouterr().err
+
+
+def test_write_build_info_main_writes_valid_json(monkeypatch, tmp_path) -> None:
+    output = tmp_path / "build_info.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "write_build_info.py",
+            "--repo-root",
+            str(tmp_path),
+            "--output",
+            str(output),
+            "--build-system",
+            "nuitka",
+            "--platform",
+            "debian_amd64",
+            "--app-version",
+            "4.37",
+        ],
+    )
+    monkeypatch.setattr(
+        write_build_info,
+        "build_payload",
+        lambda *_args: {"app_version": "4.37"},
+    )
+
+    assert write_build_info.main() == 0
+    assert json.loads(output.read_text(encoding="utf-8")) == {"app_version": "4.37"}
 
 
 def test_pyinstaller_build_info_write_logs_before_raising(monkeypatch) -> None:

--- a/tests/test_build_multiplatform_manifest.py
+++ b/tests/test_build_multiplatform_manifest.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 from launchers.build_multiplatform import MultiPlatformBuilder
+from dev_env.build import write_build_info
 
 
 def test_command_stdout_logs_metadata_command_failure(monkeypatch):
@@ -32,6 +33,76 @@ def test_command_stdout_logs_metadata_command_failure(monkeypatch):
     assert warnings
     assert "Metadata command failed" in warnings[0][0]
     assert "stderr detail" in "".join(str(item) for item in warnings[0])
+
+
+def test_build_info_payload_includes_toolchain_versions(monkeypatch):
+    builder = MultiPlatformBuilder()
+
+    outputs: dict[tuple[str, ...], str] = {
+        ("git", "rev-parse", "HEAD"): "abcdef123456",
+        ("git", "log", "-1", "--format=%cI"): "2026-05-03T22:48:02-03:00",
+        ("git", "log", "-1", "--format=%s"): "STABILITY_PATCH",
+        ("uv", "--version"): "uv 0.9.18",
+        ("cc", "--version"): "gcc 14.2.0",
+        ("rustc", "--version"): "rustc 1.90.0",
+    }
+
+    def fake_run(cmd, cwd, require_success):  # noqa: ANN001, ARG001
+        return outputs.get(tuple(str(item) for item in cmd), "")
+
+    monkeypatch.setattr(write_build_info, "_run_output", fake_run)
+
+    payload = builder._build_info_payload("pyinstaller", "windows_amd64")
+
+    assert payload["c_compiler_version"] == "gcc 14.2.0"
+    assert payload["rustc_version"] == "rustc 1.90.0"
+
+
+def test_build_info_payload_uses_msvc_environment_fallback(monkeypatch):
+    builder = MultiPlatformBuilder()
+    outputs: dict[tuple[str, ...], str] = {
+        ("git", "rev-parse", "HEAD"): "abcdef123456",
+        ("git", "log", "-1", "--format=%cI"): "2026-05-03T22:48:02-03:00",
+        ("git", "log", "-1", "--format=%s"): "STABILITY_PATCH",
+        ("uv", "--version"): "uv 0.9.18",
+        ("rustc", "--version"): "rustc 1.90.0",
+    }
+
+    def fake_run(cmd, cwd, require_success):  # noqa: ANN001, ARG001
+        return outputs.get(tuple(str(item) for item in cmd), "")
+
+    monkeypatch.setattr(write_build_info, "_run_output", fake_run)
+    monkeypatch.setenv("VCToolsVersion", "14.44.35207")
+
+    payload = builder._build_info_payload("pyinstaller", "windows_amd64")
+
+    assert payload["c_compiler_version"] == "MSVC 14.44.35207"
+
+
+def test_write_build_info_payload_includes_toolchain_versions(monkeypatch, tmp_path):
+    outputs = {
+        ("git", "rev-parse", "HEAD"): "abcdef123456",
+        ("git", "log", "-1", "--format=%cI"): "2026-05-03T22:48:02-03:00",
+        ("git", "log", "-1", "--format=%s"): "STABILITY_PATCH",
+        ("uv", "--version"): "uv 0.9.18",
+        ("cc", "--version"): "gcc 14.2.0",
+        ("rustc", "--version"): "rustc 1.90.0",
+    }
+
+    def fake_run(args, cwd, require_success):  # noqa: ANN001, FBT001
+        return outputs.get(tuple(args), "")
+
+    monkeypatch.setattr(write_build_info, "_run_output", fake_run)
+
+    payload = write_build_info.build_payload(
+        tmp_path,
+        "nuitka",
+        "debian_amd64",
+        "4.37",
+    )
+
+    assert payload["c_compiler_version"] == "gcc 14.2.0"
+    assert payload["rustc_version"] == "rustc 1.90.0"
 
 
 def test_upx_contract_uses_system_binary_not_python_package():

--- a/tests/test_build_multiplatform_manifest.py
+++ b/tests/test_build_multiplatform_manifest.py
@@ -34,6 +34,19 @@ def test_command_stdout_logs_metadata_command_failure(monkeypatch):
     assert "stderr detail" in "".join(str(item) for item in warnings[0])
 
 
+def test_upx_contract_uses_system_binary_not_python_package():
+    repo_root = Path(__file__).resolve().parents[1]
+    build_script = repo_root / "launchers" / "build_multiplatform.py"
+    requirements_files = [
+        repo_root / "requirements_build.txt",
+        repo_root / "launchers" / "platforms" / "windows_amd64" / "requirements_windows_build.txt",
+    ]
+
+    assert "shutil.which(\"upx\")" in build_script.read_text(encoding="utf-8")
+    for requirements_file in requirements_files:
+        assert "upx4py" not in requirements_file.read_text(encoding="utf-8")
+
+
 def test_create_manifest_lists_root_artifacts_and_skips_hidden(tmp_path):
     builder = MultiPlatformBuilder()
     builder.dist_dir = tmp_path / "dist"

--- a/tests/test_dev_env_build_scripts.py
+++ b/tests/test_dev_env_build_scripts.py
@@ -78,7 +78,8 @@ def test_pyoxidizer_debian_uses_root_config_kept_in_sync() -> None:
         assert '--path "${REPO_ROOT}"' in script
         assert 'BUILD_INFO_FILE="${REPO_ROOT}/config/build_info.json"' in script
         assert "cleanup_build_info" in script
-        assert 'BUILD_INFO_BACKUP_CANDIDATE="${BUILD_INFO_FILE}.$$.$RANDOM.bak"' in script
+        assert 'BUILD_INFO_BACKUP_CANDIDATE="$(mktemp "${BUILD_INFO_FILE}.XXXXXX")"' in script
+        assert 'rm -f "${BUILD_INFO_BACKUP_CANDIDATE}"' in script
         assert 'BUILD_INFO_BACKUP="${BUILD_INFO_BACKUP_CANDIDATE}"' in script
         assert "write_build_info.py" in script
         assert "--build-system pyoxidizer" in script

--- a/tests/test_dev_env_build_scripts.py
+++ b/tests/test_dev_env_build_scripts.py
@@ -78,9 +78,13 @@ def test_pyoxidizer_debian_uses_root_config_kept_in_sync() -> None:
         assert '--path "${REPO_ROOT}"' in script
         assert 'BUILD_INFO_FILE="${REPO_ROOT}/config/build_info.json"' in script
         assert "cleanup_build_info" in script
+        assert 'BUILD_INFO_BACKUP_CANDIDATE="${BUILD_INFO_FILE}.$$.$RANDOM.bak"' in script
+        assert 'BUILD_INFO_BACKUP="${BUILD_INFO_BACKUP_CANDIDATE}"' in script
         assert "write_build_info.py" in script
         assert "--build-system pyoxidizer" in script
         assert f"--platform {platform}" in script
+        assert 'if [[ -z "${APP_VERSION}" ]]; then' in script
+        assert 'if [[ ! -s "${BUILD_INFO_FILE}" ]]; then' in script
 
 
 def test_nuitka_debian_serializes_patchelf_install() -> None:
@@ -110,6 +114,8 @@ def test_nuitka_debian_uses_platform_venv_and_requirements() -> None:
         assert 'uv pip install --python "${PYTHON_EXE}" -r "${REQUIREMENTS_FILE}"' in script
         assert '"${PYTHON_EXE}" -m nuitka' in script
         assert "write_build_info.py" in script
+        assert 'if [[ -z "${APP_VERSION}" ]]; then' in script
+        assert 'if [[ ! -s "${BUILD_INFO_FILE}" ]]; then' in script
         assert '--include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md' in script
         assert script.count('--include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md') >= 2
         assert '--include-data-file="${BUILD_INFO_FILE}=config/build_info.json"' in script

--- a/tests/test_dev_env_build_scripts.py
+++ b/tests/test_dev_env_build_scripts.py
@@ -78,7 +78,9 @@ def test_pyoxidizer_debian_uses_root_config_kept_in_sync() -> None:
         assert '--path "${REPO_ROOT}"' in script
         assert 'BUILD_INFO_FILE="${REPO_ROOT}/config/build_info.json"' in script
         assert "cleanup_build_info" in script
-        assert f'"pyoxidizer" "{platform}"' in script
+        assert "write_build_info.py" in script
+        assert "--build-system pyoxidizer" in script
+        assert f"--platform {platform}" in script
 
 
 def test_nuitka_debian_serializes_patchelf_install() -> None:
@@ -107,6 +109,7 @@ def test_nuitka_debian_uses_platform_venv_and_requirements() -> None:
         assert 'uv venv --python 3.13 "${VENV_DIR}"' in script
         assert 'uv pip install --python "${PYTHON_EXE}" -r "${REQUIREMENTS_FILE}"' in script
         assert '"${PYTHON_EXE}" -m nuitka' in script
+        assert "write_build_info.py" in script
         assert '--include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md' in script
         assert script.count('--include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md') >= 2
         assert '--include-data-file="${BUILD_INFO_FILE}=config/build_info.json"' in script
@@ -127,8 +130,9 @@ def test_nuitka_windows_and_pyoxidizer_stage_include_docs_and_build_info() -> No
 
     assert "--include-data-file=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md=docs/GUIA_MIGRACAO_NOVA_INSTALACAO.md" in nuitka_script
     assert "--include-data-file=%BUILD_INFO_FILE%=config/build_info.json" in nuitka_script
-    assert "--format=%%cI" in nuitka_script
-    assert "--format=%%s" in nuitka_script
+    assert "write_build_info.py" in nuitka_script
+    assert "--build-system nuitka" in nuitka_script
+    assert "--platform windows_amd64" in nuitka_script
     assert 'set "MSVC_LINK="' in pyoxidizer_script
     assert "if not defined MSVC_LINK" in pyoxidizer_script
     assert "where link.exe" in pyoxidizer_script
@@ -145,9 +149,10 @@ def test_nuitka_windows_and_pyoxidizer_stage_include_docs_and_build_info() -> No
     assert '--set-version-string "ProductName" "SSA Consulta Rapida"' in pyoxidizer_script
     assert r"config\version.json" in pyoxidizer_script
     assert "build_info.json" in pyoxidizer_script
+    assert "write_build_info.py" in pyoxidizer_script
     assert "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in pyoxidizer_script
-    assert "--format=%%cI" in pyoxidizer_script
-    assert "--format=%%s" in pyoxidizer_script
+    assert "--build-system pyoxidizer" in pyoxidizer_script
+    assert "--platform windows_amd64" in pyoxidizer_script
 
 
 def test_pyoxidizer_debian_runtime_includes_version_json() -> None:

--- a/tests/test_gui_about_message.py
+++ b/tests/test_gui_about_message.py
@@ -20,7 +20,7 @@ def test_build_about_message_includes_commit_hash(monkeypatch) -> None:
 def test_build_about_message_uses_embedded_build_info(monkeypatch, tmp_path) -> None:
     build_info = tmp_path / "build_info.json"
     build_info.write_text(
-        '{"git_commit_short":"def5678","build_datetime":"2026-04-28T06:30:00-03:00","uv_version":"uv 0.9.18"}',
+        '{"git_commit_short":"def5678","build_datetime":"2026-04-28T06:30:00-03:00","uv_version":"uv 0.9.18","c_compiler_version":"gcc 14.2.0","rustc_version":"rustc 1.90.0"}',
         encoding="utf-8",
     )
     monkeypatch.setattr(
@@ -39,6 +39,8 @@ def test_build_about_message_uses_embedded_build_info(monkeypatch, tmp_path) -> 
     assert "uv: uv 0.9.18" in message
     assert "Commit: def5678" in message
     assert "Build: 2026-04-28T06:30:00-03:00" in message
+    assert "C/C++: gcc 14.2.0" in message
+    assert "Rust: rustc 1.90.0" in message
 
 
 def test_resolve_uv_version_uses_resolved_executable(monkeypatch) -> None:

--- a/tests/test_launcher_entry_runtime.py
+++ b/tests/test_launcher_entry_runtime.py
@@ -321,3 +321,49 @@ def test_cli_entry_pyoxidizer_runtime_uses_executable_dir_as_bundle_root(
     finally:
         os.chdir(original_cwd)
         sys.path[:] = original_sys_path
+
+
+def test_cli_seed_runtime_config_does_not_overwrite_user_files(tmp_path: Path) -> None:
+    namespace = runpy.run_path(
+        str(REPO_ROOT / "launchers" / "cli_entry.py"),
+        run_name="test_cli_seed_config",
+    )
+    seed_config = namespace["_seed_runtime_config"]
+    runtime_dir = tmp_path / "runtime"
+    bundled_config = tmp_path / "bundle" / "config"
+    bundled_config_nested = bundled_config / "nested"
+    user_config_nested = runtime_dir / "config" / "nested"
+    bundled_config_nested.mkdir(parents=True)
+    user_config_nested.mkdir(parents=True)
+    (bundled_config_nested / "settings.json").write_text("bundle", encoding="utf-8")
+    (bundled_config_nested / "new.json").write_text("new", encoding="utf-8")
+    (user_config_nested / "settings.json").write_text("user", encoding="utf-8")
+
+    seed_config(runtime_dir, bundled_config)
+
+    assert (user_config_nested / "settings.json").read_text(encoding="utf-8") == "user"
+    assert (user_config_nested / "new.json").read_text(encoding="utf-8") == "new"
+
+
+def test_gui_seed_runtime_resources_does_not_overwrite_user_files(
+    tmp_path: Path,
+) -> None:
+    namespace = runpy.run_path(
+        str(REPO_ROOT / "launchers" / "gui_entry.py"),
+        run_name="test_gui_seed_resources",
+    )
+    seed_resources = namespace["_seed_runtime_resources"]
+    runtime_dir = tmp_path / "runtime"
+    bundled_resources = tmp_path / "bundle" / "resources"
+    bundled_resources_nested = bundled_resources / "icons"
+    user_resources_nested = runtime_dir / "resources" / "icons"
+    bundled_resources_nested.mkdir(parents=True)
+    user_resources_nested.mkdir(parents=True)
+    (bundled_resources_nested / "theme.txt").write_text("bundle", encoding="utf-8")
+    (bundled_resources_nested / "new.txt").write_text("new", encoding="utf-8")
+    (user_resources_nested / "theme.txt").write_text("user", encoding="utf-8")
+
+    seed_resources(runtime_dir, bundled_resources)
+
+    assert (user_resources_nested / "theme.txt").read_text(encoding="utf-8") == "user"
+    assert (user_resources_nested / "new.txt").read_text(encoding="utf-8") == "new"

--- a/tests/test_launcher_entry_runtime.py
+++ b/tests/test_launcher_entry_runtime.py
@@ -50,6 +50,14 @@ def _run_entry_as_nuitka(
         sys.path[:] = original_sys_path
 
 
+def _write_parent_data_db(tmp_path: Path) -> Path:
+    parent_data = tmp_path / "data"
+    parent_data.mkdir()
+    parent_db = parent_data / "ssas.db"
+    parent_db.write_text("local-db-must-not-be-seeded", encoding="utf-8")
+    return parent_db
+
+
 def test_cli_entry_nuitka_runtime_does_not_use_build_repo_db(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -68,6 +76,8 @@ def test_cli_entry_nuitka_runtime_does_not_use_build_repo_db(
 def test_cli_entry_nuitka_runtime_uses_executable_layout_without_compiled_global(
     monkeypatch, tmp_path: Path
 ) -> None:
+    parent_db = _write_parent_data_db(tmp_path)
+
     namespace = _run_entry_as_nuitka(
         monkeypatch,
         tmp_path,
@@ -82,11 +92,15 @@ def test_cli_entry_nuitka_runtime_uses_executable_layout_without_compiled_global
     assert namespace["app_dir"] == str(tmp_path / "entry.dist")
     assert db_path == runtime_root / "data" / "ssas.db"
     assert REPO_ROOT not in db_path.parents
+    assert parent_db.exists()
+    assert not db_path.exists()
 
 
 def test_gui_entry_nuitka_runtime_does_not_use_build_repo_db(
     monkeypatch, tmp_path: Path
 ) -> None:
+    parent_db = _write_parent_data_db(tmp_path)
+
     namespace = _run_entry_as_nuitka(
         monkeypatch, tmp_path, "gui_entry.py", "SSA_GUI_v4.37_windows_amd64.exe"
     )
@@ -97,3 +111,5 @@ def test_gui_entry_nuitka_runtime_does_not_use_build_repo_db(
     assert namespace["app_dir"] == str(tmp_path / "entry.dist")
     assert db_path == runtime_root / "data" / "ssas.db"
     assert REPO_ROOT not in db_path.parents
+    assert parent_db.exists()
+    assert not db_path.exists()

--- a/tests/test_launcher_entry_runtime.py
+++ b/tests/test_launcher_entry_runtime.py
@@ -10,9 +10,14 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _run_entry_as_nuitka(
-    monkeypatch, tmp_path: Path, entry_name: str, executable_name: str
+    monkeypatch,
+    tmp_path: Path,
+    entry_name: str,
+    executable_name: str,
+    *,
+    compiled_global: bool = True,
 ) -> dict[str, object]:
-    exe_dir = tmp_path / "dist"
+    exe_dir = tmp_path / "entry.dist"
     exe_dir.mkdir()
     executable = exe_dir / executable_name
     executable.write_text("", encoding="utf-8")
@@ -34,9 +39,10 @@ def _run_entry_as_nuitka(
     original_cwd = Path.cwd()
     original_sys_path = list(sys.path)
     try:
+        init_globals = {"__compiled__": True} if compiled_global else None
         return runpy.run_path(
             str(REPO_ROOT / "launchers" / entry_name),
-            init_globals={"__compiled__": True},
+            init_globals=init_globals,
             run_name=f"test_{entry_name}",
         )
     finally:
@@ -54,7 +60,26 @@ def test_cli_entry_nuitka_runtime_does_not_use_build_repo_db(
     db_path = Path(os.environ["SSA_DB_PATH"])
     runtime_root = Path(os.environ["SSA_RUNTIME_ROOT"])
 
-    assert namespace["app_dir"] == str(tmp_path / "dist")
+    assert namespace["app_dir"] == str(tmp_path / "entry.dist")
+    assert db_path == runtime_root / "data" / "ssas.db"
+    assert REPO_ROOT not in db_path.parents
+
+
+def test_cli_entry_nuitka_runtime_uses_executable_layout_without_compiled_global(
+    monkeypatch, tmp_path: Path
+) -> None:
+    namespace = _run_entry_as_nuitka(
+        monkeypatch,
+        tmp_path,
+        "cli_entry.py",
+        "SSA_CLI_v4.37_windows_amd64.exe",
+        compiled_global=False,
+    )
+
+    db_path = Path(os.environ["SSA_DB_PATH"])
+    runtime_root = Path(os.environ["SSA_RUNTIME_ROOT"])
+
+    assert namespace["app_dir"] == str(tmp_path / "entry.dist")
     assert db_path == runtime_root / "data" / "ssas.db"
     assert REPO_ROOT not in db_path.parents
 
@@ -69,6 +94,6 @@ def test_gui_entry_nuitka_runtime_does_not_use_build_repo_db(
     db_path = Path(os.environ["SSA_DB_PATH"])
     runtime_root = Path(os.environ["SSA_RUNTIME_ROOT"])
 
-    assert namespace["app_dir"] == str(tmp_path / "dist")
+    assert namespace["app_dir"] == str(tmp_path / "entry.dist")
     assert db_path == runtime_root / "data" / "ssas.db"
     assert REPO_ROOT not in db_path.parents

--- a/tests/test_launcher_entry_runtime.py
+++ b/tests/test_launcher_entry_runtime.py
@@ -4,6 +4,7 @@ import os
 import runpy
 import sys
 from pathlib import Path
+from typing import cast
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -44,16 +45,41 @@ def _run_entry_as_nuitka(
 
     original_cwd = Path.cwd()
     original_sys_path = list(sys.path)
+    ssa_keys = (
+        "SSA_BUNDLED_ROOT",
+        "SSA_CONFIG_DIR",
+        "SSA_DB_PATH",
+        "SSA_EXTRA_ALLOWED_PATHS",
+        "SSA_RUNTIME_ROOT",
+    )
+    original_env = {key: os.environ.get(key) for key in ssa_keys}
     try:
         init_globals = {"__compiled__": True} if compiled_global else None
-        return runpy.run_path(
+        namespace = runpy.run_path(
             str(REPO_ROOT / "launchers" / entry_name),
             init_globals=init_globals,
             run_name=f"test_{entry_name}",
         )
+        namespace["_runtime_env"] = {
+            key: os.environ[key]
+            for key in (
+                "SSA_BUNDLED_ROOT",
+                "SSA_CONFIG_DIR",
+                "SSA_DB_PATH",
+                "SSA_EXTRA_ALLOWED_PATHS",
+                "SSA_RUNTIME_ROOT",
+            )
+            if key in os.environ
+        }
+        return namespace
     finally:
         os.chdir(original_cwd)
         sys.path[:] = original_sys_path
+        for key, value in original_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def _write_parent_data_db(tmp_path: Path) -> Path:
@@ -73,8 +99,9 @@ def test_cli_entry_nuitka_runtime_does_not_use_build_repo_db(
         monkeypatch, tmp_path, "cli_entry.py", "SSA_CLI_v4.37_windows_amd64.exe"
     )
 
-    db_path = Path(os.environ["SSA_DB_PATH"])
-    runtime_root = Path(os.environ["SSA_RUNTIME_ROOT"])
+    runtime_env = cast(dict[str, str], namespace["_runtime_env"])
+    db_path = Path(runtime_env["SSA_DB_PATH"])
+    runtime_root = Path(runtime_env["SSA_RUNTIME_ROOT"])
 
     assert namespace["app_dir"] == str(tmp_path / "entry.dist")
     assert db_path == runtime_root / "data" / "ssas.db"
@@ -96,8 +123,9 @@ def test_cli_entry_nuitka_runtime_uses_executable_layout_without_compiled_global
         compiled_global=False,
     )
 
-    db_path = Path(os.environ["SSA_DB_PATH"])
-    runtime_root = Path(os.environ["SSA_RUNTIME_ROOT"])
+    runtime_env = cast(dict[str, str], namespace["_runtime_env"])
+    db_path = Path(runtime_env["SSA_DB_PATH"])
+    runtime_root = Path(runtime_env["SSA_RUNTIME_ROOT"])
 
     assert namespace["app_dir"] == str(tmp_path / "entry.dist")
     assert db_path == runtime_root / "data" / "ssas.db"
@@ -115,11 +143,181 @@ def test_gui_entry_nuitka_runtime_does_not_use_build_repo_db(
         monkeypatch, tmp_path, "gui_entry.py", "SSA_GUI_v4.37_windows_amd64.exe"
     )
 
-    db_path = Path(os.environ["SSA_DB_PATH"])
-    runtime_root = Path(os.environ["SSA_RUNTIME_ROOT"])
+    runtime_env = cast(dict[str, str], namespace["_runtime_env"])
+    db_path = Path(runtime_env["SSA_DB_PATH"])
+    runtime_root = Path(runtime_env["SSA_RUNTIME_ROOT"])
 
     assert namespace["app_dir"] == str(tmp_path / "entry.dist")
     assert db_path == runtime_root / "data" / "ssas.db"
     assert REPO_ROOT not in db_path.parents
     assert parent_db.exists()
     assert not db_path.exists()
+
+
+def test_launcher_runtime_helper_does_not_leak_ssa_environment(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    namespace = _run_entry_as_nuitka(
+        monkeypatch,
+        tmp_path,
+        "cli_entry.py",
+        "SSA_CLI_v4.37_windows_amd64.exe",
+    )
+    runtime_env = cast(dict[str, str], namespace["_runtime_env"])
+
+    assert "SSA_RUNTIME_ROOT" in runtime_env
+    for key in (
+        "SSA_BUNDLED_ROOT",
+        "SSA_CONFIG_DIR",
+        "SSA_DB_PATH",
+        "SSA_EXTRA_ALLOWED_PATHS",
+        "SSA_RUNTIME_ROOT",
+    ):
+        assert key not in os.environ
+
+
+def test_cli_entry_pyinstaller_runtime_uses_meipass_bundle_root(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    exe_dir = tmp_path / "dist"
+    bundle_root = tmp_path / "_MEIPASS"
+    bundled_config = bundle_root / "config"
+    bundled_data = bundle_root / "data"
+    bundled_config.mkdir(parents=True)
+    bundled_data.mkdir()
+    (bundled_config / "build_info.json").write_text("{}", encoding="utf-8")
+    (bundled_data / "ssas.db").write_text("bundle-db", encoding="utf-8")
+    executable = exe_dir / "SSA_CLI_v4.37_windows_amd64.exe"
+    exe_dir.mkdir()
+    executable.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(bundle_root), raising=False)
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    for key in (
+        "SSA_BUNDLED_ROOT",
+        "SSA_CONFIG_DIR",
+        "SSA_DB_PATH",
+        "SSA_EXTRA_ALLOWED_PATHS",
+        "SSA_RUNTIME_ROOT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    original_cwd = Path.cwd()
+    original_sys_path = list(sys.path)
+    try:
+        namespace = runpy.run_path(
+            str(REPO_ROOT / "launchers" / "cli_entry.py"),
+            run_name="test_cli_entry_pyinstaller",
+        )
+        runtime_root = Path(os.environ["SSA_RUNTIME_ROOT"])
+        assert namespace["app_dir"] == str(bundle_root)
+        assert Path(os.environ["SSA_CONFIG_DIR"]) == runtime_root / "config"
+        assert (runtime_root / "config" / "build_info.json").is_file()
+        assert (runtime_root / "data" / "ssas.db").read_text(encoding="utf-8") == "bundle-db"
+    finally:
+        os.chdir(original_cwd)
+        sys.path[:] = original_sys_path
+
+
+def test_gui_entry_pyinstaller_runtime_uses_meipass_bundle_root(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    exe_dir = tmp_path / "dist"
+    bundle_root = tmp_path / "_MEIPASS"
+    bundled_config = bundle_root / "config"
+    bundled_data = bundle_root / "data"
+    bundled_resources = bundle_root / "resources"
+    bundled_config.mkdir(parents=True)
+    bundled_data.mkdir()
+    bundled_resources.mkdir()
+    (bundled_config / "build_info.json").write_text("{}", encoding="utf-8")
+    (bundled_data / "ssas.db").write_text("bundle-db", encoding="utf-8")
+    (bundled_resources / "icon.txt").write_text("icon", encoding="utf-8")
+    executable = exe_dir / "SSA_GUI_v4.37_windows_amd64.exe"
+    exe_dir.mkdir()
+    executable.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(bundle_root), raising=False)
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    for key in (
+        "SSA_BUNDLED_ROOT",
+        "SSA_CONFIG_DIR",
+        "SSA_DB_PATH",
+        "SSA_EXTRA_ALLOWED_PATHS",
+        "SSA_RUNTIME_ROOT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    original_cwd = Path.cwd()
+    original_sys_path = list(sys.path)
+    try:
+        namespace = runpy.run_path(
+            str(REPO_ROOT / "launchers" / "gui_entry.py"),
+            run_name="test_gui_entry_pyinstaller",
+        )
+        runtime_root = Path(os.environ["SSA_RUNTIME_ROOT"])
+        assert namespace["app_dir"] == str(bundle_root)
+        assert Path(os.environ["SSA_CONFIG_DIR"]) == runtime_root / "config"
+        assert (runtime_root / "config" / "build_info.json").is_file()
+        assert (runtime_root / "data" / "ssas.db").read_text(encoding="utf-8") == (
+            "bundle-db"
+        )
+        assert (runtime_root / "resources" / "icon.txt").read_text(encoding="utf-8") == (
+            "icon"
+        )
+    finally:
+        os.chdir(original_cwd)
+        sys.path[:] = original_sys_path
+
+
+def test_cli_entry_pyoxidizer_runtime_uses_executable_dir_as_bundle_root(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    bundle_root = tmp_path / "pyoxidizer"
+    bundled_config = bundle_root / "config"
+    bundled_data = bundle_root / "data"
+    bundled_config.mkdir(parents=True)
+    bundled_data.mkdir()
+    (bundled_config / "build_info.json").write_text("{}", encoding="utf-8")
+    (bundled_data / "ssas.db").write_text("bundle-db", encoding="utf-8")
+    executable = bundle_root / "SSA_Consulta_Rapida.exe"
+    executable.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setattr(sys, "oxidized", True, raising=False)
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    for key in (
+        "SSA_BUNDLED_ROOT",
+        "SSA_CONFIG_DIR",
+        "SSA_DB_PATH",
+        "SSA_EXTRA_ALLOWED_PATHS",
+        "SSA_RUNTIME_ROOT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    original_cwd = Path.cwd()
+    original_sys_path = list(sys.path)
+    try:
+        namespace = runpy.run_path(
+            str(REPO_ROOT / "launchers" / "cli_entry.py"),
+            run_name="test_cli_entry_pyoxidizer",
+        )
+        runtime_root = Path(os.environ["SSA_RUNTIME_ROOT"])
+        assert namespace["app_dir"] == str(bundle_root)
+        assert Path(os.environ["SSA_CONFIG_DIR"]) == runtime_root / "config"
+        assert (runtime_root / "config" / "build_info.json").is_file()
+        assert (runtime_root / "data" / "ssas.db").read_text(encoding="utf-8") == (
+            "bundle-db"
+        )
+    finally:
+        os.chdir(original_cwd)
+        sys.path[:] = original_sys_path

--- a/tests/test_launcher_entry_runtime.py
+++ b/tests/test_launcher_entry_runtime.py
@@ -22,11 +22,17 @@ def _run_entry_as_nuitka(
     executable = exe_dir / executable_name
     executable.write_text("", encoding="utf-8")
     appdata = tmp_path / "appdata"
+    home_dir = tmp_path / "home"
+    xdg_data_home = tmp_path / "xdg_data"
     appdata.mkdir()
+    home_dir.mkdir()
+    xdg_data_home.mkdir()
 
     monkeypatch.setattr(sys, "executable", str(executable))
     monkeypatch.setenv("APPDATA", str(appdata))
     monkeypatch.setenv("LOCALAPPDATA", str(appdata))
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data_home))
     for key in (
         "SSA_BUNDLED_ROOT",
         "SSA_CONFIG_DIR",
@@ -61,6 +67,8 @@ def _write_parent_data_db(tmp_path: Path) -> Path:
 def test_cli_entry_nuitka_runtime_does_not_use_build_repo_db(
     monkeypatch, tmp_path: Path
 ) -> None:
+    parent_db = _write_parent_data_db(tmp_path)
+
     namespace = _run_entry_as_nuitka(
         monkeypatch, tmp_path, "cli_entry.py", "SSA_CLI_v4.37_windows_amd64.exe"
     )
@@ -71,6 +79,8 @@ def test_cli_entry_nuitka_runtime_does_not_use_build_repo_db(
     assert namespace["app_dir"] == str(tmp_path / "entry.dist")
     assert db_path == runtime_root / "data" / "ssas.db"
     assert REPO_ROOT not in db_path.parents
+    assert parent_db.exists()
+    assert not db_path.exists()
 
 
 def test_cli_entry_nuitka_runtime_uses_executable_layout_without_compiled_global(

--- a/tests/test_launcher_entry_runtime.py
+++ b/tests/test_launcher_entry_runtime.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+import runpy
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_entry_as_nuitka(
+    monkeypatch, tmp_path: Path, entry_name: str, executable_name: str
+) -> dict[str, object]:
+    exe_dir = tmp_path / "dist"
+    exe_dir.mkdir()
+    executable = exe_dir / executable_name
+    executable.write_text("", encoding="utf-8")
+    appdata = tmp_path / "appdata"
+    appdata.mkdir()
+
+    monkeypatch.setattr(sys, "executable", str(executable))
+    monkeypatch.setenv("APPDATA", str(appdata))
+    monkeypatch.setenv("LOCALAPPDATA", str(appdata))
+    for key in (
+        "SSA_BUNDLED_ROOT",
+        "SSA_CONFIG_DIR",
+        "SSA_DB_PATH",
+        "SSA_EXTRA_ALLOWED_PATHS",
+        "SSA_RUNTIME_ROOT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    original_cwd = Path.cwd()
+    original_sys_path = list(sys.path)
+    try:
+        return runpy.run_path(
+            str(REPO_ROOT / "launchers" / entry_name),
+            init_globals={"__compiled__": True},
+            run_name=f"test_{entry_name}",
+        )
+    finally:
+        os.chdir(original_cwd)
+        sys.path[:] = original_sys_path
+
+
+def test_cli_entry_nuitka_runtime_does_not_use_build_repo_db(
+    monkeypatch, tmp_path: Path
+) -> None:
+    namespace = _run_entry_as_nuitka(
+        monkeypatch, tmp_path, "cli_entry.py", "SSA_CLI_v4.37_windows_amd64.exe"
+    )
+
+    db_path = Path(os.environ["SSA_DB_PATH"])
+    runtime_root = Path(os.environ["SSA_RUNTIME_ROOT"])
+
+    assert namespace["app_dir"] == str(tmp_path / "dist")
+    assert db_path == runtime_root / "data" / "ssas.db"
+    assert REPO_ROOT not in db_path.parents
+
+
+def test_gui_entry_nuitka_runtime_does_not_use_build_repo_db(
+    monkeypatch, tmp_path: Path
+) -> None:
+    namespace = _run_entry_as_nuitka(
+        monkeypatch, tmp_path, "gui_entry.py", "SSA_GUI_v4.37_windows_amd64.exe"
+    )
+
+    db_path = Path(os.environ["SSA_DB_PATH"])
+    runtime_root = Path(os.environ["SSA_RUNTIME_ROOT"])
+
+    assert namespace["app_dir"] == str(tmp_path / "dist")
+    assert db_path == runtime_root / "data" / "ssas.db"
+    assert REPO_ROOT not in db_path.parents

--- a/tests/test_release_debian_script.py
+++ b/tests/test_release_debian_script.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import argparse
 import json
 from pathlib import Path
 
@@ -264,6 +265,37 @@ def test_release_debian_report_asset_payload_errors_include_path(
 
     with pytest.raises(REPORT_MODULE.ReleaseReportError, match="package.deb"):
         REPORT_MODULE._asset_payload(asset)
+
+
+def test_release_debian_report_filters_stale_assets_from_other_backends(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    package_dir = tmp_path / "builds" / "packages" / "debian_amd64"
+    package_dir.mkdir(parents=True)
+    current = package_dir / "SSA_Consulta_Rapida_v4.37_debian_amd64_nuitka_cli.tar.gz"
+    stale = package_dir / "SSA_Consulta_Rapida_v4.37_debian_amd64_pyoxidizer.tar.gz"
+    current.write_bytes(b"current")
+    stale.write_bytes(b"stale")
+
+    monkeypatch.setattr(REPORT_MODULE, "_sha256", lambda _path: "0" * 64)
+    report_file = tmp_path / "report.json"
+
+    result = REPORT_MODULE.write_report(
+        argparse.Namespace(
+            repo_root=tmp_path,
+            report_file=report_file,
+            platform="debian_amd64",
+            backends="nuitka",
+            packages="tar",
+            app_version="4.37",
+            git_commit="abc",
+        )
+    )
+
+    payload = json.loads(report_file.read_text(encoding="utf-8"))
+    assert result == 0
+    assert [asset["name"] for asset in payload["assets"]] == [current.name]
 
 
 def test_release_debian_tests_use_guarded_string_positions() -> None:

--- a/tests/test_release_debian_script.py
+++ b/tests/test_release_debian_script.py
@@ -298,6 +298,14 @@ def test_release_debian_report_filters_stale_assets_from_other_backends(
     assert [asset["name"] for asset in payload["assets"]] == [current.name]
 
 
+def test_release_report_normalizes_csv_arguments() -> None:
+    assert REPORT_MODULE._split_csv(" nuitka, pyinstaller,,PYoxidizer ") == [
+        "nuitka",
+        "pyinstaller",
+        "pyoxidizer",
+    ]
+
+
 def test_release_debian_tests_use_guarded_string_positions() -> None:
     test_source = Path(__file__).read_text(encoding="utf-8")
 

--- a/tests/test_release_debian_script.py
+++ b/tests/test_release_debian_script.py
@@ -298,6 +298,47 @@ def test_release_debian_report_filters_stale_assets_from_other_backends(
     assert [asset["name"] for asset in payload["assets"]] == [current.name]
 
 
+def test_release_debian_report_fails_when_package_dir_is_missing(tmp_path) -> None:
+    report_file = tmp_path / "report.json"
+
+    with pytest.raises(
+        REPORT_MODULE.ReleaseReportError,
+        match="diretorio de pacotes ausente",
+    ):
+        REPORT_MODULE.write_report(
+            argparse.Namespace(
+                repo_root=tmp_path,
+                report_file=report_file,
+                platform="debian_amd64",
+                backends="nuitka",
+                packages="tar",
+                app_version="4.37",
+                git_commit="abc",
+            )
+        )
+
+
+def test_release_debian_expected_asset_names_cover_supported_package_matrix() -> None:
+    names = REPORT_MODULE._expected_debian_asset_names(
+        ["pyinstaller", "nuitka", "pyoxidizer"],
+        ["deb", "appimage", "tar"],
+        "4.37",
+    )
+
+    assert names == {
+        "ssa-consulta-rapida-pyinstaller-amd64_4.37_amd64.deb",
+        "ssa-consulta-rapida-nuitka-amd64_4.37_amd64.deb",
+        "ssa-consulta-rapida-pyoxidizer-amd64_4.37_amd64.deb",
+        "SSA_Consulta_Rapida_v4.37_debian_amd64_pyinstaller.AppImage",
+        "SSA_Consulta_Rapida_v4.37_debian_amd64_nuitka.AppImage",
+        "SSA_Consulta_Rapida_v4.37_debian_amd64_pyinstaller_cli.tar.gz",
+        "SSA_Consulta_Rapida_v4.37_debian_amd64_pyinstaller_gui.tar.gz",
+        "SSA_Consulta_Rapida_v4.37_debian_amd64_nuitka_cli.tar.gz",
+        "SSA_Consulta_Rapida_v4.37_debian_amd64_nuitka_gui.tar.gz",
+        "SSA_Consulta_Rapida_v4.37_debian_amd64_pyoxidizer.tar.gz",
+    }
+
+
 def test_release_report_normalizes_csv_arguments() -> None:
     assert REPORT_MODULE._split_csv(" nuitka, pyinstaller,,PYoxidizer ") == [
         "nuitka",

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -120,14 +120,15 @@ def test_release_windows_smoke_uses_isolated_user_environment() -> None:
     assert 'set `"USERPROFILE=$userProfileDir`"' in smoke_body
     assert "set SSA_ 2^>nul" in smoke_body
     assert 'cd /d `"$smokeDir`"' in smoke_body
-    assert "-FilePath $env:ComSpec" in smoke_body
-    assert "-RedirectStandardInput $stdinPath" in smoke_body
+    assert "$startInfo = New-Object System.Diagnostics.ProcessStartInfo" in smoke_body
+    assert "$startInfo.FileName = $env:ComSpec" in smoke_body
+    assert '< `"$stdinPath`" > `"$stdoutPath`" 2> `"$stderrPath`"' in smoke_body
+    assert "$process = New-Object System.Diagnostics.Process" in smoke_body
+    assert "$process.StartInfo = $startInfo" in smoke_body
+    assert "$completed = $process.WaitForExit($smokeTimeoutSeconds * 1000)" in smoke_body
     assert "            -Wait" not in smoke_body
     assert "$smokeTimeoutSeconds = 60" in smoke_body
-    assert "while (-not $process.HasExited" in smoke_body
-    assert "[void]$process.WaitForExit()" in smoke_body
-    assert "ExitCode indisponivel" in smoke_body
-    assert "Stop-Process -Id $process.Id -Force" in smoke_body
+    assert "$process.Kill()" in smoke_body
     assert "Smoke CLI timeout para" in smoke_body
     assert "$stderrRaw = Get-Content -LiteralPath $stderrPath -Raw" in smoke_body
     assert "if ($null -ne $stderrRaw)" in smoke_body

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -95,6 +95,8 @@ def test_release_windows_script_calls_only_windows_build_wrappers() -> None:
     assert "build_info.json" in script
     assert "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in script
     assert "Get-FileHash" in script
+    assert "[System.Security.Cryptography.SHA256]::Create()" in script
+    assert "ComputeHash($stream)" in script
     assert "functional_cli_check" in script
     assert "gui_version_check" in script
     assert "Assert-SourceProtection" in script

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -128,7 +128,11 @@ def test_release_windows_smoke_uses_isolated_user_environment() -> None:
     assert "$completed = $process.WaitForExit($smokeTimeoutSeconds * 1000)" in smoke_body
     assert "            -Wait" not in smoke_body
     assert "$smokeTimeoutSeconds = 60" in smoke_body
+    assert "& taskkill.exe /PID $process.Id /T /F | Out-Null" in smoke_body
     assert "$process.Kill()" in smoke_body
+    assert "New-Object System.Text.UTF8Encoding($false)" in smoke_body
+    assert "[System.IO.File]::WriteAllLines($wrapperPath, $wrapperLines, $utf8NoBom)" in smoke_body
+    assert "Set-Content -LiteralPath $wrapperPath -Value $wrapperLines -Encoding ASCII" not in smoke_body
     assert "Smoke CLI timeout para" in smoke_body
     assert "$stderrRaw = Get-Content -LiteralPath $stderrPath -Raw" in smoke_body
     assert "if ($null -ne $stderrRaw)" in smoke_body

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -122,6 +122,11 @@ def test_release_windows_smoke_uses_isolated_user_environment() -> None:
     assert 'cd /d `"$smokeDir`"' in smoke_body
     assert "-FilePath $env:ComSpec" in smoke_body
     assert "-RedirectStandardInput $stdinPath" in smoke_body
+    assert "            -Wait" not in smoke_body
+    assert "$smokeTimeoutSeconds = 60" in smoke_body
+    assert "while (-not $process.HasExited" in smoke_body
+    assert "Stop-Process -Id $process.Id -Force" in smoke_body
+    assert "Smoke CLI timeout para" in smoke_body
     assert "$stderrRaw = Get-Content -LiteralPath $stderrPath -Raw" in smoke_body
     assert "if ($null -ne $stderrRaw)" in smoke_body
     assert "$stdoutRaw = Get-Content -LiteralPath $stdoutPath -Raw" in smoke_body

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -113,15 +113,16 @@ def test_release_windows_smoke_uses_isolated_user_environment() -> None:
         "function Write-BackendReleaseZips",
     )
 
-    assert "System.Diagnostics.ProcessStartInfo" in smoke_body
-    assert '$processInfo.WorkingDirectory = $smokeDir' in smoke_body
-    assert '$processInfo.EnvironmentVariables["APPDATA"] = $appDataDir' in smoke_body
-    assert '$processInfo.EnvironmentVariables["LOCALAPPDATA"] = $localAppDataDir' in smoke_body
-    assert '$processInfo.EnvironmentVariables["USERPROFILE"] = $userProfileDir' in smoke_body
-    assert 'Where-Object { $_ -like "SSA_*" }' in smoke_body
+    assert '$wrapperPath = Join-Path $smokeDir "smoke.cmd"' in smoke_body
+    assert 'set `"APPDATA=$appDataDir`"' in smoke_body
+    assert 'set `"LOCALAPPDATA=$localAppDataDir`"' in smoke_body
+    assert 'set `"USERPROFILE=$userProfileDir`"' in smoke_body
+    assert "set SSA_ 2^>nul" in smoke_body
+    assert 'cd /d `"$smokeDir`"' in smoke_body
+    assert "-FilePath $env:ComSpec" in smoke_body
+    assert "-RedirectStandardInput $stdinPath" in smoke_body
     assert 'DADOS CARREGADOS:\\s+[1-9][0-9.,]*\\s+SSAs' in smoke_body
     assert "Smoke CLI contaminado por dados locais" in smoke_body
-    assert "Start-Process" not in smoke_body
 
 
 def test_release_windows_script_exposes_backend_scorecard() -> None:

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -121,6 +121,8 @@ def test_release_windows_smoke_uses_isolated_user_environment() -> None:
     assert 'cd /d `"$smokeDir`"' in smoke_body
     assert "-FilePath $env:ComSpec" in smoke_body
     assert "-RedirectStandardInput $stdinPath" in smoke_body
+    assert "([string] (Get-Content -LiteralPath $stderrPath -Raw" in smoke_body
+    assert "([string] (Get-Content -LiteralPath $stdoutPath -Raw" in smoke_body
     assert 'DADOS CARREGADOS:\\s+[1-9][0-9.,]*\\s+SSAs' in smoke_body
     assert "Smoke CLI contaminado por dados locais" in smoke_body
 

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -105,6 +105,25 @@ def test_release_windows_script_calls_only_windows_build_wrappers() -> None:
     assert '"--repo-root",' in script
 
 
+def test_release_windows_smoke_uses_isolated_user_environment() -> None:
+    script = _script_text()
+    smoke_body = section_between(
+        script,
+        "function Invoke-Smoke",
+        "function Write-BackendReleaseZips",
+    )
+
+    assert "System.Diagnostics.ProcessStartInfo" in smoke_body
+    assert '$processInfo.WorkingDirectory = $smokeDir' in smoke_body
+    assert '$processInfo.EnvironmentVariables["APPDATA"] = $appDataDir' in smoke_body
+    assert '$processInfo.EnvironmentVariables["LOCALAPPDATA"] = $localAppDataDir' in smoke_body
+    assert '$processInfo.EnvironmentVariables["USERPROFILE"] = $userProfileDir' in smoke_body
+    assert 'Where-Object { $_ -like "SSA_*" }' in smoke_body
+    assert 'DADOS CARREGADOS:\\s+[1-9][0-9.,]*\\s+SSAs' in smoke_body
+    assert "Smoke CLI contaminado por dados locais" in smoke_body
+    assert "Start-Process" not in smoke_body
+
+
 def test_release_windows_script_exposes_backend_scorecard() -> None:
     script = _script_text()
     scorecard = json.loads(SCORECARD_FILE.read_text(encoding="utf-8"))

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -121,8 +121,10 @@ def test_release_windows_smoke_uses_isolated_user_environment() -> None:
     assert 'cd /d `"$smokeDir`"' in smoke_body
     assert "-FilePath $env:ComSpec" in smoke_body
     assert "-RedirectStandardInput $stdinPath" in smoke_body
-    assert "([string] (Get-Content -LiteralPath $stderrPath -Raw" in smoke_body
-    assert "([string] (Get-Content -LiteralPath $stdoutPath -Raw" in smoke_body
+    assert "$stderrRaw = Get-Content -LiteralPath $stderrPath -Raw" in smoke_body
+    assert "if ($null -ne $stderrRaw)" in smoke_body
+    assert "$stdoutRaw = Get-Content -LiteralPath $stdoutPath -Raw" in smoke_body
+    assert "if ($null -ne $stdoutRaw)" in smoke_body
     assert 'DADOS CARREGADOS:\\s+[1-9][0-9.,]*\\s+SSAs' in smoke_body
     assert "Smoke CLI contaminado por dados locais" in smoke_body
 

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -96,6 +96,7 @@ def test_release_windows_script_calls_only_windows_build_wrappers() -> None:
     assert "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in script
     assert "Get-FileHash" in script
     assert "[System.Security.Cryptography.SHA256]::Create()" in script
+    assert "$sha256 = $null" in script
     assert "ComputeHash($stream)" in script
     assert "functional_cli_check" in script
     assert "gui_version_check" in script

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -95,6 +95,11 @@ def test_release_windows_script_calls_only_windows_build_wrappers() -> None:
     assert "build_info.json" in script
     assert "GUIA_MIGRACAO_NOVA_INSTALACAO.md" in script
     assert "Get-FileHash" in script
+    assert_before(
+        script,
+        '$hashCommand = Get-Command -Name "Get-FileHash"',
+        "foreach ($path in $Paths)",
+    )
     assert "[System.Security.Cryptography.SHA256]::Create()" in script
     assert "$sha256 = $null" in script
     assert "ComputeHash($stream)" in script

--- a/tests/test_release_windows_script.py
+++ b/tests/test_release_windows_script.py
@@ -125,6 +125,8 @@ def test_release_windows_smoke_uses_isolated_user_environment() -> None:
     assert "            -Wait" not in smoke_body
     assert "$smokeTimeoutSeconds = 60" in smoke_body
     assert "while (-not $process.HasExited" in smoke_body
+    assert "[void]$process.WaitForExit()" in smoke_body
+    assert "ExitCode indisponivel" in smoke_body
     assert "Stop-Process -Id $process.Id -Force" in smoke_body
     assert "Smoke CLI timeout para" in smoke_body
     assert "$stderrRaw = Get-Content -LiteralPath $stderrPath -Raw" in smoke_body

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -203,6 +203,7 @@ def test_secret_scan_script_valid_pattern_without_match_succeeds(tmp_path: Path)
 
 def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
     workflow = _read_repo_text(".github", "workflows", "opencode.yml")
+    local_action = _read_repo_text(".github", "actions", "opencode-github", "action.yml")
 
     assert "push:" in workflow
     assert "pull_request:" in workflow
@@ -216,7 +217,14 @@ def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
     assert "Review this pull request for concrete bugs" in workflow
     assert "Review the pushed commit range for concrete bugs" in workflow
     assert workflow.count("uses: ./.github/actions/configure-qwen-opencode") == 3
+    assert workflow.count("uses: ./.github/actions/opencode-github") == 5
     assert workflow.count("qwen-cloud-coding-plan") == 3
+    assert "anomalyco/opencode/github@" not in workflow
+    assert "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830" in local_action
+    assert "actions/cache@v4" not in local_action
+    assert "opencode-ai@${{ inputs.opencode_version }}" in local_action
+    assert "curl -fsSL https://opencode.ai/install | bash" not in local_action
+    assert "releases/latest" not in local_action
     assert "id-token: write" not in workflow
 
 

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -184,6 +184,10 @@ def test_secret_scan_script_blocks_untracked_git_workspace_matches(tmp_path: Pat
 def test_secret_scan_script_uses_fetch_head_pr_diff_and_configurable_history() -> None:
     script = _read_repo_text("scripts", "security", "scan_secrets.sh")
 
+    assert "require_commands" in script
+    assert "for command in git grep awk mktemp" in script
+    assert "grep -R" not in script
+    assert "grep -r" in script
     assert 'git cat-file -e "${diff_base}^{commit}"' in script
     assert 'git fetch --no-tags --depth=1 origin "$base_ref"' in script
     assert 'diff_base="FETCH_HEAD"' in script

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -144,9 +144,10 @@ def test_secret_scan_script_uses_fetch_head_pr_diff_and_configurable_history() -
     assert 'git fetch --no-tags origin "$base_ref"' in script
     assert "git diff --unified=0 FETCH_HEAD...HEAD" in script
     assert '>"$added_lines"' in script
+    assert "if ! git diff --unified=0 FETCH_HEAD...HEAD" in script
     assert 'grep -E -q "$SENSITIVE_PATTERN" "$added_lines"' in script
-    assert 'trap \'rm -f "${added_lines:-}"\' RETURN' in script
-    assert "trap - RETURN" in script
+    assert "PR diff scan failed" in script
+    assert "trap - RETURN" not in script
     assert 'git diff --unified=0 "origin/${base_ref}...HEAD"' not in script
     assert 'SECRET_SCAN_HISTORY_MAX_COUNT:-200' in script
 

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -222,6 +222,8 @@ def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
     assert "anomalyco/opencode/github@" not in workflow
     assert 'default: "true"' in local_action
     assert "GITHUB_TOKEN: ${{ github.token }}" in local_action
+    assert 'git config --global user.name "github-actions[bot]"' in local_action
+    assert 'git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"' in local_action
     assert "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830" in local_action
     assert "actions/cache@v4" not in local_action
     assert "opencode-ai@${{ inputs.opencode_version }}" in local_action

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -79,7 +79,9 @@ def test_secret_scan_uses_quoted_env_for_pr_base_ref() -> None:
     assert "git fetch origin ${{ github.base_ref }}" not in workflow
     assert "origin/${{ github.base_ref }}" not in workflow
     assert "BASE_REF: ${{ github.base_ref }}" in workflow
-    assert 'git fetch origin "$BASE_REF" --depth=1 || true' in workflow
+    assert 'git fetch origin "$BASE_REF"' in workflow
+    assert 'git fetch origin "$BASE_REF" --depth=1' not in workflow
+    assert 'git fetch origin "$BASE_REF" || true' not in workflow
     assert 'git diff --unified=0 "origin/${BASE_REF}...HEAD"' in workflow
 
 

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -215,6 +215,8 @@ def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
     assert "Run automatic push review" in workflow
     assert "Review this pull request for concrete bugs" in workflow
     assert "Review the pushed commit range for concrete bugs" in workflow
+    assert workflow.count("uses: ./.github/actions/configure-qwen-opencode") == 3
+    assert workflow.count("qwen-cloud-coding-plan") == 3
     assert "id-token: write" not in workflow
 
 

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -21,6 +21,7 @@ def test_key_shell_scripts_parse_with_available_bash() -> None:
         "scripts/shell_doctor.sh",
         "scripts/ci_quality_gates.sh",
         "scripts/run_tests.sh",
+        "scripts/security/scan_secrets.sh",
     ]
     for script in scripts:
         result = subprocess.run(
@@ -79,19 +80,64 @@ def test_secret_scan_uses_quoted_env_for_pr_base_ref() -> None:
     assert "git fetch origin ${{ github.base_ref }}" not in workflow
     assert "origin/${{ github.base_ref }}" not in workflow
     assert "BASE_REF: ${{ github.base_ref }}" in workflow
-    assert 'git fetch origin "$BASE_REF"' in workflow
+    assert 'bash scripts/security/scan_secrets.sh pr-diff "$BASE_REF"' in workflow
     assert 'git fetch origin "$BASE_REF" --depth=1' not in workflow
     assert 'git fetch origin "$BASE_REF" || true' not in workflow
-    assert 'git diff --unified=0 "origin/${BASE_REF}...HEAD"' in workflow
+    assert 'git diff --unified=0 "origin/${BASE_REF}...HEAD"' not in workflow
 
 
-def test_secret_scan_is_blocking_on_main_and_dev() -> None:
+def test_secret_scan_workspace_and_pr_diff_are_blocking_on_main_and_dev() -> None:
     workflow = _read_repo_text(".github", "workflows", "secret_scan.yml")
 
     assert "branches: [ main, dev ]" in workflow
     assert "continue-on-error: true" not in workflow
-    assert "echo '[ERROR] Sensitive patterns found'" in workflow
-    assert "echo '[ERROR] Possible secret in diff'" in workflow
+    assert "bash scripts/security/scan_secrets.sh workspace" in workflow
+    assert "bash scripts/security/scan_secrets.sh history" in workflow
+
+
+def test_secret_scan_script_blocks_workspace_matches(tmp_path: Path) -> None:
+    bash = shutil.which("bash")
+    assert bash is not None, "bash must be available for shell contract tests"
+
+    script = PROJECT_ROOT / "scripts" / "security" / "scan_secrets.sh"
+    clean_dir = tmp_path / "clean"
+    clean_dir.mkdir()
+    (clean_dir / "app.txt").write_text("no sensitive value here\n", encoding="utf-8")
+
+    clean_result = subprocess.run(
+        [bash, str(script), "workspace"],
+        cwd=clean_dir,
+        text=True,
+        capture_output=True,
+        check=False,
+        env={"SENSITIVE_PATTERN": "TEST_SECRET_[0-9][0-9][0-9][0-9]"},
+    )
+    assert clean_result.returncode == 0, clean_result.stderr
+
+    dirty_dir = tmp_path / "dirty"
+    dirty_dir.mkdir()
+    (dirty_dir / "app.txt").write_text("token=TEST_SECRET_1234\n", encoding="utf-8")
+
+    dirty_result = subprocess.run(
+        [bash, str(script), "workspace"],
+        cwd=dirty_dir,
+        text=True,
+        capture_output=True,
+        check=False,
+        env={"SENSITIVE_PATTERN": "TEST_SECRET_[0-9][0-9][0-9][0-9]"},
+    )
+    assert dirty_result.returncode == 1
+    assert "TEST_SECRET_1234" not in dirty_result.stdout
+    assert "TEST_SECRET_1234" not in dirty_result.stderr
+
+
+def test_secret_scan_script_uses_fetch_head_pr_diff_and_configurable_history() -> None:
+    script = _read_repo_text("scripts", "security", "scan_secrets.sh")
+
+    assert 'git fetch --no-tags origin "$base_ref"' in script
+    assert "git diff --unified=0 FETCH_HEAD...HEAD" in script
+    assert 'git diff --unified=0 "origin/${base_ref}...HEAD"' not in script
+    assert 'SECRET_SCAN_HISTORY_MAX_COUNT:-200' in script
 
 
 def test_opencode_secret_jobs_use_environment_without_oidc() -> None:

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -100,8 +102,9 @@ def test_secret_scan_uses_quoted_env_for_pr_base_ref() -> None:
 
     assert "git fetch origin ${{ github.base_ref }}" not in workflow
     assert "origin/${{ github.base_ref }}" not in workflow
-    assert "BASE_REF: ${{ github.base_ref }}" in workflow
-    assert 'bash scripts/security/scan_secrets.sh pr-diff "$BASE_REF"' in workflow
+    assert "BASE_REF: ${{ github.base_ref }}" not in workflow
+    assert "BASE_SHA: ${{ github.event.pull_request.base.sha }}" in workflow
+    assert 'bash scripts/security/scan_secrets.sh pr-diff "$BASE_SHA"' in workflow
     assert 'git fetch origin "$BASE_REF" --depth=1' not in workflow
     assert 'git fetch origin "$BASE_REF" || true' not in workflow
     assert 'git diff --unified=0 "origin/${BASE_REF}...HEAD"' not in workflow
@@ -181,11 +184,13 @@ def test_secret_scan_script_blocks_untracked_git_workspace_matches(tmp_path: Pat
 def test_secret_scan_script_uses_fetch_head_pr_diff_and_configurable_history() -> None:
     script = _read_repo_text("scripts", "security", "scan_secrets.sh")
 
-    assert 'git fetch --no-tags origin "$base_ref"' in script
-    assert "git diff --unified=0 FETCH_HEAD...HEAD" in script
+    assert 'git cat-file -e "${diff_base}^{commit}"' in script
+    assert 'git fetch --no-tags --depth=1 origin "$base_ref"' in script
+    assert 'diff_base="FETCH_HEAD"' in script
+    assert 'git diff --unified=0 "${diff_base}...HEAD"' in script
     assert "git grep --untracked" in script
     assert '>"$added_lines"' in script
-    assert "if ! git diff --unified=0 FETCH_HEAD...HEAD" in script
+    assert 'if ! git diff --unified=0 "${diff_base}...HEAD"' in script
     assert 'grep -E -q "$SENSITIVE_PATTERN" "$added_lines"' in script
     assert "PR diff scan failed" in script
     assert "trap - RETURN" not in script
@@ -220,6 +225,7 @@ def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
     assert "push:" not in workflow
     assert "pull_request:" in workflow
     assert "opencode-pr-review:" in workflow
+    assert "github.event.pull_request.head.repo.fork == false" in workflow
     assert "opencode-push-review:" not in workflow
     assert workflow.count("environment: SECRETS") == 4
     assert "noop:" in workflow
@@ -253,6 +259,37 @@ def test_opencode_review_script_extracts_pr_number() -> None:
     assert module.extract_pr_number({"issue": {"number": 59, "pull_request": {"url": "x"}}}) == 59
     with pytest.raises(ValueError, match="pull request"):
         module.extract_pr_number({"issue": {"number": 60}})
+
+
+def test_opencode_review_script_requires_clear_environment(monkeypatch) -> None:
+    module = _load_opencode_review_module()
+
+    monkeypatch.delenv("MODEL", raising=False)
+
+    with pytest.raises(RuntimeError, match="MODEL"):
+        module.required_env("MODEL")
+
+
+def test_opencode_review_script_does_not_print_failed_command_output(tmp_path: Path, capsys) -> None:
+    module = _load_opencode_review_module()
+    output_path = tmp_path / "captured.txt"
+
+    with pytest.raises(subprocess.CalledProcessError):
+        module.run_checked(
+            [
+                sys.executable,
+                "-c",
+                "import sys; print('SECRET_STDOUT'); print('SECRET_STDERR', file=sys.stderr); sys.exit(3)",
+            ],
+            stdout_path=output_path,
+        )
+
+    captured = capsys.readouterr()
+    assert "SECRET_STDOUT" not in captured.out
+    assert "SECRET_STDERR" not in captured.out
+    assert "SECRET_STDERR" not in captured.err
+    assert "stdout captured in:" in captured.out
+    assert "SECRET_STDOUT" in output_path.read_text(encoding="utf-8")
 
 
 def test_opencode_review_script_truncates_large_diff(tmp_path: Path) -> None:
@@ -312,6 +349,21 @@ def test_shell_doctor_does_not_print_sensitive_value_prefixes() -> None:
     assert 'echo "$matches"' not in script
     assert "grep -REl" in script
     assert "suspect+=(\"${name}\")" in script
+
+
+def test_secret_baseline_paths_are_posix_style() -> None:
+    payload = json.loads(_read_repo_text(".secrets.baseline"))
+
+    for path in payload["results"]:
+        assert "\\" not in path
+
+
+def test_gitleaks_baseline_hash_allowlist_is_line_anchored() -> None:
+    config = _read_repo_text(".gitleaks.toml")
+
+    assert 'regexTarget = "line"' in config
+    assert '^\\s*"hashed_secret": "[a-f0-9]{40}",?\\s*$' in config
+    assert '"hashed_secret": "[a-f0-9]{40}"\'\'\']' not in config
 
 
 def test_shell_doctor_help_describes_all_history_as_git_history() -> None:

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -204,9 +204,17 @@ def test_secret_scan_script_valid_pattern_without_match_succeeds(tmp_path: Path)
 def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
     workflow = _read_repo_text(".github", "workflows", "opencode.yml")
 
-    assert workflow.count("environment: SECRETS") == 3
+    assert "push:" in workflow
+    assert "pull_request:" in workflow
+    assert "opencode-pr-review:" in workflow
+    assert "opencode-push-review:" in workflow
+    assert workflow.count("environment: SECRETS") == 5
     assert "noop:" in workflow
     assert 'echo "No opencode command in comment; skipping."' in workflow
+    assert "Run automatic PR review" in workflow
+    assert "Run automatic push review" in workflow
+    assert "Review this pull request for concrete bugs" in workflow
+    assert "Review the pushed commit range for concrete bugs" in workflow
     assert "id-token: write" not in workflow
 
 

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -66,6 +66,13 @@ def test_ci_quality_gates_does_not_expand_arg_string_unquoted() -> None:
     assert '"${GATES_ARGS_ARRAY[@]}"' in script
 
 
+def test_minimal_ci_runs_for_any_workflow_change() -> None:
+    workflow = _read_repo_text(".github", "workflows", "minimal-ci.yml")
+
+    assert workflow.count('".github/workflows/*.yml"') == 2
+    assert '".github/workflows/minimal-ci.yml"' not in workflow
+
+
 def test_secret_scan_uses_quoted_env_for_pr_base_ref() -> None:
     workflow = _read_repo_text(".github", "workflows", "secret_scan.yml")
 
@@ -74,6 +81,22 @@ def test_secret_scan_uses_quoted_env_for_pr_base_ref() -> None:
     assert "BASE_REF: ${{ github.base_ref }}" in workflow
     assert 'git fetch origin "$BASE_REF" --depth=1 || true' in workflow
     assert 'git diff --unified=0 "origin/${BASE_REF}...HEAD"' in workflow
+
+
+def test_secret_scan_is_blocking_on_main_and_dev() -> None:
+    workflow = _read_repo_text(".github", "workflows", "secret_scan.yml")
+
+    assert "branches: [ main, dev ]" in workflow
+    assert "continue-on-error: true" not in workflow
+    assert "echo '[ERROR] Sensitive patterns found'" in workflow
+    assert "echo '[ERROR] Possible secret in diff'" in workflow
+
+
+def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
+    workflow = _read_repo_text(".github", "workflows", "opencode.yml")
+
+    assert workflow.count("environment: SECRETS") == 3
+    assert "id-token: write" not in workflow
 
 
 def test_shell_doctor_does_not_print_sensitive_value_prefixes() -> None:

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -2,10 +2,17 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import os
 from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _test_env(**overrides: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(overrides)
+    return env
 
 
 def _read_repo_text(*parts: str) -> str:
@@ -89,7 +96,7 @@ def test_secret_scan_uses_quoted_env_for_pr_base_ref() -> None:
 def test_secret_scan_workspace_and_pr_diff_are_blocking_on_main_and_dev() -> None:
     workflow = _read_repo_text(".github", "workflows", "secret_scan.yml")
 
-    assert "branches: [ main, dev ]" in workflow
+    assert "branches: [main, dev]" in workflow
     assert "continue-on-error: true" not in workflow
     assert "bash scripts/security/scan_secrets.sh workspace" in workflow
     assert "bash scripts/security/scan_secrets.sh history" in workflow
@@ -110,7 +117,7 @@ def test_secret_scan_script_blocks_workspace_matches(tmp_path: Path) -> None:
         text=True,
         capture_output=True,
         check=False,
-        env={"SENSITIVE_PATTERN": "TEST_SECRET_[0-9][0-9][0-9][0-9]"},
+        env=_test_env(SENSITIVE_PATTERN="TEST_SECRET_[0-9][0-9][0-9][0-9]"),
     )
     assert clean_result.returncode == 0, clean_result.stderr
 
@@ -124,7 +131,7 @@ def test_secret_scan_script_blocks_workspace_matches(tmp_path: Path) -> None:
         text=True,
         capture_output=True,
         check=False,
-        env={"SENSITIVE_PATTERN": "TEST_SECRET_[0-9][0-9][0-9][0-9]"},
+        env=_test_env(SENSITIVE_PATTERN="TEST_SECRET_[0-9][0-9][0-9][0-9]"),
     )
     assert dirty_result.returncode == 1
     assert "TEST_SECRET_1234" not in dirty_result.stdout
@@ -136,8 +143,32 @@ def test_secret_scan_script_uses_fetch_head_pr_diff_and_configurable_history() -
 
     assert 'git fetch --no-tags origin "$base_ref"' in script
     assert "git diff --unified=0 FETCH_HEAD...HEAD" in script
+    assert '>"$added_lines"' in script
+    assert 'grep -E -q "$SENSITIVE_PATTERN" "$added_lines"' in script
+    assert 'trap \'rm -f "${added_lines:-}"\' RETURN' in script
+    assert "trap - RETURN" in script
     assert 'git diff --unified=0 "origin/${base_ref}...HEAD"' not in script
     assert 'SECRET_SCAN_HISTORY_MAX_COUNT:-200' in script
+
+
+def test_secret_scan_script_valid_pattern_without_match_succeeds(tmp_path: Path) -> None:
+    bash = shutil.which("bash")
+    assert bash is not None, "bash must be available for shell contract tests"
+
+    script = PROJECT_ROOT / "scripts" / "security" / "scan_secrets.sh"
+    (tmp_path / "clean.txt").write_text("nothing to report\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [bash, str(script), "workspace"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=_test_env(SENSITIVE_PATTERN="TEST_SECRET_[0-9][0-9][0-9][0-9]"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "[OK] No sensitive patterns detected" in result.stdout
 
 
 def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
@@ -153,6 +184,8 @@ def test_codeql_precheck_runs_advanced_when_default_setup_is_unverified() -> Non
     assert 'RUN_ADVANCED="true"' in workflow
     assert 'REASON="advanced_allowed_default_setup_unverified"' in workflow
     assert "Could not verify CodeQL default setup state: HTTP ${HTTP_CODE}; running advanced scan." in workflow
+    assert 'HTTP_CODE="000"' in workflow
+    assert 'Unsupported CodeQL default setup state: ${STATE}; running advanced scan.' in workflow
     assert 'REASON="advanced_allowed_default_setup_unverified_http_${HTTP_CODE}"' in workflow
     assert 'echo "Could not verify CodeQL default setup state: HTTP ${HTTP_CODE}" >&2\n            exit 1' not in workflow
     assert "default-setup-skip-note:" in workflow

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -99,6 +99,18 @@ def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
     assert "id-token: write" not in workflow
 
 
+def test_codeql_precheck_runs_advanced_when_default_setup_is_unverified() -> None:
+    workflow = _read_repo_text(".github", "workflows", "codeql.yml")
+
+    assert 'RUN_ADVANCED="true"' in workflow
+    assert 'REASON="advanced_allowed_default_setup_unverified"' in workflow
+    assert "Could not verify CodeQL default setup state: HTTP ${HTTP_CODE}; running advanced scan." in workflow
+    assert 'REASON="advanced_allowed_default_setup_unverified_http_${HTTP_CODE}"' in workflow
+    assert 'echo "Could not verify CodeQL default setup state: HTTP ${HTTP_CODE}" >&2\n            exit 1' not in workflow
+    assert "default-setup-skip-note:" in workflow
+    assert "verification could not be completed" not in workflow
+
+
 def test_shell_doctor_does_not_print_sensitive_value_prefixes() -> None:
     script = _read_repo_text("scripts", "shell_doctor.sh")
 

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -31,8 +31,10 @@ def test_key_shell_scripts_parse_with_available_bash() -> None:
         "scripts/security/scan_secrets.sh",
     ]
     for script in scripts:
+        script_path = PROJECT_ROOT / script
+        assert script_path.exists(), f"Script not found: {script_path}"
         result = subprocess.run(
-            [bash, "-n", script],
+            [bash, "-n", str(script_path)],
             cwd=PROJECT_ROOT,
             text=True,
             capture_output=True,
@@ -138,11 +140,38 @@ def test_secret_scan_script_blocks_workspace_matches(tmp_path: Path) -> None:
     assert "TEST_SECRET_1234" not in dirty_result.stderr
 
 
+def test_secret_scan_script_blocks_untracked_git_workspace_matches(tmp_path: Path) -> None:
+    bash = shutil.which("bash")
+    git = shutil.which("git")
+    assert bash is not None, "bash must be available for shell contract tests"
+    assert git is not None, "git must be available for shell contract tests"
+
+    script = PROJECT_ROOT / "scripts" / "security" / "scan_secrets.sh"
+    subprocess.run([git, "init"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    (tmp_path / "tracked.txt").write_text("clean tracked file\n", encoding="utf-8")
+    subprocess.run([git, "add", "tracked.txt"], cwd=tmp_path, check=True, capture_output=True, text=True)
+    (tmp_path / "untracked.txt").write_text("token=TEST_SECRET_9999\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [bash, str(script), "workspace"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=_test_env(SENSITIVE_PATTERN="TEST_SECRET_[0-9][0-9][0-9][0-9]"),
+    )
+
+    assert result.returncode == 1
+    assert "TEST_SECRET_9999" not in result.stdout
+    assert "TEST_SECRET_9999" not in result.stderr
+
+
 def test_secret_scan_script_uses_fetch_head_pr_diff_and_configurable_history() -> None:
     script = _read_repo_text("scripts", "security", "scan_secrets.sh")
 
     assert 'git fetch --no-tags origin "$base_ref"' in script
     assert "git diff --unified=0 FETCH_HEAD...HEAD" in script
+    assert "git grep --untracked" in script
     assert '>"$added_lines"' in script
     assert "if ! git diff --unified=0 FETCH_HEAD...HEAD" in script
     assert 'grep -E -q "$SENSITIVE_PATTERN" "$added_lines"' in script
@@ -176,6 +205,8 @@ def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
     workflow = _read_repo_text(".github", "workflows", "opencode.yml")
 
     assert workflow.count("environment: SECRETS") == 3
+    assert "noop:" in workflow
+    assert 'echo "No opencode command in comment; skipping."' in workflow
     assert "id-token: write" not in workflow
 
 

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -185,21 +185,40 @@ def test_secret_scan_script_uses_fetch_head_pr_diff_and_configurable_history() -
     script = _read_repo_text("scripts", "security", "scan_secrets.sh")
 
     assert "require_commands" in script
-    assert "for command in git grep awk mktemp" in script
+    assert "for command in git grep awk mktemp sed" in script
     assert "grep -R" not in script
     assert "grep -r" in script
     assert 'git cat-file -e "${diff_base}^{commit}"' in script
     assert 'git fetch --no-tags --depth=1 origin "$base_ref"' in script
     assert 'diff_base="FETCH_HEAD"' in script
     assert 'git diff --unified=0 "${diff_base}...HEAD"' in script
-    assert "git grep --untracked" in script
+    assert 'git grep --untracked -I -E -l -e "$SENSITIVE_PATTERN"' in script
     assert '>"$added_lines"' in script
     assert 'if ! git diff --unified=0 "${diff_base}...HEAD"' in script
-    assert 'grep -E -q "$SENSITIVE_PATTERN" "$added_lines"' in script
+    assert 'grep -E -q -- "$SENSITIVE_PATTERN" "$added_lines"' in script
     assert "PR diff scan failed" in script
     assert "trap - RETURN" not in script
     assert 'git diff --unified=0 "origin/${base_ref}...HEAD"' not in script
     assert 'SECRET_SCAN_HISTORY_MAX_COUNT:-200' in script
+
+
+def test_secret_scan_script_treats_dash_prefixed_pattern_as_data(tmp_path: Path) -> None:
+    bash = shutil.which("bash")
+    assert bash is not None, "bash must be available for shell contract tests"
+
+    script = PROJECT_ROOT / "scripts" / "security" / "scan_secrets.sh"
+    (tmp_path / "clean.txt").write_text("plain text\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [bash, str(script), "workspace"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=_test_env(SENSITIVE_PATTERN="-not-a-real-secret"),
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_secret_scan_script_valid_pattern_without_match_succeeds(tmp_path: Path) -> None:
@@ -337,6 +356,8 @@ def test_codeql_precheck_runs_advanced_when_default_setup_is_unverified() -> Non
 
     assert 'RUN_ADVANCED="true"' in workflow
     assert 'REASON="advanced_allowed_default_setup_unverified"' in workflow
+    assert 'if STATE="$(jq -r' in workflow
+    assert 'STATE="unknown"' in workflow
     assert "Could not verify CodeQL default setup state: HTTP ${HTTP_CODE}; running advanced scan." in workflow
     assert 'HTTP_CODE="000"' in workflow
     assert 'Unsupported CodeQL default setup state: ${STATE}; running advanced scan.' in workflow

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -194,6 +194,7 @@ def test_secret_scan_script_uses_fetch_head_pr_diff_and_configurable_history() -
     assert 'git diff --unified=0 "${diff_base}...HEAD"' in script
     assert 'git grep --untracked -I -E -l -e "$SENSITIVE_PATTERN"' in script
     assert '>"$added_lines"' in script
+    assert 'if ! added_lines="$(mktemp)"; then' in script
     assert 'if ! git diff --unified=0 "${diff_base}...HEAD"' in script
     assert 'grep -E -q -- "$SENSITIVE_PATTERN" "$added_lines"' in script
     assert "PR diff scan failed" in script
@@ -273,6 +274,9 @@ def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
     assert "curl -fsSL https://opencode.ai/install | bash" not in local_action
     assert "releases/latest" not in local_action
     assert "id-token: write" not in workflow
+    qwen_action = _read_repo_text(".github", "actions", "configure-qwen-opencode", "action.yml")
+    assert "umask 077" in qwen_action
+    assert 'chmod 600 "${HOME}/.config/opencode/opencode.json"' in qwen_action
 
 
 def test_opencode_review_script_extracts_pr_number() -> None:

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import importlib.util
+import os
 import shutil
 import subprocess
-import os
 from pathlib import Path
 
+import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
@@ -17,6 +19,16 @@ def _test_env(**overrides: str) -> dict[str, str]:
 
 def _read_repo_text(*parts: str) -> str:
     return (PROJECT_ROOT.joinpath(*parts)).read_text(encoding="utf-8")
+
+
+def _load_opencode_review_module():
+    script_path = PROJECT_ROOT / "scripts" / "ci" / "opencode_pr_review.py"
+    spec = importlib.util.spec_from_file_location("opencode_pr_review_test", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_key_shell_scripts_parse_with_available_bash() -> None:
@@ -219,17 +231,64 @@ def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
     assert workflow.count("uses: ./.github/actions/configure-qwen-opencode") == 2
     assert workflow.count("uses: ./.github/actions/opencode-github") == 4
     assert workflow.count("qwen-cloud-coding-plan") == 2
+    assert workflow.count("github.event.issue.pull_request") == 3
     assert "anomalyco/opencode/github@" not in workflow
     assert 'default: "true"' in local_action
     assert "GITHUB_TOKEN: ${{ github.token }}" in local_action
-    assert 'git config --global user.name "github-actions[bot]"' in local_action
-    assert 'git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"' in local_action
+    assert "opencode github run" not in local_action
+    assert "python scripts/ci/opencode_pr_review.py" in local_action
+    assert "GH_TOKEN: ${{ github.token }}" in local_action
     assert "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830" in local_action
     assert "actions/cache@v4" not in local_action
     assert "opencode-ai@${{ inputs.opencode_version }}" in local_action
     assert "curl -fsSL https://opencode.ai/install | bash" not in local_action
     assert "releases/latest" not in local_action
     assert "id-token: write" not in workflow
+
+
+def test_opencode_review_script_extracts_pr_number() -> None:
+    module = _load_opencode_review_module()
+
+    assert module.extract_pr_number({"pull_request": {"number": 58}}) == 58
+    assert module.extract_pr_number({"issue": {"number": 59, "pull_request": {"url": "x"}}}) == 59
+    with pytest.raises(ValueError, match="pull request"):
+        module.extract_pr_number({"issue": {"number": 60}})
+
+
+def test_opencode_review_script_truncates_large_diff(tmp_path: Path) -> None:
+    module = _load_opencode_review_module()
+    diff_path = tmp_path / "large.diff"
+    diff_path.write_bytes(b"a" * 120)
+
+    text, truncated = module.truncate_diff(diff_path, limit=80)
+    assert truncated is True
+    data = diff_path.read_bytes()
+    assert data == b"a" * 120
+    assert len(text.encode("utf-8")) <= 80
+    assert "[diff truncated at 80 bytes]" in text
+
+    utf8_path = tmp_path / "utf8.diff"
+    utf8_path.write_text("linha\n" + ("\u00e1" * 100), encoding="utf-8")
+    text, truncated = module.truncate_diff(utf8_path, limit=80)
+    assert truncated is True
+    assert "\ufffd" not in text
+    assert "[diff truncated at 80 bytes]" in text
+
+    source_path = tmp_path / "source.diff"
+    review_path = tmp_path / "review.diff"
+    source_path.write_bytes(b"b" * 120)
+    _, truncated = module.truncate_diff(source_path, output_path=review_path, limit=80)
+    assert truncated is True
+    assert source_path.read_bytes() == b"b" * 120
+    assert b"[diff truncated at 80 bytes]" in review_path.read_bytes()
+
+
+def test_opencode_review_script_adds_lfs_note() -> None:
+    module = _load_opencode_review_module()
+
+    prompt = module.build_prompt("base", "version https://git-lfs.github.com/spec/v1")
+
+    assert "manual review" in prompt
 
 
 def test_codeql_precheck_runs_advanced_when_default_setup_is_unverified() -> None:

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -205,21 +205,23 @@ def test_opencode_secret_jobs_use_environment_without_oidc() -> None:
     workflow = _read_repo_text(".github", "workflows", "opencode.yml")
     local_action = _read_repo_text(".github", "actions", "opencode-github", "action.yml")
 
-    assert "push:" in workflow
+    assert "push:" not in workflow
     assert "pull_request:" in workflow
     assert "opencode-pr-review:" in workflow
-    assert "opencode-push-review:" in workflow
-    assert workflow.count("environment: SECRETS") == 5
+    assert "opencode-push-review:" not in workflow
+    assert workflow.count("environment: SECRETS") == 4
     assert "noop:" in workflow
     assert 'echo "No opencode command in comment; skipping."' in workflow
     assert "Run automatic PR review" in workflow
-    assert "Run automatic push review" in workflow
+    assert "Run automatic push review" not in workflow
     assert "Review this pull request for concrete bugs" in workflow
-    assert "Review the pushed commit range for concrete bugs" in workflow
-    assert workflow.count("uses: ./.github/actions/configure-qwen-opencode") == 3
-    assert workflow.count("uses: ./.github/actions/opencode-github") == 5
-    assert workflow.count("qwen-cloud-coding-plan") == 3
+    assert "Review the pushed commit range for concrete bugs" not in workflow
+    assert workflow.count("uses: ./.github/actions/configure-qwen-opencode") == 2
+    assert workflow.count("uses: ./.github/actions/opencode-github") == 4
+    assert workflow.count("qwen-cloud-coding-plan") == 2
     assert "anomalyco/opencode/github@" not in workflow
+    assert 'default: "true"' in local_action
+    assert "GITHUB_TOKEN: ${{ github.token }}" in local_action
     assert "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830" in local_action
     assert "actions/cache@v4" not in local_action
     assert "opencode-ai@${{ inputs.opencode_version }}" in local_action


### PR DESCRIPTION
## **User description**
## Summary
- Aligns main with the latest dev hardening commits.
- Keeps CodeQL precheck fail-open so the scan still runs when precheck metadata is unavailable.
- Preserves hardened Actions policy updates.

## Validation
- dev branch checks are green for minimal-ci, codeql-security-scan, Secret Scan, and dependency submission.

## Notes
- No build artifacts are included in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened GitHub Actions, secret scans, and packaged runtime to prevent data leaks and tighten security on `main` and `dev`. Adds a shared secret-scan script, vendored `opencode` actions, preserves seeded runtime files, and records toolchain versions in build metadata (shown in About).

- **Refactors**
  - CI: CodeQL precheck stays fail-open with short HTTP timeouts and `security-events: read`; minimal triggers across `.github/workflows/*.yml`; checkout with `persist-credentials: false`; diffs use env SHAs.
  - Secrets: centralized `scripts/security/scan_secrets.sh`; workspace/PR-diff scans are blocking; history scan is advisory via `schedule`/`workflow_dispatch`; uses `FETCH_HEAD`; no secret echo; `.gitleaks.toml` allowlists only detect-secrets hash metadata; `.secrets.baseline` normalized.
  - OpenCode: vendored `configure-qwen-opencode` and `opencode-github`; runs only on authorized non‑fork `pull_request` or approved comments; pinned `actions/cache` and `opencode-ai`; no `id-token`; `environment: SECRETS`; stricter noop guard and event-scoped concurrency; reviews run via `scripts/ci/opencode_pr_review.py` with truncated diffs and LFS pointer detection.
  - Releases: Debian report filters assets by backend/package and skips `pyoxidizer` AppImage; Windows smoke runs in an isolated temp user env with a timeout and forced kill, avoids local data contamination, and falls back to .NET SHA256 when `Get-FileHash` is unavailable.
  - Runtime/metadata: launchers detect PyInstaller/Nuitka/`pyoxidizer` and `.dist` layouts, resolve from the executable dir, block seeding from parent `data/ssas.db`, and preserve already‑seeded runtime files; new `dev_env/build/write_build_info.py` records git and C/C++/Rust toolchains; GUI About shows these versions.
  - Pyoxidizer build: Debian scripts use a safe `mktemp` backup for `config/build_info.json` and stricter `APP_VERSION` checks to avoid corrupting build metadata.

- **Dependencies**
  - Bumped `black` to `>=26.3.1` to address `GHSA-3936-cmfr-pm3m`.
  - Removed `upx4py`; use system `upx`. Normalized environment markers in `requirements*.txt`.

<sup>Written for commit 0b35364e8c7a603e278fd6776d19bd696a786463. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Harden release and CI checks, and fix packaged app runtime detection**

### What Changed
- Release reports now include only the expected Debian assets for the selected backend and package type, so stale files from older builds are left out.
- Packaged CLI and GUI launchers now recognize Nuitka-style builds and avoid loading app data from the build folder, preventing the wrong database from being copied into runtime.
- The Windows release smoke test now runs in an isolated temporary user environment, waits with a timeout, and fails if local user data leaks into the output.
- Secret scanning now uses a shared script, blocks matches in workspace and PR diffs, and keeps history checks advisory on scheduled runs.
- CodeQL and other GitHub Actions workflows now use tighter permissions and safer checkout settings; the CodeQL precheck now keeps scanning when default-setup status cannot be verified.
- UPX is treated as a system tool instead of a Python dependency, and Windows build docs and requirements were updated to match.

### Impact
`✅ Fewer stale release assets`
`✅ Lower risk of shipping the wrong database`
`✅ Fewer false positives in CI security scans`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=P2fjXAiMPBEdliE8SaespAFpybDBTptqqMZ2wRzE--U&org=mauriciomenon)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved secret-scanning workflows and a new configurable secret-scan script for workspace/PR/history modes.
  * Better build metadata reporting surfaced in About dialogs (includes toolchain info when present).

* **Bug Fixes**
  * Windows build flow: optional UPX compression now uses system binary and avoids false warnings.
  * Launcher runtimes: stronger runtime isolation to avoid leaking or contaminating user data.

* **Chores**
  * CI/workflow hardening and updated tooling pins.
  * Expanded test coverage and updated documentation/operational status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->