### PR TITLE
Doc sync after PR59 merge

### DIFF
--- a/ROUND_STATUS.md
+++ b/ROUND_STATUS.md
@@ -3,11 +3,11 @@
 ## CURRENT TRUTH 2026-05-04 01h14
 
 - Branch alvo operacional: `dev` e `main` sincronizados.
-- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
-- PR #58: merged.
-- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #58.
+- Base minima sincronizada: `4705c2e5722c4f3a5266ac02a5d15a1928d5a223 2026-05-04T02:07:12-03:00 Merge PR #59: sync docs and required CI`; usar este commit ou sucessor sincronizado em `main`/`dev`.
+- PR #58 e PR #59: merged.
+- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #59.
 - `main`, `dev`, `origin/main` e `origin/dev` apontam para o mesmo HEAD.
-- Artefatos v4.37 anteriores ao HEAD `8298036fff754b246bd2cdd3edc1db969b35a449` seguem stale e nao devem ser usados para publicacao final.
+- Artefatos v4.37 anteriores a base minima `4705c2e5722c4f3a5266ac02a5d15a1928d5a223` seguem stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Windows AMD64: `dev_env/build/release_windows.ps1`.

--- a/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
+++ b/docs/AGENTS_HANDOFF_NEXT_CYCLE.md
@@ -3,11 +3,11 @@
 ## CURRENT TRUTH 2026-05-04 01h14
 
 - Branch alvo operacional: `dev` e `main` sincronizados.
-- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
-- PR #58: merged.
-- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #58.
+- Base minima sincronizada: `4705c2e5722c4f3a5266ac02a5d15a1928d5a223 2026-05-04T02:07:12-03:00 Merge PR #59: sync docs and required CI`; usar este commit ou sucessor sincronizado em `main`/`dev`.
+- PR #58 e PR #59: merged.
+- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #59.
 - `main`, `dev`, `origin/main` e `origin/dev` apontam para o mesmo HEAD.
-- Artefatos v4.37 anteriores ao HEAD `8298036fff754b246bd2cdd3edc1db969b35a449` seguem stale e nao devem ser usados para publicacao final.
+- Artefatos v4.37 anteriores a base minima `4705c2e5722c4f3a5266ac02a5d15a1928d5a223` seguem stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Windows AMD64: `dev_env/build/release_windows.ps1`.

--- a/docs/BUILD_3X3_RUNBOOK.md
+++ b/docs/BUILD_3X3_RUNBOOK.md
@@ -3,7 +3,7 @@
 ## CURRENT TRUTH 2026-05-04 01h14
 
 - Fonte operacional completa: `docs/GUIA_DISTRIBUICAO.md`, bloco `CURRENT TRUTH`.
-- PR #58: merged; `main`, `dev`, `origin/main` e `origin/dev` devem seguir sincronizados apos o PR de DOC_SYNC/CI.
+- PR #58 e PR #59: merged; usar base minima `4705c2e5722c4f3a5266ac02a5d15a1928d5a223`, ou sucessor sincronizado em `main`/`dev`.
 - Este runbook detalha execucao 3x3; nao deve duplicar a matriz completa de release.
 
 ## Objetivo

--- a/docs/BUILD_TOOLING_LESSONS_LEARNED.md
+++ b/docs/BUILD_TOOLING_LESSONS_LEARNED.md
@@ -3,7 +3,7 @@
 ## CURRENT TRUTH 2026-05-04 01h14
 
 - Fonte operacional completa: `docs/GUIA_DISTRIBUICAO.md`, bloco `CURRENT TRUTH`.
-- PR #58: merged; `main`, `dev`, `origin/main` e `origin/dev` devem seguir sincronizados apos o PR de DOC_SYNC/CI.
+- PR #58 e PR #59: merged; usar base minima `4705c2e5722c4f3a5266ac02a5d15a1928d5a223`, ou sucessor sincronizado em `main`/`dev`.
 - Este documento registra aprendizados; nao deve duplicar a matriz completa de release.
 
 ## HISTORICAL SNAPSHOT (4.37 local / v4.36 published)

--- a/docs/GUIA_DISTRIBUICAO.md
+++ b/docs/GUIA_DISTRIBUICAO.md
@@ -4,9 +4,9 @@
 
 - Branch fonte: `dev`.
 - Branch destino: `main`.
-- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
-- PR #58: merged; `main`, `dev`, `origin/main` e `origin/dev` estao no mesmo HEAD.
-- Artefatos v4.37 anteriores a este HEAD estao stale e nao devem ser usados para publicacao final.
+- Base minima sincronizada: `4705c2e5722c4f3a5266ac02a5d15a1928d5a223 2026-05-04T02:07:12-03:00 Merge PR #59: sync docs and required CI`; usar este commit ou sucessor sincronizado em `main`/`dev`.
+- PR #58 e PR #59: merged; `main`, `dev`, `origin/main` e `origin/dev` devem estar sincronizados antes de qualquer rebuild.
+- Artefatos v4.37 anteriores a base minima `4705c2e5722c4f3a5266ac02a5d15a1928d5a223` estao stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Local Windows + WSL: `dev_env/build/release_local.ps1`.

--- a/docs/NEXT_CHAT_MIGRATION.md
+++ b/docs/NEXT_CHAT_MIGRATION.md
@@ -3,11 +3,11 @@
 ## CURRENT TRUTH 2026-05-04 01h14
 
 - Branch alvo operacional: `dev` e `main` sincronizados.
-- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
-- PR #58: merged.
-- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #58.
+- Base minima sincronizada: `4705c2e5722c4f3a5266ac02a5d15a1928d5a223 2026-05-04T02:07:12-03:00 Merge PR #59: sync docs and required CI`; usar este commit ou sucessor sincronizado em `main`/`dev`.
+- PR #58 e PR #59: merged.
+- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #59.
 - `main`, `dev`, `origin/main` e `origin/dev` apontam para o mesmo HEAD.
-- Artefatos v4.37 anteriores ao HEAD `8298036fff754b246bd2cdd3edc1db969b35a449` seguem stale e nao devem ser usados para publicacao final.
+- Artefatos v4.37 anteriores a base minima `4705c2e5722c4f3a5266ac02a5d15a1928d5a223` seguem stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Windows AMD64: `dev_env/build/release_windows.ps1`.

--- a/docs/PENDING_ACTION_MATRIX.md
+++ b/docs/PENDING_ACTION_MATRIX.md
@@ -3,11 +3,11 @@
 ## CURRENT TRUTH 2026-05-04 01h14
 
 - Branch alvo operacional: `dev` e `main` sincronizados.
-- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
-- PR #58: merged.
-- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #58.
+- Base minima sincronizada: `4705c2e5722c4f3a5266ac02a5d15a1928d5a223 2026-05-04T02:07:12-03:00 Merge PR #59: sync docs and required CI`; usar este commit ou sucessor sincronizado em `main`/`dev`.
+- PR #58 e PR #59: merged.
+- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #59.
 - `main`, `dev`, `origin/main` e `origin/dev` apontam para o mesmo HEAD.
-- Artefatos v4.37 anteriores ao HEAD `8298036fff754b246bd2cdd3edc1db969b35a449` seguem stale e nao devem ser usados para publicacao final.
+- Artefatos v4.37 anteriores a base minima `4705c2e5722c4f3a5266ac02a5d15a1928d5a223` seguem stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Windows AMD64: `dev_env/build/release_windows.ps1`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,8 @@
 - Esta pagina e a entrada curta da pasta `docs/`.
 - Navegacao oficial: `docs/INDEX.md`.
 - Current truth operacional 2026-05-04 01h14:
-  - `main`, `dev`, `origin/main` e `origin/dev` sincronizados em `8298036fff754b246bd2cdd3edc1db969b35a449`
-  - PR #58 merged
+  - `main`, `dev`, `origin/main` e `origin/dev` devem estar sincronizados; base minima `4705c2e5722c4f3a5266ac02a5d15a1928d5a223`
+  - PR #58 e PR #59 merged
   - artefatos v4.37 anteriores a este HEAD seguem stale
   - proximo passo: rebuild Windows AMD64 e Debian AMD64 antes de atualizar release v4.37
 - Current truth sincronizado com commits anteriores desta frente:

--- a/docs/RECOVERY_BACKLOG.md
+++ b/docs/RECOVERY_BACKLOG.md
@@ -3,11 +3,11 @@
 ## CURRENT TRUTH 2026-05-04 01h14
 
 - Branch alvo operacional: `dev` e `main` sincronizados.
-- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
-- PR #58: merged.
-- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #58.
+- Base minima sincronizada: `4705c2e5722c4f3a5266ac02a5d15a1928d5a223 2026-05-04T02:07:12-03:00 Merge PR #59: sync docs and required CI`; usar este commit ou sucessor sincronizado em `main`/`dev`.
+- PR #58 e PR #59: merged.
+- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #59.
 - `main`, `dev`, `origin/main` e `origin/dev` apontam para o mesmo HEAD.
-- Artefatos v4.37 anteriores ao HEAD `8298036fff754b246bd2cdd3edc1db969b35a449` seguem stale e nao devem ser usados para publicacao final.
+- Artefatos v4.37 anteriores a base minima `4705c2e5722c4f3a5266ac02a5d15a1928d5a223` seguem stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Windows AMD64: `dev_env/build/release_windows.ps1`.

--- a/docs/SOLUCOES_AMBIENTE_BUILD.md
+++ b/docs/SOLUCOES_AMBIENTE_BUILD.md
@@ -3,7 +3,7 @@
 ## CURRENT TRUTH 2026-05-04 01h14
 
 - Fonte operacional completa: `docs/GUIA_DISTRIBUICAO.md`, bloco `CURRENT TRUTH`.
-- PR #58: merged; `main`, `dev`, `origin/main` e `origin/dev` estao sincronizados em `8298036fff754b246bd2cdd3edc1db969b35a449`.
+- PR #58 e PR #59: merged; base minima sincronizada `4705c2e5722c4f3a5266ac02a5d15a1928d5a223`, ou sucessor sincronizado em `main`/`dev`.
 - Este documento registra solucoes de ambiente; nao deve duplicar a matriz completa de release.
 - Proximo passo operacional: rebuildar artefatos v4.37 no Windows AMD64 e Debian AMD64 a partir do HEAD sincronizado.
 

--- a/launchers/README_BUILD_AUTOMATIZADO.md
+++ b/launchers/README_BUILD_AUTOMATIZADO.md
@@ -3,11 +3,11 @@
 ## CURRENT TRUTH 2026-05-04 01h14
 
 - Branch alvo operacional: `dev` e `main` sincronizados.
-- HEAD sincronizado: `8298036fff754b246bd2cdd3edc1db969b35a449 2026-05-04 01:14:06 -0300 Merge PR #58: shell CI and build hardening`.
-- PR #58: merged.
-- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #58.
+- Base minima sincronizada: `4705c2e5722c4f3a5266ac02a5d15a1928d5a223 2026-05-04T02:07:12-03:00 Merge PR #59: sync docs and required CI`; usar este commit ou sucessor sincronizado em `main`/`dev`.
+- PR #58 e PR #59: merged.
+- PR #56 e PR #57: merged anteriormente; o estado ativo agora e pos-merge do PR #59.
 - `main`, `dev`, `origin/main` e `origin/dev` apontam para o mesmo HEAD.
-- Artefatos v4.37 anteriores ao HEAD `8298036fff754b246bd2cdd3edc1db969b35a449` seguem stale e nao devem ser usados para publicacao final.
+- Artefatos v4.37 anteriores a base minima `4705c2e5722c4f3a5266ac02a5d15a1928d5a223` seguem stale e nao devem ser usados para publicacao final.
 - Fonte unica de backends/pacotes: `dev_env/build/release_targets.json`.
 - Orquestradores ativos:
   - Windows AMD64: `dev_env/build/release_windows.ps1`.

--- a/tests/test_release_docs_contract.py
+++ b/tests/test_release_docs_contract.py
@@ -20,7 +20,7 @@ def test_solucoes_ambiente_doc_marks_legacy_body_historical() -> None:
 
     assert text.count("## CURRENT TRUTH") == 1
     assert "Fonte operacional completa: `docs/GUIA_DISTRIBUICAO.md`" in text
-    assert "PR #58: merged" in text
+    assert "PR #58 e PR #59: merged" in text
     assert "PR atual: #57" not in text
     assert "- Branch alvo: `dev`." not in text
     assert "## HISTORICAL SNAPSHOT 2025-11-14" in text
@@ -38,11 +38,11 @@ def test_release_docs_sync_contract() -> None:
     source_text = read_repo_text("docs", "GUIA_DISTRIBUICAO.md")
     source_truth = source_text.split("## HISTORICAL SNAPSHOT", 1)[0]
 
-    assert "PR #58: merged" in source_truth
+    assert "PR #58 e PR #59: merged" in source_truth
     assert "PR #57: aberto em draft" not in source_truth
     assert "PR #56: merged" not in source_truth
     assert "df0345caea9ac3050c87d2172eb75817b8fc3689" not in source_truth
-    assert "8298036fff754b246bd2cdd3edc1db969b35a449" in source_truth
+    assert "4705c2e5722c4f3a5266ac02a5d15a1928d5a223" in source_truth
 
     for doc_name in [
         "SOLUCOES_AMBIENTE_BUILD.md",
@@ -51,6 +51,6 @@ def test_release_docs_sync_contract() -> None:
     ]:
         current_truth = read_repo_text("docs", doc_name).split("## HISTORICAL SNAPSHOT", 1)[0]
         assert "Fonte operacional completa: `docs/GUIA_DISTRIBUICAO.md`" in current_truth
-        assert "PR #58: merged" in current_truth
+        assert "PR #58 e PR #59: merged" in current_truth
         assert "PR atual: #57" not in current_truth
         assert "df0345caea9ac3050c87d2172eb75817b8fc3689" not in current_truth


### PR DESCRIPTION
## **User description**
## Objetivo

Ajuste documental pos-merge do PR #59.

## Conteudo

- Registra PR #59 como baseline minimo sincronizado.
- Evita declarar hash volatil como HEAD exato futuro; usa base minima ou sucessor sincronizado em main/dev.
- Atualiza contrato de docs para bloquear retorno ao estado PR #57/#58 antigo.

## Validacao local

- git diff --check
- busca sem referencias stale em docs vivos
- py_compile, ruff, ty em tests/test_release_docs_contract.py
- pytest tests/test_release_docs_contract.py tests/test_shell_ci_contracts.py: 29 passed
- Kluster: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs release docs after PR #59 by moving from a pinned HEAD to a minimum synced baseline and aligning all pages to the post-PR59 state. Updates tests to enforce the new contract and mark older v4.37 artifacts as stale.

- **Refactors**
  - Replaced "HEAD sincronizado" with "Base mínima sincronizada" across release docs.
  - Recorded PR #58 and PR #59 as merged; require `main`/`dev` to match the baseline or a synced successor.
  - Marked v4.37 artifacts older than the baseline as stale.
  - Updated `tests/test_release_docs_contract.py` to check the new wording and baseline contract.

<sup>Written for commit 87d718a4351be24651e8ca50dc034c2ab0321a87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Sync release docs to the new PR #59 baseline

### What Changed
- Replaces the old synced HEAD with a new minimum synced baseline tied to PR #59
- Marks PR #58 and PR #59 as merged across the release docs and related handoff pages
- Updates stale-artifact warnings so older v4.37 outputs are treated as unusable before the new baseline
- Adjusts the release-docs checks to enforce the new baseline wording and commit reference

### Impact
`✅ Clearer release source of truth`
`✅ Fewer rebuilds from outdated artifacts`
`✅ Safer handoff before publishing v4.37`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=nW-cuBU7SvvyIGD7CVH5FSq-DfLoC343ujQvwWAjM_o&org=mauriciomenon)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated 'CURRENT TRUTH' sections in multiple documentation files to reference the merge of PR #59 instead of PR #58.</li>
<li>Changed the synchronized HEAD commit hash from the PR #58 merge to the PR #59 merge commit.</li>
<li>Updated references to stale artifacts to use the new base minima commit from PR #59.</li>
<li>Adjusted PR status notes to indicate both PR #58 and PR #59 are merged.</li>
</ul></div>