### PR TITLE
Sync docs and required CI after PR58

### DIFF
--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -3,18 +3,8 @@ name: minimal-ci
 on:
   push:
     branches: [main, dev]
-    paths:
-      - "**/*.py"
-      - "pyproject.toml"
-      - "requirements*.txt"
-      - ".github/workflows/*.yml"
   pull_request:
     branches: [main, dev]
-    paths:
-      - "**/*.py"
-      - "pyproject.toml"
-      - "requirements*.txt"
-      - ".github/workflows/*.yml"
 
 permissions:
   contents: read
@@ -41,28 +31,8 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.13"
-
-      - name: Setup uv
-        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
-
-      - name: Install Qt runtime libraries
-        run: |
-          set -euo pipefail
-          sudo apt-get install -y libegl1 || {
-            sudo apt-get update
-            sudo apt-get install -y libegl1
-          }
-
-      - name: Sync dev dependencies
-        run: |
-          set -euo pipefail
-          uv sync --extra dev
-
-      - name: Detect changed Python files
+      - name: Detect quality gate scope
+        id: changed-scope
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -76,24 +46,62 @@ jobs:
           else
             BASE_SHA="${BEFORE_SHA}"
           fi
-          if [ "$BASE_SHA" = "$ZERO_SHA" ]; then
-            git ls-files "*.py" > .changed_python_files
+          if [ -z "${BASE_SHA}" ] || [ "$BASE_SHA" = "$ZERO_SHA" ]; then
+            git ls-files > .changed_quality_scope
           else
-            git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" -- "*.py" \
-              | while IFS= read -r -d '' file_path; do
-                  if [ -f "$file_path" ]; then
-                    printf '%s\n' "$file_path"
-                  fi
-                done > .changed_python_files
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" > .changed_quality_scope
           fi
-          if [ ! -s .changed_python_files ]; then
-            echo "No changed Python files detected for scoped static checks."
+          : > .changed_python_files
+          while IFS= read -r file_path; do
+            case "$file_path" in
+              *.py)
+                if [ -f "$file_path" ]; then
+                  printf '%s\n' "$file_path" >> .changed_python_files
+                fi
+                ;;
+            esac
+          done < .changed_quality_scope
+          if grep -Eq '(^|/)[^/]+\.py$|^pyproject\.toml$|^requirements[^/]*\.txt$|^uv\.lock$|^\.github/workflows/[^/]+\.ya?ml$' .changed_quality_scope; then
+            echo "run_python=true" >> "$GITHUB_OUTPUT"
+            echo "Python or CI config changes detected."
+            if [ -s .changed_python_files ]; then
+              echo "Changed Python files:"
+              cat .changed_python_files
+            else
+              echo "No changed Python files detected for scoped static checks."
+            fi
           else
-            echo "Changed Python files:"
-            cat .changed_python_files
+            echo "run_python=false" >> "$GITHUB_OUTPUT"
+            echo "No Python or CI config changes detected; required status will pass without expensive gates."
           fi
 
+      - name: Setup Python
+        if: steps.changed-scope.outputs.run_python == 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13"
+
+      - name: Setup uv
+        if: steps.changed-scope.outputs.run_python == 'true'
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
+
+      - name: Install Qt runtime libraries
+        if: steps.changed-scope.outputs.run_python == 'true'
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y libegl1 || {
+            sudo apt-get update
+            sudo apt-get install -y libegl1
+          }
+
+      - name: Sync dev dependencies
+        if: steps.changed-scope.outputs.run_python == 'true'
+        run: |
+          set -euo pipefail
+          uv sync --extra dev
+
       - name: Py compile changed Python paths
+        if: steps.changed-scope.outputs.run_python == 'true'
         run: |
           set -euo pipefail
           uv run --python 3.13 python - <<'PY'
@@ -111,6 +119,7 @@ jobs:
           PY
 
       - name: Ruff (changed files)
+        if: steps.changed-scope.outputs.run_python == 'true'
         run: |
           set -euo pipefail
           mapfile -t files < .changed_python_files
@@ -121,6 +130,7 @@ jobs:
           fi
 
       - name: Ty (changed files)
+        if: steps.changed-scope.outputs.run_python == 'true'
         run: |
           set -euo pipefail
           mapfile -t files < .changed_python_files
@@ -131,6 +141,7 @@ jobs:
           fi
 
       - name: Pytest suite
+        if: steps.changed-scope.outputs.run_python == 'true'
         env:
           QT_QPA_PLATFORM: offscreen
         run: |

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -61,7 +61,7 @@ jobs:
                 ;;
             esac
           done < .changed_quality_scope
-          if grep -Eq '(^|/)[^/]+\.py$|^pyproject\.toml$|^requirements[^/]*\.txt$|^uv\.lock$|^\.github/workflows/[^/]+\.ya?ml$' .changed_quality_scope; then
+          if grep -Eq '(^|/)[^/]+\.py$|^pyproject\.toml$|^requirements[^/]*\.txt$|^uv\.lock$|^\.github/workflows/[^/]+\.ya?ml$|^scripts/|^dev_env/build/' .changed_quality_scope; then
             echo "run_python=true" >> "$GITHUB_OUTPUT"
             echo "Python or CI config changes detected."
             if [ -s .changed_python_files ]; then

--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -1,24 +1,26 @@
 # ROUND_STATUS
 
-## CURRENT TRUTH 2026-05-01 20h56
+## CURRENT TRUTH 2026-05-04 01h14
 
-- Branch alvo: `dev`.
-- HEAD validado: `55e2c4e2685099d672e05897f4631ca1af6b0175 2026-05-01 20:55:47 -0300 STABILITY_PATCH: deduplicate Debian target normalization`.
-- PR #56: merged.
-- `dev` contem correcoes de release v4.37 que ainda precisam chegar ao `main` antes do rebuild final.
-- Artefatos v4.37 anteriores a este HEAD estao stale e nao devem ser usados para publicacao final.
+- Branch alvo operacional: `dev` e `main` sincronizados.
+- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
+- PR #58: merged.
+- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #58.
+- `main`, `dev`, `origin/main` e `origin/dev` apontam para o mesmo HEAD.
+- Artefatos v4.37 anteriores ao HEAD `8298036fff754b246bd2cdd3edc1db969b35a449` seguem stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Windows AMD64: `dev_env/build/release_windows.ps1`.
   - Debian AMD64: `dev_env/build/release_debian.sh`.
-- Dry-run validado neste HEAD:
-  - Windows: `release_windows.ps1 -Backend all -DryRun -Yes -SkipBuild -SkipPackage -SkipInstaller`.
-  - Debian WSL: `release_debian.sh --backend all --package all --dry-run -y`.
+  - Orquestrador local Windows+WSL: `dev_env/build/release_local.ps1`.
+- Checks GitHub do merge PR #58:
+  - Pass: `minimal-ci`, `Secret Scan`, `codeql-security-scan`, `opencode-pr-review`, `semgrep-cloud-platform/scan`, `security/snyk`, `GitGuardian`, `Socket`, `CodeFactor`, `DeepScan`, `CodeQL`.
+  - Externos/advisory: `code/snyk (mauriciomenon)` falhou por limite `Code test limit reached`; `DeepSource: Python` falhou no dashboard externo.
 - Protecao de codigo:
-  - Nuitka e o backend preferencial para release protegido.
+  - Nuitka continua backend preferencial para release protegido.
   - PyInstaller tem protecao parcial.
   - PyOxidizer so e aceitavel como protegido quando o pacote nao expuser `.py`/`.pyc` do app.
-- Proximo passo operacional: sincronizar `main`, rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e so entao atualizar release v4.37.
+- Proximo passo operacional: rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e atualizar release v4.37 somente com pacotes novos.
 
 ## 2026-04-30T14:51:45-03:00 PR56 stability slice
 

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -1,24 +1,26 @@
 # AGENTS Handoff For Next Cycle
 
-## CURRENT TRUTH 2026-05-01 20h56
+## CURRENT TRUTH 2026-05-04 01h14
 
-- Branch alvo: `dev`.
-- HEAD validado: `55e2c4e2685099d672e05897f4631ca1af6b0175 2026-05-01 20:55:47 -0300 STABILITY_PATCH: deduplicate Debian target normalization`.
-- PR #56: merged.
-- `dev` contem correcoes de release v4.37 que ainda precisam chegar ao `main` antes do rebuild final.
-- Artefatos v4.37 anteriores a este HEAD estao stale e nao devem ser usados para publicacao final.
+- Branch alvo operacional: `dev` e `main` sincronizados.
+- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
+- PR #58: merged.
+- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #58.
+- `main`, `dev`, `origin/main` e `origin/dev` apontam para o mesmo HEAD.
+- Artefatos v4.37 anteriores ao HEAD `8298036fff754b246bd2cdd3edc1db969b35a449` seguem stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Windows AMD64: `dev_env/build/release_windows.ps1`.
   - Debian AMD64: `dev_env/build/release_debian.sh`.
-- Dry-run validado neste HEAD:
-  - Windows: `release_windows.ps1 -Backend all -DryRun -Yes -SkipBuild -SkipPackage -SkipInstaller`.
-  - Debian WSL: `release_debian.sh --backend all --package all --dry-run -y`.
+  - Orquestrador local Windows+WSL: `dev_env/build/release_local.ps1`.
+- Checks GitHub do merge PR #58:
+  - Pass: `minimal-ci`, `Secret Scan`, `codeql-security-scan`, `opencode-pr-review`, `semgrep-cloud-platform/scan`, `security/snyk`, `GitGuardian`, `Socket`, `CodeFactor`, `DeepScan`, `CodeQL`.
+  - Externos/advisory: `code/snyk (mauriciomenon)` falhou por limite `Code test limit reached`; `DeepSource: Python` falhou no dashboard externo.
 - Protecao de codigo:
-  - Nuitka e o backend preferencial para release protegido.
+  - Nuitka continua backend preferencial para release protegido.
   - PyInstaller tem protecao parcial.
   - PyOxidizer so e aceitavel como protegido quando o pacote nao expuser `.py`/`.pyc` do app.
-- Proximo passo operacional: sincronizar `main`, rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e so entao atualizar release v4.37.
+- Proximo passo operacional: rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e atualizar release v4.37 somente com pacotes novos.
 
 Este handoff esta pronto para reutilizacao no proximo ciclo.
 

--- a/docs/BUILD_3X3_RUNBOOK.md
+++ b/docs/BUILD_3X3_RUNBOOK.md
@@ -1,9 +1,9 @@
 # Build 3x3 Runbook (Windows Linux macOS x PyInstaller Nuitka PyOxidizer)
 
-## CURRENT TRUTH 2026-05-02 00h01
+## CURRENT TRUTH 2026-05-04 01h14
 
 - Fonte operacional completa: `docs/GUIA_DISTRIBUICAO.md`, bloco `CURRENT TRUTH`.
-- PR atual: #57, aberto em draft, `dev` -> `main`.
+- PR #58: merged; `main`, `dev`, `origin/main` e `origin/dev` devem seguir sincronizados apos o PR de DOC_SYNC/CI.
 - Este runbook detalha execucao 3x3; nao deve duplicar a matriz completa de release.
 
 ## Objetivo

--- a/docs/BUILD_TOOLING_LESSONS_LEARNED.md
+++ b/docs/BUILD_TOOLING_LESSONS_LEARNED.md
@@ -1,9 +1,9 @@
 # Build Tooling Lessons Learned (PyInstaller/Nuitka/PyOxidizer)
 
-## CURRENT TRUTH 2026-05-02 00h01
+## CURRENT TRUTH 2026-05-04 01h14
 
 - Fonte operacional completa: `docs/GUIA_DISTRIBUICAO.md`, bloco `CURRENT TRUTH`.
-- PR atual: #57, aberto em draft, `dev` -> `main`.
+- PR #58: merged; `main`, `dev`, `origin/main` e `origin/dev` devem seguir sincronizados apos o PR de DOC_SYNC/CI.
 - Este documento registra aprendizados; nao deve duplicar a matriz completa de release.
 
 ## HISTORICAL SNAPSHOT (4.37 local / v4.36 published)
@@ -157,4 +157,3 @@
   - seed inicial nao deve sobrescrever customizacao local do usuario.
 
 <!-- DOC_SYNC_MAC: 2026-03-29 host-agnostic paths, continue from repo root on macOS -->
-

--- a/docs/GUIA_DISTRIBUICAO.md
+++ b/docs/GUIA_DISTRIBUICAO.md
@@ -1,26 +1,23 @@
 # Guia de Distribuicao - SSA Consulta Rapida
 
-## CURRENT TRUTH 2026-05-02 00h01
+## CURRENT TRUTH 2026-05-04 01h14
 
 - Branch fonte: `dev`.
-- Branch destino do PR: `main`.
-- HEAD funcional validado: `df0345caea9ac3050c87d2172eb75817b8fc3689 2026-05-02T00:01:26-03:00 STABILITY_PATCH: cover release local backend forwarding`.
-- PR #57: aberto em draft, `dev` -> `main`.
-- `dev` contem correcoes de release v4.37 que ainda precisam chegar ao `main` antes do rebuild final.
-- Artefatos v4.37 anteriores a este HEAD funcional estao stale e nao devem ser usados para publicacao final.
+- Branch destino: `main`.
+- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
+- PR #58: merged; `main`, `dev`, `origin/main` e `origin/dev` estao no mesmo HEAD.
+- Artefatos v4.37 anteriores a este HEAD estao stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
+  - Local Windows + WSL: `dev_env/build/release_local.ps1`.
   - Windows AMD64: `dev_env/build/release_windows.ps1`.
   - Debian AMD64: `dev_env/build/release_debian.sh`.
-- Dry-run validado neste HEAD:
-  - Local Windows + Windows AMD64: `release_local.ps1 -Backend "pyinstaller,nuitka" -SkipDebian -DryRun -Yes`.
-  - Windows: `release_windows.ps1 -Backend all -DryRun -Yes -SkipBuild -SkipPackage -SkipInstaller`.
-  - Debian WSL: `release_debian.sh --backend all --package all --dry-run -y`.
+- Dry-run previamente validado para os orquestradores; depois do merge PR #58, o proximo ciclo deve rodar dry-run novamente antes de build real.
 - Protecao de codigo:
   - Nuitka e o backend preferencial para release protegido.
   - PyInstaller tem protecao parcial.
   - PyOxidizer so e aceitavel como protegido quando o pacote nao expuser `.py`/`.pyc` do app.
-- Proximo passo operacional: sincronizar `main`, rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e so entao atualizar release v4.37.
+- Proximo passo operacional: rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar conteudo/metadata/smoke e so entao atualizar release v4.37.
 
 ## HISTORICAL SNAPSHOT (4.37 local automation)
 

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -1,24 +1,26 @@
 # Next Chat Migration Guide
 
-## CURRENT TRUTH 2026-05-01 20h56
+## CURRENT TRUTH 2026-05-04 01h14
 
-- Branch alvo: `dev`.
-- HEAD validado: `55e2c4e2685099d672e05897f4631ca1af6b0175 2026-05-01 20:55:47 -0300 STABILITY_PATCH: deduplicate Debian target normalization`.
-- PR #56: merged.
-- `dev` contem correcoes de release v4.37 que ainda precisam chegar ao `main` antes do rebuild final.
-- Artefatos v4.37 anteriores a este HEAD estao stale e nao devem ser usados para publicacao final.
+- Branch alvo operacional: `dev` e `main` sincronizados.
+- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
+- PR #58: merged.
+- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #58.
+- `main`, `dev`, `origin/main` e `origin/dev` apontam para o mesmo HEAD.
+- Artefatos v4.37 anteriores ao HEAD `8298036fff754b246bd2cdd3edc1db969b35a449` seguem stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Windows AMD64: `dev_env/build/release_windows.ps1`.
   - Debian AMD64: `dev_env/build/release_debian.sh`.
-- Dry-run validado neste HEAD:
-  - Windows: `release_windows.ps1 -Backend all -DryRun -Yes -SkipBuild -SkipPackage -SkipInstaller`.
-  - Debian WSL: `release_debian.sh --backend all --package all --dry-run -y`.
+  - Orquestrador local Windows+WSL: `dev_env/build/release_local.ps1`.
+- Checks GitHub do merge PR #58:
+  - Pass: `minimal-ci`, `Secret Scan`, `codeql-security-scan`, `opencode-pr-review`, `semgrep-cloud-platform/scan`, `security/snyk`, `GitGuardian`, `Socket`, `CodeFactor`, `DeepScan`, `CodeQL`.
+  - Externos/advisory: `code/snyk (mauriciomenon)` falhou por limite `Code test limit reached`; `DeepSource: Python` falhou no dashboard externo.
 - Protecao de codigo:
-  - Nuitka e o backend preferencial para release protegido.
+  - Nuitka continua backend preferencial para release protegido.
   - PyInstaller tem protecao parcial.
   - PyOxidizer so e aceitavel como protegido quando o pacote nao expuser `.py`/`.pyc` do app.
-- Proximo passo operacional: sincronizar `main`, rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e so entao atualizar release v4.37.
+- Proximo passo operacional: rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e atualizar release v4.37 somente com pacotes novos.
 
 Use este arquivo para migrar contexto para um novo chat sem perder qualidade de execucao.
 

--- a/docs/PENDING_ACTION_MATRIX.md
+++ b/docs/PENDING_ACTION_MATRIX.md
@@ -1,24 +1,26 @@
 # Pending Action Matrix
 
-## CURRENT TRUTH 2026-05-01 20h56
+## CURRENT TRUTH 2026-05-04 01h14
 
-- Branch alvo: `dev`.
-- HEAD validado: `55e2c4e2685099d672e05897f4631ca1af6b0175 2026-05-01 20:55:47 -0300 STABILITY_PATCH: deduplicate Debian target normalization`.
-- PR #56: merged.
-- `dev` contem correcoes de release v4.37 que ainda precisam chegar ao `main` antes do rebuild final.
-- Artefatos v4.37 anteriores a este HEAD estao stale e nao devem ser usados para publicacao final.
+- Branch alvo operacional: `dev` e `main` sincronizados.
+- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
+- PR #58: merged.
+- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #58.
+- `main`, `dev`, `origin/main` e `origin/dev` apontam para o mesmo HEAD.
+- Artefatos v4.37 anteriores ao HEAD `8298036fff754b246bd2cdd3edc1db969b35a449` seguem stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Windows AMD64: `dev_env/build/release_windows.ps1`.
   - Debian AMD64: `dev_env/build/release_debian.sh`.
-- Dry-run validado neste HEAD:
-  - Windows: `release_windows.ps1 -Backend all -DryRun -Yes -SkipBuild -SkipPackage -SkipInstaller`.
-  - Debian WSL: `release_debian.sh --backend all --package all --dry-run -y`.
+  - Orquestrador local Windows+WSL: `dev_env/build/release_local.ps1`.
+- Checks GitHub do merge PR #58:
+  - Pass: `minimal-ci`, `Secret Scan`, `codeql-security-scan`, `opencode-pr-review`, `semgrep-cloud-platform/scan`, `security/snyk`, `GitGuardian`, `Socket`, `CodeFactor`, `DeepScan`, `CodeQL`.
+  - Externos/advisory: `code/snyk (mauriciomenon)` falhou por limite `Code test limit reached`; `DeepSource: Python` falhou no dashboard externo.
 - Protecao de codigo:
-  - Nuitka e o backend preferencial para release protegido.
+  - Nuitka continua backend preferencial para release protegido.
   - PyInstaller tem protecao parcial.
   - PyOxidizer so e aceitavel como protegido quando o pacote nao expuser `.py`/`.pyc` do app.
-- Proximo passo operacional: sincronizar `main`, rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e so entao atualizar release v4.37.
+- Proximo passo operacional: rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e atualizar release v4.37 somente com pacotes novos.
 
 Fonte: docs/RECOVERY_BACKLOG.md
 Total itens: 108
@@ -1165,4 +1167,3 @@ Legenda:
 - Corrigidos comentarios recentes de review (scripts/tests/docs) e removidos emojis em arquivos versionados.
 
 <!-- DOC_SYNC_MAC: 2026-03-29 host-agnostic paths, continue from repo root on macOS -->
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,11 @@
 - Versao de referencia: `4.37`.
 - Esta pagina e a entrada curta da pasta `docs/`.
 - Navegacao oficial: `docs/INDEX.md`.
+- Current truth operacional 2026-05-04 01h14:
+  - `main`, `dev`, `origin/main` e `origin/dev` sincronizados em `8298036fff754b246bd2cdd3edc1db969b35a449`
+  - PR #58 merged
+  - artefatos v4.37 anteriores a este HEAD seguem stale
+  - proximo passo: rebuild Windows AMD64 e Debian AMD64 antes de atualizar release v4.37
 - Current truth sincronizado com commits anteriores desta frente:
   - `tests/test_gui_filter_logic.py` deixou de depender de globais compartilhados entre testes para aposentadoria/limpeza de workers
   - o harness agora tira snapshot e restaura o estado global de lifecycle em `setup_method`/`teardown_method`

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -1,24 +1,26 @@
 # Recovery Backlog
 
-## CURRENT TRUTH 2026-05-01 20h56
+## CURRENT TRUTH 2026-05-04 01h14
 
-- Branch alvo: `dev`.
-- HEAD validado: `55e2c4e2685099d672e05897f4631ca1af6b0175 2026-05-01 20:55:47 -0300 STABILITY_PATCH: deduplicate Debian target normalization`.
-- PR #56: merged.
-- `dev` contem correcoes de release v4.37 que ainda precisam chegar ao `main` antes do rebuild final.
-- Artefatos v4.37 anteriores a este HEAD estao stale e nao devem ser usados para publicacao final.
+- Branch alvo operacional: `dev` e `main` sincronizados.
+- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
+- PR #58: merged.
+- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #58.
+- `main`, `dev`, `origin/main` e `origin/dev` apontam para o mesmo HEAD.
+- Artefatos v4.37 anteriores ao HEAD `8298036fff754b246bd2cdd3edc1db969b35a449` seguem stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Windows AMD64: `dev_env/build/release_windows.ps1`.
   - Debian AMD64: `dev_env/build/release_debian.sh`.
-- Dry-run validado neste HEAD:
-  - Windows: `release_windows.ps1 -Backend all -DryRun -Yes -SkipBuild -SkipPackage -SkipInstaller`.
-  - Debian WSL: `release_debian.sh --backend all --package all --dry-run -y`.
+  - Orquestrador local Windows+WSL: `dev_env/build/release_local.ps1`.
+- Checks GitHub do merge PR #58:
+  - Pass: `minimal-ci`, `Secret Scan`, `codeql-security-scan`, `opencode-pr-review`, `semgrep-cloud-platform/scan`, `security/snyk`, `GitGuardian`, `Socket`, `CodeFactor`, `DeepScan`, `CodeQL`.
+  - Externos/advisory: `code/snyk (mauriciomenon)` falhou por limite `Code test limit reached`; `DeepSource: Python` falhou no dashboard externo.
 - Protecao de codigo:
-  - Nuitka e o backend preferencial para release protegido.
+  - Nuitka continua backend preferencial para release protegido.
   - PyInstaller tem protecao parcial.
   - PyOxidizer so e aceitavel como protegido quando o pacote nao expuser `.py`/`.pyc` do app.
-- Proximo passo operacional: sincronizar `main`, rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e so entao atualizar release v4.37.
+- Proximo passo operacional: rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e atualizar release v4.37 somente com pacotes novos.
 
 Este arquivo registra hardening e limpeza pos-merge da branch de recovery.
 O escopo fica dividido por prioridade para manter a entrega segura e incremental.

--- a/docs/SOLUCOES_AMBIENTE_BUILD.md
+++ b/docs/SOLUCOES_AMBIENTE_BUILD.md
@@ -1,10 +1,11 @@
 # Solucoes para Problemas de Ambiente - Build Systems
 
-## CURRENT TRUTH 2026-05-02 00h01
+## CURRENT TRUTH 2026-05-04 01h14
 
 - Fonte operacional completa: `docs/GUIA_DISTRIBUICAO.md`, bloco `CURRENT TRUTH`.
-- PR atual: #57, aberto em draft, `dev` -> `main`.
+- PR #58: merged; `main`, `dev`, `origin/main` e `origin/dev` estao sincronizados em `8298036fff754b246bd2cdd3edc1db969b35a449`.
 - Este documento registra solucoes de ambiente; nao deve duplicar a matriz completa de release.
+- Proximo passo operacional: rebuildar artefatos v4.37 no Windows AMD64 e Debian AMD64 a partir do HEAD sincronizado.
 
 ## HISTORICAL SNAPSHOT 2025-11-14
 

--- a/launchers/README_BUILD_AUTOMATIZADO.md
+++ b/launchers/README_BUILD_AUTOMATIZADO.md
@@ -1,26 +1,26 @@
 # README – PIPELINE DE BUILD AUTOMATIZADO (RASCUNHO)
 
-## CURRENT TRUTH 2026-05-01 20h56
+## CURRENT TRUTH 2026-05-04 01h14
 
-- Branch alvo: `dev`.
-- HEAD validado: `55e2c4e2685099d672e05897f4631ca1af6b0175 2026-05-01 20:55:47 -0300 STABILITY_PATCH: deduplicate Debian target normalization`.
-- PR #56: merged.
-- `dev` contem correcoes de release v4.37 que ainda precisam chegar ao `main` antes do rebuild final.
-- Artefatos v4.37 anteriores a este HEAD estao stale e nao devem ser usados para publicacao final.
+- Branch alvo operacional: `dev` e `main` sincronizados.
+- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
+- PR #58: merged.
+- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #58.
+- `main`, `dev`, `origin/main` e `origin/dev` apontam para o mesmo HEAD.
+- Artefatos v4.37 anteriores ao HEAD `8298036fff754b246bd2cdd3edc1db969b35a449` seguem stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Windows AMD64: `dev_env/build/release_windows.ps1`.
   - Debian AMD64: `dev_env/build/release_debian.sh`.
-- Dry-run validado neste HEAD:
-  - Windows: `release_windows.ps1 -Backend all -DryRun -Yes -SkipBuild -SkipPackage -SkipInstaller`.
-  - Debian WSL: `release_debian.sh --backend all --package all --dry-run -y`.
+  - Orquestrador local Windows+WSL: `dev_env/build/release_local.ps1`.
+- Checks GitHub do merge PR #58:
+  - Pass: `minimal-ci`, `Secret Scan`, `codeql-security-scan`, `opencode-pr-review`, `semgrep-cloud-platform/scan`, `security/snyk`, `GitGuardian`, `Socket`, `CodeFactor`, `DeepScan`, `CodeQL`.
+  - Externos/advisory: `code/snyk (mauriciomenon)` falhou por limite `Code test limit reached`; `DeepSource: Python` falhou no dashboard externo.
 - Protecao de codigo:
-  - Nuitka e o backend preferencial para release protegido.
+  - Nuitka continua backend preferencial para release protegido.
   - PyInstaller tem protecao parcial.
   - PyOxidizer so e aceitavel como protegido quando o pacote nao expuser `.py`/`.pyc` do app.
-- Proximo passo operacional: sincronizar `main`, rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e so entao atualizar release v4.37.
-
-Este documento descreve como estruturar uma pipeline de build/test/validacao minima para o projeto visando reprodutibilidade e deteccao precoce de problemas.
+- Proximo passo operacional: rebuildar Windows AMD64 e Debian AMD64 a partir deste HEAD, validar artefatos e atualizar release v4.37 somente com pacotes novos.
 
 ## 1. Objetivos
 | Objetivo | Beneficio |

--- a/tests/test_release_docs_contract.py
+++ b/tests/test_release_docs_contract.py
@@ -20,7 +20,8 @@ def test_solucoes_ambiente_doc_marks_legacy_body_historical() -> None:
 
     assert text.count("## CURRENT TRUTH") == 1
     assert "Fonte operacional completa: `docs/GUIA_DISTRIBUICAO.md`" in text
-    assert "PR atual: #57" in text
+    assert "PR #58: merged" in text
+    assert "PR atual: #57" not in text
     assert "- Branch alvo: `dev`." not in text
     assert "## HISTORICAL SNAPSHOT 2025-11-14" in text
     assert "**Data**: 2025-11-14" not in text
@@ -37,10 +38,11 @@ def test_release_docs_sync_contract() -> None:
     source_text = read_repo_text("docs", "GUIA_DISTRIBUICAO.md")
     source_truth = source_text.split("## HISTORICAL SNAPSHOT", 1)[0]
 
-    assert "PR #57: aberto em draft" in source_truth
+    assert "PR #58: merged" in source_truth
+    assert "PR #57: aberto em draft" not in source_truth
     assert "PR #56: merged" not in source_truth
-    assert "df0345caea9ac3050c87d2172eb75817b8fc3689" in source_truth
-    assert 'release_local.ps1 -Backend "pyinstaller,nuitka"' in source_truth
+    assert "df0345caea9ac3050c87d2172eb75817b8fc3689" not in source_truth
+    assert "8298036fff754b246bd2cdd3edc1db969b35a449" in source_truth
 
     for doc_name in [
         "SOLUCOES_AMBIENTE_BUILD.md",
@@ -49,5 +51,6 @@ def test_release_docs_sync_contract() -> None:
     ]:
         current_truth = read_repo_text("docs", doc_name).split("## HISTORICAL SNAPSHOT", 1)[0]
         assert "Fonte operacional completa: `docs/GUIA_DISTRIBUICAO.md`" in current_truth
-        assert "PR atual: #57" in current_truth
+        assert "PR #58: merged" in current_truth
+        assert "PR atual: #57" not in current_truth
         assert "df0345caea9ac3050c87d2172eb75817b8fc3689" not in current_truth

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -93,8 +93,10 @@ def test_ci_quality_gates_does_not_expand_arg_string_unquoted() -> None:
 def test_minimal_ci_runs_for_any_workflow_change() -> None:
     workflow = _read_repo_text(".github", "workflows", "minimal-ci.yml")
 
-    assert workflow.count('".github/workflows/*.yml"') == 2
-    assert '".github/workflows/minimal-ci.yml"' not in workflow
+    assert "paths:" not in workflow
+    assert "Detect quality gate scope" in workflow
+    assert "run_python=false" in workflow
+    assert "required status will pass without expensive gates" in workflow
 
 
 def test_secret_scan_uses_quoted_env_for_pr_base_ref() -> None:

--- a/tests/test_shell_ci_contracts.py
+++ b/tests/test_shell_ci_contracts.py
@@ -97,6 +97,7 @@ def test_minimal_ci_runs_for_any_workflow_change() -> None:
     assert "Detect quality gate scope" in workflow
     assert "run_python=false" in workflow
     assert "required status will pass without expensive gates" in workflow
+    assert "|^scripts/|^dev_env/build/" in workflow
 
 
 def test_secret_scan_uses_quoted_env_for_pr_base_ref() -> None:


### PR DESCRIPTION
## **User description**
## Objetivo

Sincronizar main com dev apos PR #58 e DOC_SYNC, sem bypass de branch protection.

## Conteudo

- DOC_SYNC dos Markdown vivos para o HEAD pos-PR #58.
- Ajuste de minimal-ci para criar o status obrigatorio quality-gates tambem em docs-only.
- Otimizacao do job: docs-only passa sem setup Python/Qt/uv/testes pesados; mudancas Python/config continuam rodando gates.

## Validacao local

- actionlint .github/workflows/minimal-ci.yml
- git diff --check
- uv run --python 3.13 python -m py_compile scripts/ci/opencode_pr_review.py dev_env/build/release_platform_report.py dev_env/build/write_build_info.py tests/test_shell_ci_contracts.py
- uv run --python 3.13 ruff check tests/test_shell_ci_contracts.py scripts/ci/opencode_pr_review.py dev_env/build/release_platform_report.py dev_env/build/write_build_info.py
- uv run --python 3.13 ty check tests/test_shell_ci_contracts.py scripts/ci/opencode_pr_review.py dev_env/build/release_platform_report.py dev_env/build/write_build_info.py
- uv run --python 3.13 pytest -q tests/test_shell_ci_contracts.py

## Risco

Baixo: altera somente workflow/teste de contrato e docs ja commitados em dev.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs live docs to the post‑PR58 state and updates `minimal-ci` so docs-only changes still report the required `quality-gates` status while skipping heavy Python jobs.

- **Refactors**
  - Added a “Detect quality gate scope” step that sets `run_python=true/false` and runs on any change (removed `paths:` filters).
  - Expanded scope to trigger Python gates on `.py`, `pyproject.toml`, `requirements*.txt`, `uv.lock`, `.github/workflows/*.yml`, and changes under `scripts/` or `dev_env/build/`; otherwise skip Python/Qt/`uv`/lint/tests and only set the required status.
  - Updated tests: `tests/test_shell_ci_contracts.py` asserts no `paths:` block, detector messages, and the `|^scripts/|^dev_env/build/` pattern; `tests/test_release_docs_contract.py` asserts docs reflect “PR #58: merged” and remove stale references.

<sup>Written for commit 5961aff67a283430295f6763972d4ae9c971384e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Keep the required CI status for docs-only changes while skipping heavy checks**

### What Changed
- `minimal-ci` now runs for any change, including workflow edits, instead of only selected file paths
- Docs-only changes still complete the required `quality-gates` status, but skip Python setup, Qt install, dependency sync, linting, and tests
- When Python or CI config files change, the workflow continues to run the full set of Python checks
- Updated internal docs to match the current merged release state and next rebuild steps

### Impact
`✅ Required CI status for docs-only PRs`
`✅ Fewer slow CI runs on documentation changes`
`✅ Clearer release handoff after PR #58`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=3ViRU_4XHpj20LFYz5P1kG3-PBaidrD8zV8WXgJb4DE&org=mauriciomenon)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized CI/CD workflow to selectively run Python quality checks based on code changes
  * Updated internal operational documentation to reflect current repository synchronization status and merge state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Modified CI workflow to conditionally execute Python-related steps only when Python or CI configuration files are changed, enhancing pipeline efficiency.</li>
<li>Updated multiple documentation files to reflect the latest operational status, HEAD commit, and post-merge state after PR #58.</li>
<li>Adjusted test assertions in CI contract tests to validate the new workflow logic without path-based triggers.</li>
</ul></div>